### PR TITLE
rules: add noEval

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -136,6 +136,7 @@ impl Linter {
       Box::new(rules::NoVar::new(context.clone())),
       Box::new(rules::SingleVarDeclarator::new(context.clone())),
       Box::new(rules::ExplicitFunctionReturnType::new(context.clone())),
+      Box::new(rules::NoEval::new(context.clone())),
     ];
 
     for rule in rules {

--- a/src/rules/mod.rs
+++ b/src/rules/mod.rs
@@ -9,6 +9,8 @@ mod explicit_function_return_type;
 pub use explicit_function_return_type::ExplicitFunctionReturnType;
 mod no_debugger;
 pub use no_debugger::NoDebugger;
+mod no_eval;
+pub use no_eval::NoEval;
 mod no_explicit_any;
 pub use no_explicit_any::NoExplicitAny;
 mod no_var;

--- a/src/rules/no_eval.rs
+++ b/src/rules/no_eval.rs
@@ -1,0 +1,32 @@
+// Copyright 2020 the Deno authors. All rights reserved. MIT license.
+use super::Context;
+use crate::traverse::AstTraverser;
+use swc_ecma_ast::CallExpr;
+use swc_ecma_ast::Expr;
+use swc_ecma_ast::ExprOrSuper;
+
+pub struct NoEval {
+  context: Context,
+}
+
+impl NoEval {
+  pub fn new(context: Context) -> Self {
+    Self { context }
+  }
+}
+
+impl AstTraverser for NoEval {
+  fn walk_call_expr(&self, call_expr: CallExpr) {
+    if let ExprOrSuper::Expr(expr) = call_expr.callee {
+      if let Expr::Ident(ident) = expr.as_ref() {
+        if ident.sym.to_string() == "eval" {
+          self.context.add_diagnostic(
+            &call_expr.span,
+            "noEval",
+            "`eval` call is not allowed",
+          );
+        }
+      }
+    }
+  }
+}

--- a/src/traverse.rs
+++ b/src/traverse.rs
@@ -354,7 +354,9 @@ pub trait AstTraverser {
       }
     }
   }
-  fn walk_expr_stmt(&self, expr_stmt: ExprStmt) {}
+  fn walk_expr_stmt(&self, expr_stmt: ExprStmt) {
+    self.walk_expression(expr_stmt.expr);
+  }
 
   fn walk_class_decl(&self, class_decl: ClassDecl) {}
   fn walk_fn_decl(&self, fn_decl: FnDecl) {

--- a/test.ts
+++ b/test.ts
@@ -28,6 +28,9 @@ function asdf(): number {
     return 1;
 }
 
+/** noEval */
+eval("123");
+
 /** explicitFunctionReturnType */
 // TODO:
 function missingType() {


### PR DESCRIPTION
+ Add a basic rule to ban `eval(...)`;
+ By default walks expression for `ExprStmt`