### PR TITLE
Wrote deeper traverse funcs for a bunch of stmts

### DIFF
--- a/src/traverse.rs
+++ b/src/traverse.rs
@@ -392,7 +392,7 @@ pub trait AstTraverser {
     if let Some(init) = for_stmt.init {
       match init {
         VarDeclOrExpr::VarDecl(var_decl) => self.walk_var_decl(var_decl),
-        VarDeclOrExpr::Expr(expr) => self.walk_expression(expr)
+        VarDeclOrExpr::Expr(expr) => self.walk_expression(expr),
       }
     }
     if let Some(expr) = for_stmt.test {
@@ -406,7 +406,7 @@ pub trait AstTraverser {
   fn walk_for_in_stmt(&self, for_in_stmt: ForInStmt) {
     match for_in_stmt.left {
       VarDeclOrPat::Pat(pat) => self.walk_pattern(pat),
-      VarDeclOrPat::VarDecl(var_decl) => self.walk_var_decl(var_decl)
+      VarDeclOrPat::VarDecl(var_decl) => self.walk_var_decl(var_decl),
     }
 
     self.walk_expression(for_in_stmt.right);
@@ -415,7 +415,7 @@ pub trait AstTraverser {
   fn walk_for_of_stmt(&self, for_of_stmt: ForOfStmt) {
     match for_of_stmt.left {
       VarDeclOrPat::Pat(pat) => self.walk_pattern(pat),
-      VarDeclOrPat::VarDecl(var_decl) => self.walk_var_decl(var_decl)
+      VarDeclOrPat::VarDecl(var_decl) => self.walk_var_decl(var_decl),
     }
 
     self.walk_expression(for_of_stmt.right);


### PR DESCRIPTION
Wrote deeper traverse functions for a bunch of stmts so that not only top level rules work. A list of the functions i wrote deeper traverse statements are:
* walk_with_stmt
* walk_return_stmt
* walk_labeled_stmt, walk_break_stmt
* walk_continue_stmt
* walk_if_stmt
* walk_switch_stmt
* walk_throw_stmt
* walk_try_stmt
* walk_while_stmt
* walk_do_while_stmt
* walk_for_stmt
* walk_for_in_stmt
* walk_for_of_stmt
And i also added three new walk functions:
* walk_switch_cases
* walk_switch_case
* walk_catch_clause