### PR TITLE
Change ignore directive to deno-lint-ignore

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,12 +28,12 @@ Very much work-in-progress
 Only single line ignores are supported:
 
 ```ts
-// deno:ignore noExplicitAny
+// deno-lint-ignore noExplicitAny
 function foo(): any {
   // ...
 }
 
-// deno:ignore noExplicitAny explicitFunctionReturnType
+// deno-lint-ignore noExplicitAny explicitFunctionReturnType
 function bar(a: any) {
   // ...
 }

--- a/src/linter.rs
+++ b/src/linter.rs
@@ -143,7 +143,7 @@ impl Linter {
 
     let comment_text = comment.text.trim();
 
-    let codes: Vec<String> = if comment_text.starts_with("deno:ignore") {
+    let codes: Vec<String> = if comment_text.starts_with("deno-lint-ignore") {
       comment_text
         .split(' ')
         .map(|e| e.to_string())


### PR DESCRIPTION
Changes the ignore directive from `deno:ignore` to `deno-lint-ignore` as per #27.