### PR TITLE
Bump actions/cache version from v1 to v2.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
           rustup component add rustfmt
 
       - name: Cache
-        uses: actions/cache@v1
+        uses: actions/cache@v2
         with:
           path: target/
           key: ${{ matrix.config.os }}-${{ hashFiles('Cargo.lock') }}


### PR DESCRIPTION
actions/cache released v2.
https://github.com/actions/cache/releases/tag/v2.0.0