### PR TITLE
refactor: Testing utils

### DIFF
--- a/src/rules/ban_ts_ignore.rs
+++ b/src/rules/ban_ts_ignore.rs
@@ -46,42 +46,31 @@ impl LintRule for BanTsIgnore {
 #[cfg(test)]
 mod tests {
   use super::*;
-  use crate::test_util::test_lint;
-  use serde_json::json;
+  use crate::test_util::*;
 
   #[test]
   fn ban_ts_ignore() {
-    test_lint(
-      "ban_ts_ignore",
+    assert_lint_err_on_line::<BanTsIgnore>(
       r#"
 // @ts-ignore
 function foo() {
   // pass
 }
-
+    "#,
+      "banTsIgnore",
+      2,
+      0,
+    );
+    assert_lint_err_on_line::<BanTsIgnore>(
+      r#"
 function bar() {
   // @ts-ignore
   const a = "bar";
 }
-      "#,
-      vec![BanTsIgnore::new()],
-      json!([{
-        "code": "banTsIgnore",
-        "message": "@ts-ignore is not allowed",
-        "location": {
-          "filename": "ban_ts_ignore",
-          "line": 2,
-          "col": 0,
-        }
-      }, {
-        "code": "banTsIgnore",
-        "message": "@ts-ignore is not allowed",
-        "location": {
-          "filename": "ban_ts_ignore",
-          "line": 8,
-          "col": 2,
-        }
-      }]),
-    )
+    "#,
+      "banTsIgnore",
+      3,
+      2,
+    );
   }
 }

--- a/src/rules/ban_untagged_todo.rs
+++ b/src/rules/ban_untagged_todo.rs
@@ -54,46 +54,39 @@ impl LintRule for BanUntaggedTodo {
 #[cfg(test)]
 mod tests {
   use super::*;
-  use crate::test_util::test_lint;
-  use serde_json::json;
+  use crate::test_util::*;
 
   #[test]
   fn ban_ts_ignore() {
-    test_lint(
-      "ban_untagged_todo",
+    assert_lint_ok::<BanUntaggedTodo>(vec![
+      r#"
+// TODO(#1234)
+const b = "b";
+      "#,
+      r#"
+// TODO(@someusername)
+const c = "c";
+      "#,
+    ]);
+    assert_lint_err_on_line::<BanUntaggedTodo>(
       r#"
 // TODO
 function foo() {
   // pass
 }
-
+      "#,
+      "banUntaggedTodo",
+      2,
+      0,
+    );
+    assert_lint_err_on_line::<BanUntaggedTodo>(
+      r#"
 // TODO(username)
 const a = "a";
-
-// TODO(#1234)
-const b = "b";
-
-// TODO(@someusername)
-const c = "c";
       "#,
-      vec![BanUntaggedTodo::new()],
-      json!([{
-        "code": "banUntaggedTodo",
-        "message": "TODO should be tagged with (@username) or (#issue)",
-        "location": {
-          "filename": "ban_untagged_todo",
-          "line": 2,
-          "col": 0,
-        }
-      }, {
-        "code": "banUntaggedTodo",
-        "message": "TODO should be tagged with (@username) or (#issue)",
-        "location": {
-          "filename": "ban_untagged_todo",
-          "line": 7,
-          "col": 0,
-        }
-      }]),
-    )
+      "banUntaggedTodo",
+      2,
+      0,
+    );
   }
 }

--- a/src/test_util.rs
+++ b/src/test_util.rs
@@ -38,3 +38,90 @@ pub fn test_lint(
 
   assert_eq!(serialized_diagnostics, expected_diagnostics);
 }
+
+fn lint<T: LintRule + 'static>(source: &str) -> Vec<LintDiagnostic> {
+  let mut linter = Linter::default();
+  let rule = T::new();
+  linter
+    .lint(
+      "deno_lint_test.tsx".to_string(),
+      source.to_string(),
+      vec![rule],
+    )
+    .expect("Failed to lint")
+}
+
+fn assert_diagnostic(
+  diagnostic: &LintDiagnostic,
+  code: &str,
+  line: usize,
+  col: usize,
+) {
+  if diagnostic.code == code
+    && diagnostic.location.line == line
+    && diagnostic.location.col == col
+  {
+    return;
+  }
+  panic!(format!(
+    "expect diagnostics {} at {}:{} to be {} at {}:{}",
+    diagnostic.code,
+    diagnostic.location.line,
+    diagnostic.location.col,
+    code,
+    line,
+    col
+  ))
+}
+
+pub fn assert_lint_ok<T: LintRule + 'static>(cases: Vec<&str>) {
+  for source in cases {
+    let diagnostics = lint::<T>(source);
+    assert!(diagnostics.is_empty());
+  }
+}
+
+#[allow(dead_code)]
+pub fn assert_lint_err<T: LintRule + 'static>(
+  source: &str,
+  code: &str,
+  col: usize,
+) {
+  assert_lint_err_on_line::<T>(source, code, 0, col)
+}
+
+pub fn assert_lint_err_on_line<T: LintRule + 'static>(
+  source: &str,
+  code: &str,
+  line: usize,
+  col: usize,
+) {
+  let diagnostics = lint::<T>(source);
+  assert!(diagnostics.len() == 1);
+  assert_diagnostic(&diagnostics[0], code, line, col);
+}
+
+#[allow(dead_code)]
+pub fn assert_lint_err_n<T: LintRule + 'static>(
+  source: &str,
+  expected: Vec<(&str, usize)>,
+) {
+  let mut real: Vec<(&str, usize, usize)> = Vec::new();
+  for x in expected {
+    let (code, col) = x;
+    real.push((code, 0, col));
+  }
+  assert_lint_err_on_line_n::<T>(source, real)
+}
+
+pub fn assert_lint_err_on_line_n<T: LintRule + 'static>(
+  source: &str,
+  expected: Vec<(&str, usize, usize)>,
+) {
+  let diagnostics = lint::<T>(source);
+  assert!(diagnostics.len() == expected.len());
+  for i in 0..diagnostics.len() {
+    let (code, line, col) = expected[i];
+    assert_diagnostic(&diagnostics[i], code, line, col);
+  }
+}


### PR DESCRIPTION
@bartlomieju If this seems good then I'll move all of the other tests over to the new utils. I did ultimately keep a line number version of the utils because it seems useful for the multi line tests (the comment related ones for example).