### PR TITLE
Bump actions/checkout version from v1 to v2.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: Clone repository
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
 
       - name: Install rust
         uses: hecrj/setup-rust-action@v1


### PR DESCRIPTION
actions/checkout released v2.
https://github.com/actions/checkout#checkout-v2