### PR TITLE
(fix-report) Multiple clutter lines

### DIFF
--- a/src/diagnostic.rs
+++ b/src/diagnostic.rs
@@ -33,7 +33,7 @@ pub struct LintDiagnostic {
   pub message: String,
   pub code: String,
   pub line_src: String,
-  pub snippet_length: usize,
+  pub glyphes_length: usize,
 }
 
 impl LintDiagnostic {
@@ -64,7 +64,7 @@ impl LintDiagnostic {
       "{}|{}{}",
       " ".repeat(line_str_len + 1),
       " ".repeat(self.location.col + 1),
-      colors::red("^".repeat(self.snippet_length))
+      colors::red("^".repeat(self.glyphes_length))
     );
 
     let lines = vec![

--- a/src/diagnostic.rs
+++ b/src/diagnostic.rs
@@ -33,7 +33,7 @@ pub struct LintDiagnostic {
   pub message: String,
   pub code: String,
   pub line_src: String,
-  pub glyphes_length: usize,
+  pub snippet_length: usize,
 }
 
 impl LintDiagnostic {
@@ -64,7 +64,7 @@ impl LintDiagnostic {
       "{}|{}{}",
       " ".repeat(line_str_len + 1),
       " ".repeat(self.location.col + 1),
-      colors::red("^".repeat(self.glyphes_length))
+      colors::red("^".repeat(self.snippet_length))
     );
 
     let lines = vec![

--- a/src/linter.rs
+++ b/src/linter.rs
@@ -36,7 +36,7 @@ impl Context {
 
     let snippet_length = self
       .source_map
-      .span_to_snippet(span)
+      .span_to_snippet(self.source_map.span_until_char(span, '\n'))
       .expect("error loading snippet")
       .len();
 

--- a/src/linter.rs
+++ b/src/linter.rs
@@ -40,18 +40,18 @@ impl Context {
       .expect("error loading snippet")
       .len();
 
-    let glyphes_length = if snippet_length > line_src.len() {
-      line_src.len()
-    } else {
-      snippet_length
-    };
-
+    // let glyphes_length = if snippet_length > line_src.len() {
+    //   line_src.len()
+    // } else {
+    //   snippet_length
+    // };
+      
     diags.push(LintDiagnostic {
       location: location.into(),
       message: message.to_string(),
       code: code.to_string(),
       line_src,
-      glyphes_length,
+      snippet_length,
     });
   }
 }

--- a/src/linter.rs
+++ b/src/linter.rs
@@ -40,12 +40,18 @@ impl Context {
       .expect("error loading snippet")
       .len();
 
+    let glyphes_length = if snippet_length > line_src.len() {
+      line_src.len()
+    } else {
+      snippet_length
+    };
+
     diags.push(LintDiagnostic {
       location: location.into(),
       message: message.to_string(),
       code: code.to_string(),
       line_src,
-      snippet_length,
+      glyphes_length,
     });
   }
 }

--- a/src/linter.rs
+++ b/src/linter.rs
@@ -40,12 +40,6 @@ impl Context {
       .expect("error loading snippet")
       .len();
 
-    // let glyphes_length = if snippet_length > line_src.len() {
-    //   line_src.len()
-    // } else {
-    //   snippet_length
-    // };
-
     diags.push(LintDiagnostic {
       location: location.into(),
       message: message.to_string(),

--- a/src/linter.rs
+++ b/src/linter.rs
@@ -45,7 +45,7 @@ impl Context {
     // } else {
     //   snippet_length
     // };
-      
+
     diags.push(LintDiagnostic {
       location: location.into(),
       message: message.to_string(),


### PR DESCRIPTION
the current report format of multiline snippets : 

```ts
function multiple(num: number) {
    
}
```
```shell
(explicitFunctionReturnType) Missing return type on function
 --> ./problem.ts:1:0
  |
1 | function multiple(num: number) {
  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  |
(noEmpty) Empty block statement
 --> ./problem.ts:1:31
  |
1 | function multiple(num: number) {
  |                                ^^^^^^^^^^
  |
(noEmptyFunction) Empty functions are not allowed
 --> ./problem.ts:1:0
  |
1 | function multiple(num: number) {
  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  |
}
```
should be :

```shell
(explicitFunctionReturnType) Missing return type on function
 --> ./problem.ts:1:0
  |
1 | function multiple(num: number) {
  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  |
(noEmpty) Empty block statement
 --> ./problem.ts:1:31
  |
1 | function multiple(num: number) {
  |                                ^
  |
(noEmptyFunction) Empty functions are not allowed
 --> ./problem.ts:1:0
  |
1 | function multiple(num: number) {
  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  |
```

