### PR TITLE
fix no-empty-function rule

### DIFF
--- a/src/rules/no_empty_function.rs
+++ b/src/rules/no_empty_function.rs
@@ -41,6 +41,10 @@ impl Visit for NoEmptyFunctionVisitor {
         "no-empty-function",
         "Empty functions are not allowed",
       )
+    } else {
+      for stmt in &fn_decl.function.body {
+        self.visit_block_stmt(stmt, _parent);
+      }
     }
   }
 }
@@ -59,6 +63,14 @@ mod tests {
     assert_lint_err::<NoEmptyFunction>(
       "function emptyFunctionWithoutBody();",
       0,
+    );
+  }
+
+  #[test]
+  fn no_empty_function_nested_test() {
+    assert_lint_err::<NoEmptyFunction>(
+      "function parentFunction() { function childFunction(); }",
+      28,
     );
   }
 }


### PR DESCRIPTION
this PR is going to support `nested` functions in no-empty-functions rule

current behavior :
```ts
function a(){
    function b(){}
}
```
deno lint : `nothing about empty function of 'b'.`
eslint : `2:17  warning  Unexpected empty function 'b'                  no-empty-function`


after this patch : 
```shell
(no-empty-function) Empty functions are not allowed
 --> .\problem.ts:2:4
  |
2 |     function b(){}
  |     ^^^^^^^^^^^^^^
  |
```