### PR TITLE
add ban-ts-comment rule

### DIFF
--- a/src/rules/ban_ts_comment.rs
+++ b/src/rules/ban_ts_comment.rs
@@ -14,7 +14,7 @@ impl BanTsComment {
 
     lazy_static! {
       static ref BTC_REGEX: regex::Regex =
-        regex::Regex::new(r#"^/*\s*@ts-(expect-error|ignore|nocheck)(.*)"#)
+        regex::Regex::new(r#"^/*\s*@ts-(expect-error|ignore|nocheck)$"#)
           .unwrap();
     }
 
@@ -97,6 +97,31 @@ mod tests {
 */
 "#,
     ]);
+
+    assert_lint_ok::<BanTsComment>(
+      r#"if (false) {
+// @ts-ignore: Unreachable code error
+console.log('hello');
+}"#,
+    );
+    assert_lint_ok::<BanTsComment>(
+      r#"if (false) {
+// @ts-expect-error: Unreachable code error
+console.log('hello');
+}"#,
+    );
+    assert_lint_ok::<BanTsComment>(
+      r#"if (false) {
+// @ts-nocheck: Unreachable code error
+console.log('hello');
+}"#,
+    );
+
+    assert_lint_ok::<BanTsComment>(
+      r#"// @ts-expect-error: Suppress next line"#,
+    );
+    assert_lint_ok::<BanTsComment>(r#"// @ts-ignore: Suppress next line"#);
+    assert_lint_ok::<BanTsComment>(r#"// @ts-nocheck: Suppress next line"#);
   }
 
   #[test]
@@ -104,37 +129,5 @@ mod tests {
     assert_lint_err::<BanTsComment>(r#"// @ts-expect-error"#, 0);
     assert_lint_err::<BanTsComment>(r#"// @ts-ignore"#, 0);
     assert_lint_err::<BanTsComment>(r#"// @ts-nocheck"#, 0);
-
-    assert_lint_err::<BanTsComment>(
-      r#"// @ts-expect-error: Suppress next line"#,
-      0,
-    );
-    assert_lint_err::<BanTsComment>(r#"// @ts-ignore: Suppress next line"#, 0);
-    assert_lint_err::<BanTsComment>(r#"// @ts-nocheck: Suppress next line"#, 0);
-
-    assert_lint_err_on_line::<BanTsComment>(
-      r#"if (false) {
-// @ts-ignore: Unreachable code error
-console.log('hello');
-}"#,
-      2,
-      0,
-    );
-    assert_lint_err_on_line::<BanTsComment>(
-      r#"if (false) {
-// @ts-expect-error: Unreachable code error
-console.log('hello');
-}"#,
-      2,
-      0,
-    );
-    assert_lint_err_on_line::<BanTsComment>(
-      r#"if (false) {
-// @ts-nocheck: Unreachable code error
-console.log('hello');
-}"#,
-      2,
-      0,
-    );
   }
 }

--- a/src/rules/ban_ts_comment.rs
+++ b/src/rules/ban_ts_comment.rs
@@ -1,0 +1,140 @@
+// Copyright 2020 the Deno authors. All rights reserved. MIT license.
+use super::Context;
+use super::LintRule;
+use swc_common::comments::Comment;
+use swc_common::comments::CommentKind;
+
+pub struct BanTsComment;
+
+impl BanTsComment {
+  fn lint_comment(&self, context: &Context, comment: &Comment) {
+    if comment.kind != CommentKind::Line {
+      return;
+    }
+
+    lazy_static! {
+      static ref BTC_REGEX: regex::Regex =
+        regex::Regex::new(r#"^/*\s*@ts-(expect-error|ignore|nocheck)(.*)"#)
+          .unwrap();
+    }
+
+    if BTC_REGEX.is_match(&comment.text) {
+      context.add_diagnostic(
+        comment.span,
+        "ban-ts-comment",
+        "ts directives are not allowed",
+      );
+    }
+  }
+}
+
+impl LintRule for BanTsComment {
+  fn new() -> Box<Self> {
+    Box::new(BanTsComment)
+  }
+
+  fn code(&self) -> &'static str {
+    "ban-ts-comment"
+  }
+
+  fn lint_module(&self, context: Context, _module: swc_ecma_ast::Module) {
+    context.leading_comments.iter().for_each(|ref_multi| {
+      for comment in ref_multi.value() {
+        self.lint_comment(&context, comment);
+      }
+    });
+    context.trailing_comments.iter().for_each(|ref_multi| {
+      for comment in ref_multi.value() {
+        self.lint_comment(&context, comment);
+      }
+    });
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use crate::test_util::*;
+
+  #[test]
+  fn ban_ts_comment_valid() {
+    assert_lint_ok_n::<BanTsComment>(vec![
+      r#"// just a comment containing @ts-expect-error somewhere"#,
+      r#"/* @ts-expect-error */"#,
+      r#"/** @ts-expect-error */"#,
+      r#"/*
+// @ts-expect-error in a block
+*/
+"#,
+    ]);
+
+    assert_lint_ok_n::<BanTsComment>(vec![
+      r#"// just a comment containing @ts-ignore somewhere"#,
+      r#"/* @ts-ignore */"#,
+      r#"/** @ts-ignore */"#,
+      r#"/*
+// @ts-ignore in a block
+*/
+"#,
+    ]);
+
+    assert_lint_ok_n::<BanTsComment>(vec![
+      r#"// just a comment containing @ts-nocheck somewhere"#,
+      r#"/* @ts-nocheck */"#,
+      r#"/** @ts-nocheck */"#,
+      r#"/*
+// @ts-nocheck in a block
+*/
+"#,
+    ]);
+
+    assert_lint_ok_n::<BanTsComment>(vec![
+      r#"// just a comment containing @ts-check somewhere"#,
+      r#"/* @ts-check */"#,
+      r#"/** @ts-check */"#,
+      r#"/*
+// @ts-check in a block
+*/
+"#,
+    ]);
+  }
+
+  #[test]
+  fn ban_ts_comment_invalid() {
+    assert_lint_err::<BanTsComment>(r#"// @ts-expect-error"#, 0);
+    assert_lint_err::<BanTsComment>(r#"// @ts-ignore"#, 0);
+    assert_lint_err::<BanTsComment>(r#"// @ts-nocheck"#, 0);
+
+    assert_lint_err::<BanTsComment>(
+      r#"// @ts-expect-error: Suppress next line"#,
+      0,
+    );
+    assert_lint_err::<BanTsComment>(r#"// @ts-ignore: Suppress next line"#, 0);
+    assert_lint_err::<BanTsComment>(r#"// @ts-nocheck: Suppress next line"#, 0);
+
+    assert_lint_err_on_line::<BanTsComment>(
+      r#"if (false) {
+// @ts-ignore: Unreachable code error
+console.log('hello');
+}"#,
+      2,
+      0,
+    );
+    assert_lint_err_on_line::<BanTsComment>(
+      r#"if (false) {
+// @ts-expect-error: Unreachable code error
+console.log('hello');
+}"#,
+      2,
+      0,
+    );
+    assert_lint_err_on_line::<BanTsComment>(
+      r#"if (false) {
+// @ts-nocheck: Unreachable code error
+console.log('hello');
+}"#,
+      2,
+      0,
+    );
+  }
+}

--- a/src/rules/mod.rs
+++ b/src/rules/mod.rs
@@ -62,8 +62,8 @@ pub trait LintRule {
 
 pub fn get_all_rules() -> Vec<Box<dyn LintRule>> {
   vec![
-    ban_ts_ignore::BanTsIgnore::new(),
     ban_ts_comment::BanTsComment::new(),
+    ban_ts_ignore::BanTsIgnore::new(),
     ban_untagged_todo::BanUntaggedTodo::new(),
     ban_untagged_ignore::BanUntaggedIgnore::new(),
     constructor_super::ConstructorSuper::new(),

--- a/src/rules/mod.rs
+++ b/src/rules/mod.rs
@@ -1,6 +1,7 @@
 // Copyright 2020 the Deno authors. All rights reserved. MIT license.
 use crate::linter::Context;
 
+mod ban_ts_comment;
 mod ban_ts_ignore;
 mod ban_untagged_ignore;
 mod ban_untagged_todo;
@@ -50,7 +51,6 @@ mod single_var_declarator;
 mod triple_slash_reference;
 mod use_isnan;
 mod valid_typeof;
-mod ban_ts_comment;
 
 pub trait LintRule {
   fn new() -> Box<Self>

--- a/src/rules/mod.rs
+++ b/src/rules/mod.rs
@@ -50,6 +50,7 @@ mod single_var_declarator;
 mod triple_slash_reference;
 mod use_isnan;
 mod valid_typeof;
+mod ban_ts_comment;
 
 pub trait LintRule {
   fn new() -> Box<Self>
@@ -62,6 +63,7 @@ pub trait LintRule {
 pub fn get_all_rules() -> Vec<Box<dyn LintRule>> {
   vec![
     ban_ts_ignore::BanTsIgnore::new(),
+    ban_ts_comment::BanTsComment::new(),
     ban_untagged_todo::BanUntaggedTodo::new(),
     ban_untagged_ignore::BanUntaggedIgnore::new(),
     constructor_super::ConstructorSuper::new(),


### PR DESCRIPTION
  this PR is going to add :
+ `ban-ts-comment rule`
+ `25 tests about it`

_ps: `@ts-check` is allowed by default on tslint._