### PR TITLE
no-dupe-else-if

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ See [`./benchmarks/`](./benchmarks/) directory for more info.*
 - [`no-delete-var`](https://eslint.org/docs/rules/no-delete-var)
 - [`no-dupe-args`](https://eslint.org/docs/rules/no-dupe-args)
 - [`no-dupe-class-members`](https://eslint.org/docs/rules/no-dupe-class-members)
+- [`no-dupe-else-if`](https://eslint.org/docs/rules/no-dupe-else-if)
 - [`no-dupe-keys`](https://eslint.org/docs/rules/no-dupe-keys)
 - [`no-duplicate-case`](https://eslint.org/docs/rules/no-duplicate-case)
 - [`no-empty-character-class`](https://eslint.org/docs/rules/no-empty-character-class)

--- a/src/rules/mod.rs
+++ b/src/rules/mod.rs
@@ -23,6 +23,7 @@ mod no_debugger;
 mod no_delete_var;
 mod no_dupe_args;
 mod no_dupe_class_members;
+mod no_dupe_else_if;
 mod no_dupe_keys;
 mod no_duplicate_case;
 mod no_empty;
@@ -85,6 +86,7 @@ pub fn get_recommended_rules() -> Vec<Box<dyn LintRule>> {
     no_delete_var::NoDeleteVar::new(),
     no_dupe_args::NoDupeArgs::new(),
     no_dupe_class_members::NoDupeClassMembers::new(),
+    no_dupe_else_if::NoDupeElseIf::new(),
     no_dupe_keys::NoDupeKeys::new(),
     no_duplicate_case::NoDuplicateCase::new(),
     no_empty_character_class::NoEmptyCharacterClass::new(),
@@ -143,6 +145,7 @@ pub fn get_all_rules() -> Vec<Box<dyn LintRule>> {
     no_delete_var::NoDeleteVar::new(),
     no_dupe_args::NoDupeArgs::new(),
     no_dupe_class_members::NoDupeClassMembers::new(),
+    no_dupe_else_if::NoDupeElseIf::new(),
     no_dupe_keys::NoDupeKeys::new(),
     no_duplicate_case::NoDuplicateCase::new(),
     no_empty_character_class::NoEmptyCharacterClass::new(),

--- a/src/rules/no_dupe_else_if.rs
+++ b/src/rules/no_dupe_else_if.rs
@@ -82,7 +82,7 @@ impl Visit for NoDupeElseIfVisitor {
 
             if current_condition_to_check
               .iter()
-              .any(|or_operands| or_operands.len() == 0)
+              .any(|or_operands| or_operands.is_empty())
             {
               self
               .context
@@ -142,7 +142,7 @@ fn split_by_or_then_and(expr: Expr) -> Vec<Vec<Expr>> {
   split_by_or(expr).into_iter().map(split_by_and).collect()
 }
 
-fn is_subset(arr_a: &Vec<Expr>, arr_b: &Vec<Expr>) -> bool {
+fn is_subset(arr_a: &[Expr], arr_b: &[Expr]) -> bool {
   arr_a
     .iter()
     .all(|a| arr_b.iter().any(|b| equal_in_if_else(a, b)))

--- a/src/rules/no_dupe_else_if.rs
+++ b/src/rules/no_dupe_else_if.rs
@@ -1,21 +1,10 @@
-#![allow(unused_imports, dead_code)]
 // Copyright 2020 the Deno authors. All rights reserved. MIT license.
 use super::{Context, LintRule};
-use crate::swc_util::{equal_in_if_else, DropSpan, SpanDropped};
-use std::cmp::Ordering;
-use std::collections::{BTreeMap, HashSet};
-use swc_common::{Span, Spanned, DUMMY_SP};
-use swc_ecma_ast::{
-  ArrayLit, ArrowExpr, AssignExpr, AwaitExpr, BigInt, BinExpr, BlockStmt,
-  BlockStmtOrExpr, Bool, CallExpr, ClassExpr, CondExpr, Constructor, Expr,
-  FnExpr, Function, Ident, IfStmt, Invalid, JSXElement, JSXEmptyExpr,
-  JSXFragment, JSXMemberExpr, JSXNamespacedName, JSXText, Lit, MemberExpr,
-  MetaPropExpr, Module, NewExpr, Null, Number, ObjectLit, OptChainExpr,
-  ParenExpr, PrivateName, Regex, SeqExpr, Stmt, Str, SwitchStmt, TaggedTpl,
-  ThisExpr, Tpl, TsAsExpr, TsConstAssertion, TsNonNullExpr, TsTypeAssertion,
-  TsTypeCastExpr, UnaryExpr, UpdateExpr, YieldExpr,
-};
-use swc_ecma_visit::{Fold, Node, Visit};
+use crate::swc_util::DropSpan;
+use std::collections::HashSet;
+use swc_common::{Span, Spanned};
+use swc_ecma_ast::{BinExpr, BinaryOp, Expr, IfStmt, Module, ParenExpr, Stmt};
+use swc_ecma_visit::{Node, Visit};
 
 pub struct NoDupeElseIf;
 
@@ -51,78 +40,287 @@ impl NoDupeElseIfVisitor {
 impl Visit for NoDupeElseIfVisitor {
   fn visit_if_stmt(&mut self, if_stmt: &IfStmt, parent: &dyn Node) {
     let span = if_stmt.test.span();
+
+    // This check is necessary to avoid outputting the same errors multiple times.
     if !self.checked_span.contains(&span) {
       self.checked_span.insert(span);
-      let mut conditions = BTreeMap::new();
-      let test = (&*if_stmt.test).clone().drop_span();
-      conditions.insert(IfElseEqualChecker(test), vec![span]);
+      let span_dropped_test = if_stmt.test.clone().drop_span();
+      //let conditions_to_check = match &test {
+      //Expr::Bin(BinExpr { ref op, .. }) if *op == BinaryOp::LogicalAnd => {
+      //let mut v = vec![&test];
+      //v.append(&mut split_by_and(&test));
+      //v
+      //}
+      //_ => vec![&test],
+      //};
+
+      //let mut list_to_check: Vec<Vec<Vec<&Expr>>> = conditions_to_check
+      //.iter()
+      //.map(|&c| split_by_or(c).into_iter().map(split_by_and).collect())
+      //.collect();
+      let mut appeared_conditions: Vec<Vec<Vec<Expr>>> = Vec::new();
+      append_test(&mut appeared_conditions, span_dropped_test);
+
+      //let append_test_to_check = |expr: &Expr| {
+      //let conditions_to_check = match *expr {
+      //Expr::Bin(BinExpr { ref op, .. }) if *op == BinaryOp::LogicalAnd => {
+      //let mut v = vec![expr];
+      //v.append(&mut split_by_and(expr));
+      //v
+      //}
+      //_ => vec![expr],
+      //};
+      //list_to_check.extend(
+      //conditions_to_check
+      //.iter()
+      //.map(|&c| split_by_or(c).into_iter().map(split_by_and).collect()),
+      //);
+      //};
+
+      //append_test_to_check(&span_dropped_test);
+
+      //let mut conditions = BTreeMap::new();
+      //conditions.insert(IfElseEqualChecker(test), vec![span]);
       let mut next = if_stmt.alt.as_ref();
-      while let Some(alt) = next {
+      while let Some(cur) = next {
         if let Stmt::If(IfStmt {
           ref test, ref alt, ..
-        }) = &**alt
+        }) = &**cur
         {
           // preserve the span before dropping
           let span = test.span();
-          let test = (&**test).clone().drop_span();
-          conditions
-            .entry(IfElseEqualChecker(test))
-            .or_insert_with(Vec::new)
-            .push(span);
+          let span_dropped_test = test.clone().drop_span();
+          //let current_or_operands: Vec<Vec<Expr>> =
+          //split_by_or(span_dropped_test.clone())
+          //.into_iter()
+          //.map(split_by_and)
+          //.collect();
+          let mut current_condition_to_check: Vec<Vec<Vec<Expr>>> =
+            mk_condition_to_check(span_dropped_test.clone())
+              .into_iter()
+              .map(split_by_or_then_and)
+              .collect();
+          //let mut appeared_conditions_to_check = appeared_conditions.clone();
+
+          for ap_cond in &appeared_conditions {
+            current_condition_to_check = current_condition_to_check
+              .into_iter()
+              .map(|current_or_operands| {
+                current_or_operands
+                  .into_iter()
+                  .filter(|current_or_operand| {
+                    !ap_cond.iter().any(|ap_or_operand| {
+                      is_subset(ap_or_operand, current_or_operand)
+                    })
+                  })
+                  .collect()
+              })
+              .collect();
+
+            if current_condition_to_check
+              .iter()
+              .any(|or_operands| or_operands.len() == 0)
+            {
+              self
+              .context
+              .add_diagnostic(span, "no-dupe-else-if", "This branch can never execute. Its condition is a duplicate or covered by previous conditions in the if-else-if chain.");
+              break;
+            }
+          }
+
+          //if current_condition_to_check
+          //.into_iter()
+          //.map(split_by_or_then_and)
+          //.any(|current_or_operands| {
+          //current_or_operands
+          //.iter()
+          //.find(|current_or_operand| {
+          //appeared_conditions
+          //.iter()
+          //.any(|ap_cond| is_subset(current_or_operand, ap_cond))
+          //})
+          //.is_some()
+          //})
+          //{
+          //self
+          //.context
+          //.add_diagnostic(span, "no-dupe-else-if", "This branch can never execute. Its condition is a duplicate or covered by previous conditions in the if-else-if chain.");
+          //}
+
+          //conditions
+          //.entry(IfElseEqualChecker(test))
+          //.or_insert_with(Vec::new)
+          //.push(span);
           self.checked_span.insert(span);
+          append_test(&mut appeared_conditions, span_dropped_test);
           next = alt.as_ref();
         } else {
           break;
         }
       }
-      //dbg!(&conditions);
 
-      conditions
-        .values()
-        .map(|c| c.iter().skip(1))
-        .flatten()
-        .for_each(|span| {
-          self
-            .context
-            .add_diagnostic(*span, "no-dupe-else-if", "This branch can never execute. Its condition is a duplicate or covered by previous conditions in the if-else-if chain.")
-        });
+      //conditions
+      //.values()
+      //.map(|c| c.iter().skip(1))
+      //.flatten()
+      //.for_each(|span| {
+      //self
+      //.context
+      //.add_diagnostic(*span, "no-dupe-else-if", "This branch can never execute. Its condition is a duplicate or covered by previous conditions in the if-else-if chain.")
+      //});
     }
 
     swc_ecma_visit::visit_if_stmt(self, if_stmt, parent);
   }
 }
 
-#[derive(Debug)]
-struct IfElseEqualChecker(SpanDropped<Expr>);
-
-impl PartialEq for IfElseEqualChecker {
-  fn eq(&self, other: &Self) -> bool {
-    let IfElseEqualChecker(ref self_sd) = self;
-    let IfElseEqualChecker(ref other_sd) = other;
-
-    equal_in_if_else(&self_sd.as_ref(), &other_sd.as_ref())
-  }
-}
-
-impl Eq for IfElseEqualChecker {}
-
-impl PartialOrd for IfElseEqualChecker {
-  fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-    Some(self.cmp(other))
-  }
-}
-
-impl Ord for IfElseEqualChecker {
-  fn cmp(&self, other: &Self) -> Ordering {
-    if self == other {
-      Ordering::Equal
-    } else {
-      let IfElseEqualChecker(ref self_sd) = self;
-      let IfElseEqualChecker(ref other_sd) = other;
-      self_sd.cmp(other_sd)
+fn mk_condition_to_check(cond: Expr) -> Vec<Expr> {
+  match cond {
+    Expr::Bin(BinExpr { op, .. }) if op == BinaryOp::LogicalAnd => {
+      let mut c = vec![cond.clone()];
+      c.append(&mut split_by_and(cond));
+      c
     }
+    Expr::Paren(ParenExpr { expr, .. }) => mk_condition_to_check(*expr),
+    _ => vec![cond],
   }
 }
+
+fn split_by_bin_op(op_to_split: BinaryOp, expr: Expr) -> Vec<Expr> {
+  match expr {
+    Expr::Bin(BinExpr {
+      op, left, right, ..
+    }) if op == op_to_split => {
+      let mut ret = split_by_bin_op(op_to_split, *left);
+      ret.append(&mut split_by_bin_op(op_to_split, *right));
+      ret
+    }
+    Expr::Paren(ParenExpr { expr, .. }) => split_by_bin_op(op_to_split, *expr),
+    _ => vec![expr],
+  }
+}
+
+fn split_by_or(expr: Expr) -> Vec<Expr> {
+  split_by_bin_op(BinaryOp::LogicalOr, expr)
+}
+
+fn split_by_and(expr: Expr) -> Vec<Expr> {
+  split_by_bin_op(BinaryOp::LogicalAnd, expr)
+}
+
+fn is_subset(arr_a: &Vec<Expr>, arr_b: &Vec<Expr>) -> bool {
+  arr_a
+    .iter()
+    .all(|a| arr_b.iter().any(|b| equal_in_if_else(a, b)))
+}
+
+/// Determines whether the two given `Expr`s are considered to be equal in if-else condition
+/// context. Note that `expr1` and `expr2` must be span-dropped to be compared properly.
+fn equal_in_if_else(expr1: &Expr, expr2: &Expr) -> bool {
+  use swc_ecma_ast::Expr::*;
+  match (expr1, expr2) {
+    (Bin(ref bin1), Bin(ref bin2))
+      if matches!(bin1.op, BinaryOp::LogicalOr | BinaryOp::LogicalAnd)
+        && bin1.op == bin2.op =>
+    {
+      equal_in_if_else(&*bin1.left, &*bin2.left)
+        && equal_in_if_else(&*bin1.right, &*bin2.right)
+        || equal_in_if_else(&*bin1.left, &*bin2.right)
+          && equal_in_if_else(&*bin1.right, &*bin2.left)
+    }
+    (Paren(ParenExpr { ref expr, .. }), _) => equal_in_if_else(&**expr, expr2),
+    (_, Paren(ParenExpr { ref expr, .. })) => equal_in_if_else(expr1, &**expr),
+    (This(_), This(_))
+    | (Array(_), Array(_))
+    | (Object(_), Object(_))
+    | (Fn(_), Fn(_))
+    | (Unary(_), Unary(_))
+    | (Update(_), Update(_))
+    | (Bin(_), Bin(_))
+    | (Assign(_), Member(_))
+    | (Cond(_), Cond(_))
+    | (Call(_), Call(_))
+    | (New(_), New(_))
+    | (Seq(_), Seq(_))
+    | (Ident(_), Ident(_))
+    | (Lit(_), Lit(_))
+    | (Tpl(_), Tpl(_))
+    | (TaggedTpl(_), TaggedTpl(_))
+    | (Arrow(_), Arrow(_))
+    | (Class(_), Class(_))
+    | (Yield(_), Yield(_))
+    | (MetaProp(_), MetaProp(_))
+    | (Await(_), Await(_))
+    | (JSXMember(_), JSXMember(_))
+    | (JSXNamespacedName(_), JSXNamespacedName(_))
+    | (JSXEmpty(_), JSXEmpty(_))
+    | (JSXElement(_), JSXElement(_))
+    | (JSXFragment(_), JSXFragment(_))
+    | (TsTypeAssertion(_), TsTypeAssertion(_))
+    | (TsConstAssertion(_), TsConstAssertion(_))
+    | (TsNonNull(_), TsNonNull(_))
+    | (TsTypeCast(_), TsTypeCast(_))
+    | (TsAs(_), TsAs(_))
+    | (PrivateName(_), PrivateName(_))
+    | (OptChain(_), OptChain(_))
+    | (Invalid(_), Invalid(_)) => expr1 == expr2,
+    _ => false,
+  }
+}
+
+fn append_test(appeared_conditions: &mut Vec<Vec<Vec<Expr>>>, expr: Expr) {
+  //let conditions_to_check = match expr {
+  //Expr::Bin(BinExpr { ref op, .. }) if *op == BinaryOp::LogicalAnd => {
+  //let mut v = vec![expr.clone()];
+  //v.append(&mut split_by_and(expr));
+  //v
+  //}
+  //_ => vec![expr],
+  //};
+  appeared_conditions.push(split_by_or_then_and(expr));
+  //appeared_conditions.extend(conditions_to_check.iter().map(|c| {
+  //split_by_or(c.clone())
+  //.into_iter()
+  //.map(split_by_and)
+  //.collect()
+  //}));
+}
+
+fn split_by_or_then_and(expr: Expr) -> Vec<Vec<Expr>> {
+  split_by_or(expr).into_iter().map(split_by_and).collect()
+}
+
+//#[derive(Debug)]
+//struct IfElseEqualChecker(SpanDropped<Expr>);
+
+//impl PartialEq for IfElseEqualChecker {
+//fn eq(&self, other: &Self) -> bool {
+//let IfElseEqualChecker(ref self_sd) = self;
+//let IfElseEqualChecker(ref other_sd) = other;
+
+//equal_in_if_else(&self_sd.as_ref(), &other_sd.as_ref())
+//}
+//}
+
+//impl Eq for IfElseEqualChecker {}
+
+//impl PartialOrd for IfElseEqualChecker {
+//fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+//Some(self.cmp(other))
+//}
+//}
+
+//impl Ord for IfElseEqualChecker {
+//fn cmp(&self, other: &Self) -> Ordering {
+//if self == other {
+//Ordering::Equal
+//} else {
+//let IfElseEqualChecker(ref self_sd) = self;
+//let IfElseEqualChecker(ref other_sd) = other;
+//self_sd.cmp(other_sd)
+//}
+//}
+//}
 
 #[cfg(test)]
 mod tests {
@@ -177,10 +375,7 @@ mod tests {
 
   #[test]
   fn hogepiyo() {
-    assert_lint_err::<NoDupeElseIf>(
-      "if (a === 1) {} else if ((a === 1)) {}",
-      0,
-    );
+    assert_lint_ok::<NoDupeElseIf>("if (a || b) {} else if (a || c) {}");
   }
 
   #[test]
@@ -226,7 +421,7 @@ mod tests {
     );
     assert_lint_err_n::<NoDupeElseIf>(
       "if (a) {} else if (b) {} else if (a) {} else if (b) {} else if (a) {}",
-      vec![34, 64, 49],
+      vec![34, 49, 64],
     );
     assert_lint_err::<NoDupeElseIf>("if (a) { if (b) {} } else if (a) {}", 30);
     assert_lint_err::<NoDupeElseIf>("if (a === 1) {} else if (a === 1) {}", 25);
@@ -247,97 +442,97 @@ mod tests {
       "if (a === 1) {} else if ((a === 1)) {}",
       25,
     );
-    assert_lint_err::<NoDupeElseIf>("if (a || b) {} else if (a) {}", 0);
-    assert_lint_err::<NoDupeElseIf>(
+    assert_lint_err::<NoDupeElseIf>("if (a || b) {} else if (a) {}", 24);
+    assert_lint_err_n::<NoDupeElseIf>(
       "if (a || b) {} else if (a) {} else if (b) {}",
-      0,
+      vec![24, 39],
     );
-    assert_lint_err::<NoDupeElseIf>("if (a || b) {} else if (b || a) {}", 0);
+    assert_lint_err::<NoDupeElseIf>("if (a || b) {} else if (b || a) {}", 24);
     assert_lint_err::<NoDupeElseIf>(
       "if (a) {} else if (b) {} else if (a || b) {}",
-      0,
+      34,
     );
     assert_lint_err::<NoDupeElseIf>(
       "if (a || b) {} else if (c || d) {} else if (a || d) {}",
-      0,
+      44,
     );
     assert_lint_err::<NoDupeElseIf>(
       "if ((a === b && fn(c)) || d) {} else if (fn(c) && a === b) {}",
-      0,
+      41,
     );
-    assert_lint_err::<NoDupeElseIf>("if (a) {} else if (a && b) {}", 0);
-    assert_lint_err::<NoDupeElseIf>("if (a && b) {} else if (b && a) {}", 0);
+    assert_lint_err::<NoDupeElseIf>("if (a) {} else if (a && b) {}", 19);
+    assert_lint_err::<NoDupeElseIf>("if (a && b) {} else if (b && a) {}", 24);
     assert_lint_err::<NoDupeElseIf>(
       "if (a && b) {} else if (a && b && c) {}",
-      0,
+      24,
     );
     assert_lint_err::<NoDupeElseIf>(
       "if (a || c) {} else if (a && b || c) {}",
-      0,
+      24,
     );
     assert_lint_err::<NoDupeElseIf>(
       "if (a) {} else if (b) {} else if (c && a || b) {}",
-      0,
+      34,
     );
     assert_lint_err::<NoDupeElseIf>(
       "if (a) {} else if (b) {} else if (c && (a || b)) {}",
-      0,
+      34,
     );
     assert_lint_err::<NoDupeElseIf>(
       "if (a) {} else if (b && c) {} else if (d && (a || e && c && b)) {}",
-      0,
+      39,
     );
     assert_lint_err::<NoDupeElseIf>(
       "if (a || b && c) {} else if (b && c && d) {}",
-      0,
+      29,
     );
-    assert_lint_err::<NoDupeElseIf>("if (a || b) {} else if (b && c) {}", 0);
+    assert_lint_err::<NoDupeElseIf>("if (a || b) {} else if (b && c) {}", 24);
     assert_lint_err::<NoDupeElseIf>(
       "if (a) {} else if (b) {} else if ((a || b) && c) {}",
-      0,
+      34,
     );
     assert_lint_err::<NoDupeElseIf>(
       "if ((a && (b || c)) || d) {} else if ((c || b) && e && a) {}",
-      0,
+      38,
     );
     assert_lint_err::<NoDupeElseIf>(
       "if (a && b || b && c) {} else if (a && b && c) {}",
-      0,
+      34,
     );
     assert_lint_err::<NoDupeElseIf>(
       "if (a) {} else if (b && c) {} else if (d && (c && e && b || a)) {}",
-      0,
+      39,
     );
     assert_lint_err::<NoDupeElseIf>(
       "if (a || (b && (c || d))) {} else if ((d || c) && b) {}",
-      0,
+      38,
     );
     assert_lint_err::<NoDupeElseIf>(
       "if (a || b) {} else if ((b || a) && c) {}",
-      0,
+      24,
     );
     assert_lint_err::<NoDupeElseIf>(
       "if (a || b) {} else if (c) {} else if (d) {} else if (b && (a || c)) {}",
-      0,
+      54,
     );
     assert_lint_err::<NoDupeElseIf>(
       "if (a || b || c) {} else if (a || (b && d) || (c && e)) {}",
-      0,
+      29,
     );
     assert_lint_err::<NoDupeElseIf>(
       "if (a || (b || c)) {} else if (a || (b && c)) {}",
-      0,
+      31,
     );
-    assert_lint_err::<NoDupeElseIf>("if (a || b) {} else if (c) {} else if (d) {} else if ((a || c) && (b || d)) {}", 0);
+    assert_lint_err::<NoDupeElseIf>("if (a || b) {} else if (c) {} else if (d) {} else if ((a || c) && (b || d)) {}", 54);
     assert_lint_err::<NoDupeElseIf>(
       "if (a) {} else if (b) {} else if (c && (a || d && b)) {}",
-      0,
+      34,
     );
-    assert_lint_err::<NoDupeElseIf>("if (a) {} else if (a || a) {}", 0);
-    assert_lint_err::<NoDupeElseIf>("if (a || a) {} else if (a || a) {}", 0);
-    assert_lint_err::<NoDupeElseIf>("if (a || a) {} else if (a) {}", 0);
-    assert_lint_err::<NoDupeElseIf>("if (a) {} else if (a && a) {}", 0);
-    assert_lint_err::<NoDupeElseIf>("if (a && a) {} else if (a && a) {}", 0);
-    assert_lint_err::<NoDupeElseIf>("if (a && a) {} else if (a) {}", 0);
+    assert_lint_err::<NoDupeElseIf>("if (a) {} else if (a || a) {}", 19);
+    assert_lint_err::<NoDupeElseIf>("if (a || a) {} else if (a || a) {}", 24);
+    assert_lint_err::<NoDupeElseIf>("if (a || a) {} else if (a) {}", 24);
+    assert_lint_err::<NoDupeElseIf>("if (a) {} else if (a && a) {}", 19);
+    assert_lint_err::<NoDupeElseIf>("if (a && a) {} else if (a && a) {}", 24);
+    assert_lint_err::<NoDupeElseIf>("if (a && a) {} else if (a) {}", 24);
   }
 }

--- a/src/rules/no_dupe_else_if.rs
+++ b/src/rules/no_dupe_else_if.rs
@@ -1,0 +1,511 @@
+#![allow(unused_imports, dead_code)]
+// Copyright 2020 the Deno authors. All rights reserved. MIT license.
+use super::{Context, LintRule};
+use std::cmp::Ordering;
+use std::collections::{HashMap, HashSet};
+use swc_common::{Span, Spanned, DUMMY_SP};
+use swc_ecma_ast::{
+  ArrayLit, ArrowExpr, AssignExpr, AwaitExpr, BigInt, BinExpr, BlockStmt,
+  BlockStmtOrExpr, Bool, CallExpr, ClassExpr, CondExpr, Constructor, Expr,
+  FnExpr, Function, Ident, IfStmt, Invalid, JSXElement, JSXEmptyExpr,
+  JSXFragment, JSXMemberExpr, JSXNamespacedName, JSXText, Lit, MemberExpr,
+  MetaPropExpr, Module, NewExpr, Null, Number, ObjectLit, OptChainExpr,
+  ParenExpr, PrivateName, Regex, SeqExpr, Stmt, Str, SwitchStmt, TaggedTpl,
+  ThisExpr, Tpl, TsAsExpr, TsConstAssertion, TsNonNullExpr, TsTypeAssertion,
+  TsTypeCastExpr, UnaryExpr, UpdateExpr, YieldExpr,
+};
+use swc_ecma_visit::{Fold, Node, Visit};
+
+pub struct NoDupeElseIf;
+
+impl LintRule for NoDupeElseIf {
+  fn new() -> Box<Self> {
+    Box::new(NoDupeElseIf)
+  }
+
+  fn code(&self) -> &'static str {
+    "no-dupe-else-if"
+  }
+
+  fn lint_module(&self, context: Context, module: Module) {
+    let mut visitor = NoDupeElseIfVisitor::new(context);
+    visitor.visit_module(&module, &module);
+  }
+}
+
+struct NoDupeElseIfVisitor {
+  context: Context,
+  checked_span: HashSet<Span>,
+}
+
+impl NoDupeElseIfVisitor {
+  pub fn new(context: Context) -> Self {
+    Self {
+      context,
+      checked_span: HashSet::new(),
+    }
+  }
+}
+
+impl Visit for NoDupeElseIfVisitor {
+  fn visit_if_stmt(&mut self, if_stmt: &IfStmt, parent: &dyn Node) {
+    let mut dropper = ExprSpanDropper;
+    let span = if_stmt.test.span();
+    if !self.checked_span.contains(&span) {
+      self.checked_span.insert(span);
+      let mut conditions = HashMap::new();
+      let test = dropper.fold_expr((&*if_stmt.test).clone());
+      conditions.insert(ConditionToCheck::new(test), vec![if_stmt.test.span()]);
+      let mut next = if_stmt.alt.as_ref();
+      while let Some(alt) = next {
+        if let Stmt::If(IfStmt {
+          ref test, ref alt, ..
+        }) = &**alt
+        {
+          // preserve the span before dropping
+          let span = test.span();
+          let test = dropper.fold_expr((&**test).clone());
+          conditions
+            .entry(ConditionToCheck::new(test))
+            .or_insert_with(Vec::new)
+            .push(span);
+          self.checked_span.insert(span);
+          next = alt.as_ref();
+        } else {
+          break;
+        }
+      }
+      dbg!(&conditions);
+
+      conditions
+        .values()
+        .filter_map(|c| if c.len() >= 2 {
+          Some(c.iter().skip(1))
+        } else {
+          None
+        })
+        .flatten()
+        .for_each(|span| {
+          self
+            .context
+            .add_diagnostic(*span, "no-dupe-else-if", "This branch can never execute. Its condition is a duplicate or covered by previous conditions in the if-else-if chain.")
+        });
+    }
+
+    swc_ecma_visit::visit_if_stmt(self, if_stmt, parent);
+  }
+}
+
+struct ExprSpanDropper;
+
+impl Fold for ExprSpanDropper {
+  fn fold_expr(&mut self, expr: Expr) -> Expr {
+    let dropped = match expr {
+      Expr::This(_) => Expr::This(ThisExpr { span: DUMMY_SP }),
+      Expr::Array(ArrayLit { elems, .. }) => Expr::Array(ArrayLit {
+        span: DUMMY_SP,
+        elems,
+      }),
+      Expr::Object(ObjectLit { props, .. }) => Expr::Object(ObjectLit {
+        span: DUMMY_SP,
+        props,
+      }),
+      Expr::Fn(FnExpr {
+        mut ident,
+        mut function,
+      }) => {
+        ident.as_mut().map(|i| i.span = DUMMY_SP);
+        function.span = DUMMY_SP;
+        Expr::Fn(FnExpr { ident, function })
+      }
+      Expr::Unary(UnaryExpr { op, arg, .. }) => Expr::Unary(UnaryExpr {
+        span: DUMMY_SP,
+        op,
+        arg,
+      }),
+      Expr::Update(UpdateExpr {
+        op, prefix, arg, ..
+      }) => Expr::Update(UpdateExpr {
+        span: DUMMY_SP,
+        op,
+        prefix,
+        arg,
+      }),
+      Expr::Bin(BinExpr {
+        op, left, right, ..
+      }) => Expr::Bin(BinExpr {
+        span: DUMMY_SP,
+        op,
+        left,
+        right,
+      }),
+      Expr::Assign(AssignExpr {
+        op, left, right, ..
+      }) => Expr::Assign(AssignExpr {
+        span: DUMMY_SP,
+        op,
+        left,
+        right,
+      }),
+      Expr::Member(MemberExpr {
+        obj,
+        prop,
+        computed,
+        ..
+      }) => Expr::Member(MemberExpr {
+        span: DUMMY_SP,
+        obj,
+        prop,
+        computed,
+      }),
+      Expr::Cond(CondExpr {
+        test, cons, alt, ..
+      }) => Expr::Cond(CondExpr {
+        span: DUMMY_SP,
+        test,
+        cons,
+        alt,
+      }),
+      Expr::Call(CallExpr {
+        callee,
+        args,
+        type_args,
+        ..
+      }) => Expr::Call(CallExpr {
+        span: DUMMY_SP,
+        callee,
+        args,
+        type_args,
+      }),
+      Expr::New(NewExpr {
+        callee,
+        args,
+        type_args,
+        ..
+      }) => Expr::New(NewExpr {
+        span: DUMMY_SP,
+        callee,
+        args,
+        type_args,
+      }),
+      Expr::Seq(SeqExpr { exprs, .. }) => Expr::Seq(SeqExpr {
+        span: DUMMY_SP,
+        exprs,
+      }),
+      Expr::Ident(Ident {
+        sym,
+        type_ann,
+        optional,
+        ..
+      }) => Expr::Ident(Ident {
+        span: DUMMY_SP,
+        sym,
+        type_ann,
+        optional,
+      }),
+      Expr::Lit(lit) => {
+        let l = match lit {
+          Lit::Str(Str {
+            value, has_escape, ..
+          }) => Lit::Str(Str {
+            span: DUMMY_SP,
+            value,
+            has_escape,
+          }),
+          Lit::Bool(Bool { value, .. }) => Lit::Bool(Bool {
+            span: DUMMY_SP,
+            value,
+          }),
+          Lit::Null(_) => Lit::Null(Null { span: DUMMY_SP }),
+          Lit::Num(Number { value, .. }) => Lit::Num(Number {
+            span: DUMMY_SP,
+            value,
+          }),
+          Lit::BigInt(BigInt { value, .. }) => Lit::BigInt(BigInt {
+            span: DUMMY_SP,
+            value,
+          }),
+          Lit::Regex(Regex { exp, flags, .. }) => Lit::Regex(Regex {
+            span: DUMMY_SP,
+            exp,
+            flags,
+          }),
+          Lit::JSXText(JSXText { value, raw, .. }) => Lit::JSXText(JSXText {
+            span: DUMMY_SP,
+            value,
+            raw,
+          }),
+        };
+        Expr::Lit(l)
+      }
+      Expr::Tpl(Tpl { exprs, quasis, .. }) => Expr::Tpl(Tpl {
+        span: DUMMY_SP,
+        exprs,
+        quasis,
+      }),
+      Expr::TaggedTpl(TaggedTpl {
+        tag,
+        exprs,
+        quasis,
+        type_params,
+        ..
+      }) => Expr::TaggedTpl(TaggedTpl {
+        span: DUMMY_SP,
+        tag,
+        exprs,
+        quasis,
+        type_params,
+      }),
+      Expr::Arrow(ArrowExpr {
+        params,
+        body,
+        is_async,
+        is_generator,
+        type_params,
+        return_type,
+        ..
+      }) => Expr::Arrow(ArrowExpr {
+        span: DUMMY_SP,
+        params,
+        body,
+        is_async,
+        is_generator,
+        type_params,
+        return_type,
+      }),
+      // TODO(magurotuna) from here. next is ClassExpr
+      _ => Expr::Invalid(Invalid { span: DUMMY_SP }),
+    };
+
+    swc_ecma_visit::fold_expr(self, dropped)
+  }
+}
+
+#[derive(Debug, Eq, PartialEq, Hash)]
+struct ConditionToCheck {
+  condition: Expr,
+}
+
+impl ConditionToCheck {
+  fn new(condition: Expr) -> Self {
+    Self { condition }
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use crate::test_util::*;
+
+  #[test]
+  fn no_dupe_else_if_valid() {
+    assert_lint_ok::<NoDupeElseIf>("if (a) {} else if (b) {}");
+    assert_lint_ok::<NoDupeElseIf>("if (a); else if (b); else if (c);");
+    assert_lint_ok::<NoDupeElseIf>("if (true) {} else if (false) {} else {}");
+    assert_lint_ok::<NoDupeElseIf>("if (1) {} else if (2) {}");
+    assert_lint_ok::<NoDupeElseIf>("if (f) {} else if (f()) {}");
+    assert_lint_ok::<NoDupeElseIf>("if (f(a)) {} else if (g(a)) {}");
+    assert_lint_ok::<NoDupeElseIf>("if (f(a)) {} else if (f(b)) {}");
+    assert_lint_ok::<NoDupeElseIf>("if (a === 1) {} else if (a === 2) {}");
+    assert_lint_ok::<NoDupeElseIf>("if (a === 1) {} else if (b === 1) {}");
+    assert_lint_ok::<NoDupeElseIf>("if (a) {}");
+    assert_lint_ok::<NoDupeElseIf>("if (a);");
+    assert_lint_ok::<NoDupeElseIf>("if (a) {} else {}");
+    assert_lint_ok::<NoDupeElseIf>("if (a) if (a) {}");
+    assert_lint_ok::<NoDupeElseIf>("if (a) if (a);");
+    assert_lint_ok::<NoDupeElseIf>("if (a) { if (a) {} }");
+    assert_lint_ok::<NoDupeElseIf>("if (a) {} else { if (a) {} }");
+    assert_lint_ok::<NoDupeElseIf>("if (a) {} if (a) {}");
+    assert_lint_ok::<NoDupeElseIf>("if (a); if (a);");
+    assert_lint_ok::<NoDupeElseIf>("while (a) if (a);");
+    assert_lint_ok::<NoDupeElseIf>("if (a); else a ? a : a;");
+    assert_lint_ok::<NoDupeElseIf>("if (a) { if (b) {} } else if (b) {}");
+    assert_lint_ok::<NoDupeElseIf>("if (a) if (b); else if (a);");
+    assert_lint_ok::<NoDupeElseIf>("if (a) {} else if (!!a) {}");
+    assert_lint_ok::<NoDupeElseIf>("if (a === 1) {} else if (a === (1)) {}");
+    assert_lint_ok::<NoDupeElseIf>("if (a || b) {} else if (c || d) {}");
+    assert_lint_ok::<NoDupeElseIf>("if (a || b) {} else if (a || c) {}");
+    assert_lint_ok::<NoDupeElseIf>("if (a) {} else if (a || b) {}");
+    assert_lint_ok::<NoDupeElseIf>(
+      "if (a) {} else if (b) {} else if (a || b || c) {}",
+    );
+    assert_lint_ok::<NoDupeElseIf>(
+      "if (a && b) {} else if (a) {} else if (b) {}",
+    );
+    assert_lint_ok::<NoDupeElseIf>(
+      "if (a && b) {} else if (b && c) {} else if (a && c) {}",
+    );
+    assert_lint_ok::<NoDupeElseIf>("if (a && b) {} else if (b || c) {}");
+    assert_lint_ok::<NoDupeElseIf>("if (a) {} else if (b && (a || c)) {}");
+    assert_lint_ok::<NoDupeElseIf>("if (a) {} else if (b && (c || d && a)) {}");
+    assert_lint_ok::<NoDupeElseIf>(
+      "if (a && b && c) {} else if (a && b && (c || d)) {}",
+    );
+  }
+
+  #[test]
+  fn hogepiyo() {
+    assert_lint_err::<NoDupeElseIf>(
+      "if (a>1) {} else if (a >             1) {} else if (b) {}",
+      21,
+    );
+  }
+
+  #[test]
+  fn no_dupe_else_if_invalid() {
+    assert_lint_err::<NoDupeElseIf>(
+      "if (a) {} else if (a) {} else if (b) {}",
+      19,
+    );
+    assert_lint_err::<NoDupeElseIf>("if (a); else if (a);", 17);
+    assert_lint_err::<NoDupeElseIf>("if (a) {} else if (a) {} else {}", 0); // TODO(magurotuna) from here
+    assert_lint_err::<NoDupeElseIf>(
+      "if (a) {} else if (b) {} else if (a) {} else if (c) {}",
+      0,
+    );
+    assert_lint_err::<NoDupeElseIf>(
+      "if (a) {} else if (b) {} else if (a) {}",
+      0,
+    );
+    assert_lint_err::<NoDupeElseIf>(
+      "if (a) {} else if (b) {} else if (c) {} else if (a) {}",
+      0,
+    );
+    assert_lint_err::<NoDupeElseIf>(
+      "if (a) {} else if (b) {} else if (b) {}",
+      0,
+    );
+    assert_lint_err::<NoDupeElseIf>(
+      "if (a) {} else if (b) {} else if (b) {} else {}",
+      0,
+    );
+    assert_lint_err::<NoDupeElseIf>(
+      "if (a) {} else if (b) {} else if (c) {} else if (b) {}",
+      0,
+    );
+    assert_lint_err::<NoDupeElseIf>(
+      "if (a); else if (b); else if (c); else if (b); else if (d); else;",
+      0,
+    );
+    assert_lint_err::<NoDupeElseIf>("if (a); else if (b); else if (c); else if (d); else if (b); else if (e);", 0);
+    assert_lint_err::<NoDupeElseIf>(
+      "if (a) {} else if (a) {} else if (a) {}",
+      0,
+    );
+    assert_lint_err::<NoDupeElseIf>(
+      "if (a) {} else if (b) {} else if (a) {} else if (b) {} else if (a) {}",
+      0,
+    );
+    assert_lint_err::<NoDupeElseIf>("if (a) { if (b) {} } else if (a) {}", 0);
+    assert_lint_err::<NoDupeElseIf>("if (a === 1) {} else if (a === 1) {}", 0);
+    assert_lint_err::<NoDupeElseIf>("if (1 < a) {} else if (1 < a) {}", 0);
+    assert_lint_err::<NoDupeElseIf>("if (true) {} else if (true) {}", 0);
+    assert_lint_err::<NoDupeElseIf>("if (a && b) {} else if (a && b) {}", 0);
+    assert_lint_err::<NoDupeElseIf>(
+      "if (a && b || c)  {} else if (a && b || c) {}",
+      0,
+    );
+    assert_lint_err::<NoDupeElseIf>("if (f(a)) {} else if (f(a)) {}", 0);
+    assert_lint_err::<NoDupeElseIf>("if (a === 1) {} else if (a===1) {}", 0);
+    assert_lint_err::<NoDupeElseIf>(
+      "if (a === 1) {} else if (a === /* comment */ 1) {}",
+      0,
+    );
+    assert_lint_err::<NoDupeElseIf>(
+      "if (a === 1) {} else if ((a === 1)) {}",
+      0,
+    );
+    assert_lint_err::<NoDupeElseIf>("if (a || b) {} else if (a) {}", 0);
+    assert_lint_err::<NoDupeElseIf>(
+      "if (a || b) {} else if (a) {} else if (b) {}",
+      0,
+    );
+    assert_lint_err::<NoDupeElseIf>("if (a || b) {} else if (b || a) {}", 0);
+    assert_lint_err::<NoDupeElseIf>(
+      "if (a) {} else if (b) {} else if (a || b) {}",
+      0,
+    );
+    assert_lint_err::<NoDupeElseIf>(
+      "if (a || b) {} else if (c || d) {} else if (a || d) {}",
+      0,
+    );
+    assert_lint_err::<NoDupeElseIf>(
+      "if ((a === b && fn(c)) || d) {} else if (fn(c) && a === b) {}",
+      0,
+    );
+    assert_lint_err::<NoDupeElseIf>("if (a) {} else if (a && b) {}", 0);
+    assert_lint_err::<NoDupeElseIf>("if (a && b) {} else if (b && a) {}", 0);
+    assert_lint_err::<NoDupeElseIf>(
+      "if (a && b) {} else if (a && b && c) {}",
+      0,
+    );
+    assert_lint_err::<NoDupeElseIf>(
+      "if (a || c) {} else if (a && b || c) {}",
+      0,
+    );
+    assert_lint_err::<NoDupeElseIf>(
+      "if (a) {} else if (b) {} else if (c && a || b) {}",
+      0,
+    );
+    assert_lint_err::<NoDupeElseIf>(
+      "if (a) {} else if (b) {} else if (c && (a || b)) {}",
+      0,
+    );
+    assert_lint_err::<NoDupeElseIf>(
+      "if (a) {} else if (b && c) {} else if (d && (a || e && c && b)) {}",
+      0,
+    );
+    assert_lint_err::<NoDupeElseIf>(
+      "if (a || b && c) {} else if (b && c && d) {}",
+      0,
+    );
+    assert_lint_err::<NoDupeElseIf>("if (a || b) {} else if (b && c) {}", 0);
+    assert_lint_err::<NoDupeElseIf>(
+      "if (a) {} else if (b) {} else if ((a || b) && c) {}",
+      0,
+    );
+    assert_lint_err::<NoDupeElseIf>(
+      "if ((a && (b || c)) || d) {} else if ((c || b) && e && a) {}",
+      0,
+    );
+    assert_lint_err::<NoDupeElseIf>(
+      "if (a && b || b && c) {} else if (a && b && c) {}",
+      0,
+    );
+    assert_lint_err::<NoDupeElseIf>(
+      "if (a) {} else if (b && c) {} else if (d && (c && e && b || a)) {}",
+      0,
+    );
+    assert_lint_err::<NoDupeElseIf>(
+      "if (a || (b && (c || d))) {} else if ((d || c) && b) {}",
+      0,
+    );
+    assert_lint_err::<NoDupeElseIf>(
+      "if (a || b) {} else if ((b || a) && c) {}",
+      0,
+    );
+    assert_lint_err::<NoDupeElseIf>(
+      "if (a || b) {} else if (c) {} else if (d) {} else if (b && (a || c)) {}",
+      0,
+    );
+    assert_lint_err::<NoDupeElseIf>(
+      "if (a || b || c) {} else if (a || (b && d) || (c && e)) {}",
+      0,
+    );
+    assert_lint_err::<NoDupeElseIf>(
+      "if (a || (b || c)) {} else if (a || (b && c)) {}",
+      0,
+    );
+    assert_lint_err::<NoDupeElseIf>("if (a || b) {} else if (c) {} else if (d) {} else if ((a || c) && (b || d)) {}", 0);
+    assert_lint_err::<NoDupeElseIf>(
+      "if (a) {} else if (b) {} else if (c && (a || d && b)) {}",
+      0,
+    );
+    assert_lint_err::<NoDupeElseIf>("if (a) {} else if (a || a) {}", 0);
+    assert_lint_err::<NoDupeElseIf>("if (a || a) {} else if (a || a) {}", 0);
+    assert_lint_err::<NoDupeElseIf>("if (a || a) {} else if (a) {}", 0);
+    assert_lint_err::<NoDupeElseIf>("if (a) {} else if (a && a) {}", 0);
+    assert_lint_err::<NoDupeElseIf>("if (a && a) {} else if (a && a) {}", 0);
+    assert_lint_err::<NoDupeElseIf>("if (a && a) {} else if (a) {}", 0);
+  }
+}

--- a/src/rules/no_dupe_else_if.rs
+++ b/src/rules/no_dupe_else_if.rs
@@ -23,6 +23,8 @@ impl LintRule for NoDupeElseIf {
   }
 }
 
+/// A visitor to check the `no-dupe-else-if` rule.
+/// Determination logic is ported from ESLint's implementation. For more, see [eslint/no-dupe-else-if.js](https://github.com/eslint/eslint/blob/master/lib/rules/no-dupe-else-if.js).
 struct NoDupeElseIfVisitor {
   context: Context,
   checked_span: HashSet<Span>,
@@ -45,42 +47,9 @@ impl Visit for NoDupeElseIfVisitor {
     if !self.checked_span.contains(&span) {
       self.checked_span.insert(span);
       let span_dropped_test = if_stmt.test.clone().drop_span();
-      //let conditions_to_check = match &test {
-      //Expr::Bin(BinExpr { ref op, .. }) if *op == BinaryOp::LogicalAnd => {
-      //let mut v = vec![&test];
-      //v.append(&mut split_by_and(&test));
-      //v
-      //}
-      //_ => vec![&test],
-      //};
-
-      //let mut list_to_check: Vec<Vec<Vec<&Expr>>> = conditions_to_check
-      //.iter()
-      //.map(|&c| split_by_or(c).into_iter().map(split_by_and).collect())
-      //.collect();
       let mut appeared_conditions: Vec<Vec<Vec<Expr>>> = Vec::new();
       append_test(&mut appeared_conditions, span_dropped_test);
 
-      //let append_test_to_check = |expr: &Expr| {
-      //let conditions_to_check = match *expr {
-      //Expr::Bin(BinExpr { ref op, .. }) if *op == BinaryOp::LogicalAnd => {
-      //let mut v = vec![expr];
-      //v.append(&mut split_by_and(expr));
-      //v
-      //}
-      //_ => vec![expr],
-      //};
-      //list_to_check.extend(
-      //conditions_to_check
-      //.iter()
-      //.map(|&c| split_by_or(c).into_iter().map(split_by_and).collect()),
-      //);
-      //};
-
-      //append_test_to_check(&span_dropped_test);
-
-      //let mut conditions = BTreeMap::new();
-      //conditions.insert(IfElseEqualChecker(test), vec![span]);
       let mut next = if_stmt.alt.as_ref();
       while let Some(cur) = next {
         if let Stmt::If(IfStmt {
@@ -90,17 +59,11 @@ impl Visit for NoDupeElseIfVisitor {
           // preserve the span before dropping
           let span = test.span();
           let span_dropped_test = test.clone().drop_span();
-          //let current_or_operands: Vec<Vec<Expr>> =
-          //split_by_or(span_dropped_test.clone())
-          //.into_iter()
-          //.map(split_by_and)
-          //.collect();
           let mut current_condition_to_check: Vec<Vec<Vec<Expr>>> =
             mk_condition_to_check(span_dropped_test.clone())
               .into_iter()
               .map(split_by_or_then_and)
               .collect();
-          //let mut appeared_conditions_to_check = appeared_conditions.clone();
 
           for ap_cond in &appeared_conditions {
             current_condition_to_check = current_condition_to_check
@@ -128,29 +91,6 @@ impl Visit for NoDupeElseIfVisitor {
             }
           }
 
-          //if current_condition_to_check
-          //.into_iter()
-          //.map(split_by_or_then_and)
-          //.any(|current_or_operands| {
-          //current_or_operands
-          //.iter()
-          //.find(|current_or_operand| {
-          //appeared_conditions
-          //.iter()
-          //.any(|ap_cond| is_subset(current_or_operand, ap_cond))
-          //})
-          //.is_some()
-          //})
-          //{
-          //self
-          //.context
-          //.add_diagnostic(span, "no-dupe-else-if", "This branch can never execute. Its condition is a duplicate or covered by previous conditions in the if-else-if chain.");
-          //}
-
-          //conditions
-          //.entry(IfElseEqualChecker(test))
-          //.or_insert_with(Vec::new)
-          //.push(span);
           self.checked_span.insert(span);
           append_test(&mut appeared_conditions, span_dropped_test);
           next = alt.as_ref();
@@ -158,16 +98,6 @@ impl Visit for NoDupeElseIfVisitor {
           break;
         }
       }
-
-      //conditions
-      //.values()
-      //.map(|c| c.iter().skip(1))
-      //.flatten()
-      //.for_each(|span| {
-      //self
-      //.context
-      //.add_diagnostic(*span, "no-dupe-else-if", "This branch can never execute. Its condition is a duplicate or covered by previous conditions in the if-else-if chain.")
-      //});
     }
 
     swc_ecma_visit::visit_if_stmt(self, if_stmt, parent);
@@ -206,6 +136,10 @@ fn split_by_or(expr: Expr) -> Vec<Expr> {
 
 fn split_by_and(expr: Expr) -> Vec<Expr> {
   split_by_bin_op(BinaryOp::LogicalAnd, expr)
+}
+
+fn split_by_or_then_and(expr: Expr) -> Vec<Vec<Expr>> {
+  split_by_or(expr).into_iter().map(split_by_and).collect()
 }
 
 fn is_subset(arr_a: &Vec<Expr>, arr_b: &Vec<Expr>) -> bool {
@@ -269,58 +203,8 @@ fn equal_in_if_else(expr1: &Expr, expr2: &Expr) -> bool {
 }
 
 fn append_test(appeared_conditions: &mut Vec<Vec<Vec<Expr>>>, expr: Expr) {
-  //let conditions_to_check = match expr {
-  //Expr::Bin(BinExpr { ref op, .. }) if *op == BinaryOp::LogicalAnd => {
-  //let mut v = vec![expr.clone()];
-  //v.append(&mut split_by_and(expr));
-  //v
-  //}
-  //_ => vec![expr],
-  //};
   appeared_conditions.push(split_by_or_then_and(expr));
-  //appeared_conditions.extend(conditions_to_check.iter().map(|c| {
-  //split_by_or(c.clone())
-  //.into_iter()
-  //.map(split_by_and)
-  //.collect()
-  //}));
 }
-
-fn split_by_or_then_and(expr: Expr) -> Vec<Vec<Expr>> {
-  split_by_or(expr).into_iter().map(split_by_and).collect()
-}
-
-//#[derive(Debug)]
-//struct IfElseEqualChecker(SpanDropped<Expr>);
-
-//impl PartialEq for IfElseEqualChecker {
-//fn eq(&self, other: &Self) -> bool {
-//let IfElseEqualChecker(ref self_sd) = self;
-//let IfElseEqualChecker(ref other_sd) = other;
-
-//equal_in_if_else(&self_sd.as_ref(), &other_sd.as_ref())
-//}
-//}
-
-//impl Eq for IfElseEqualChecker {}
-
-//impl PartialOrd for IfElseEqualChecker {
-//fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-//Some(self.cmp(other))
-//}
-//}
-
-//impl Ord for IfElseEqualChecker {
-//fn cmp(&self, other: &Self) -> Ordering {
-//if self == other {
-//Ordering::Equal
-//} else {
-//let IfElseEqualChecker(ref self_sd) = self;
-//let IfElseEqualChecker(ref other_sd) = other;
-//self_sd.cmp(other_sd)
-//}
-//}
-//}
 
 #[cfg(test)]
 mod tests {

--- a/src/swc_util.rs
+++ b/src/swc_util.rs
@@ -218,40 +218,7 @@ impl Fold for SpanDropper {
   }
 }
 
-///// A struct that has span-dropped ast node.
-//#[derive(Debug, Eq, PartialEq)]
-//pub(crate) struct SpanDropped<T: std::fmt::Debug + Eq + PartialEq>(T);
-
-//impl<T: std::fmt::Debug + Eq + PartialEq> SpanDropped<T> {
-//pub(crate) fn as_ref(&self) -> SpanDropped<&T> {
-//let SpanDropped(ref inner) = self;
-//SpanDropped(inner)
-//}
-//}
-
-//impl<T> PartialOrd for SpanDropped<T>
-//where
-//T: std::fmt::Debug + Eq + PartialEq,
-//{
-//fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-//Some(self.cmp(other))
-//}
-//}
-
-//impl<T> Ord for SpanDropped<T>
-//where
-//T: std::fmt::Debug + Eq + PartialEq,
-//{
-//fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-//let SpanDropped(ref self_inner) = self;
-//let SpanDropped(ref other_inner) = other;
-//let self_debug = format!("{:?}", self_inner);
-//let other_debug = format!("{:?}", other_inner);
-//self_debug.cmp(&other_debug)
-//}
-//}
-
-/// Provides a additional method to drop spans.
+/// Provides an additional method to drop spans.
 pub(crate) trait DropSpan {
   fn drop_span(self) -> Self;
 }

--- a/src/swc_util.rs
+++ b/src/swc_util.rs
@@ -14,7 +14,7 @@ use swc_common::Globals;
 use swc_common::SourceMap;
 use swc_common::Span;
 use swc_common::DUMMY_SP;
-use swc_ecma_ast::{BinaryOp, Expr, ParenExpr};
+use swc_ecma_ast::Expr;
 use swc_ecma_parser::lexer::Lexer;
 use swc_ecma_parser::EsConfig;
 use swc_ecma_parser::JscTarget;
@@ -218,118 +218,47 @@ impl Fold for SpanDropper {
   }
 }
 
-/// A struct that has span-dropped ast node.
-#[derive(Debug, Eq, PartialEq)]
-pub(crate) struct SpanDropped<T: std::fmt::Debug + Eq + PartialEq>(T);
+///// A struct that has span-dropped ast node.
+//#[derive(Debug, Eq, PartialEq)]
+//pub(crate) struct SpanDropped<T: std::fmt::Debug + Eq + PartialEq>(T);
 
-impl<T: std::fmt::Debug + Eq + PartialEq> SpanDropped<T> {
-  pub(crate) fn as_ref(&self) -> SpanDropped<&T> {
-    let SpanDropped(ref inner) = self;
-    SpanDropped(inner)
-  }
-}
+//impl<T: std::fmt::Debug + Eq + PartialEq> SpanDropped<T> {
+//pub(crate) fn as_ref(&self) -> SpanDropped<&T> {
+//let SpanDropped(ref inner) = self;
+//SpanDropped(inner)
+//}
+//}
 
-/// Determines whether the two given `Expr`s are considered to be equal in if-else condition
-/// context.
-pub(crate) fn equal_in_if_else(
-  one: &SpanDropped<&Expr>,
-  other: &SpanDropped<&Expr>,
-) -> bool {
-  let SpanDropped(ref expr1) = one;
-  let SpanDropped(ref expr2) = other;
+//impl<T> PartialOrd for SpanDropped<T>
+//where
+//T: std::fmt::Debug + Eq + PartialEq,
+//{
+//fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+//Some(self.cmp(other))
+//}
+//}
 
-  use swc_ecma_ast::Expr::*;
-  match (expr1, expr2) {
-    (Bin(ref bin1), Bin(ref bin2))
-      if matches!(bin1.op, BinaryOp::LogicalOr | BinaryOp::LogicalAnd)
-        && bin1.op == bin2.op =>
-    {
-      let b1_left = SpanDropped(&*bin1.left);
-      let b2_left = SpanDropped(&*bin2.left);
-      let b1_right = SpanDropped(&*bin1.right);
-      let b2_right = SpanDropped(&*bin2.right);
-      equal_in_if_else(&b1_left, &b2_left)
-        && equal_in_if_else(&b1_right, &b2_right)
-        || equal_in_if_else(&b1_left, &b2_right)
-          && equal_in_if_else(&b1_right, &b2_left)
-    }
-    (Paren(ParenExpr { ref expr, .. }), _) => {
-      equal_in_if_else(&SpanDropped(&**expr), other)
-    }
-    (_, Paren(ParenExpr { ref expr, .. })) => {
-      equal_in_if_else(one, &SpanDropped(&**expr))
-    }
-    (This(_), This(_))
-    | (Array(_), Array(_))
-    | (Object(_), Object(_))
-    | (Fn(_), Fn(_))
-    | (Unary(_), Unary(_))
-    | (Update(_), Update(_))
-    | (Bin(_), Bin(_))
-    | (Assign(_), Member(_))
-    | (Cond(_), Cond(_))
-    | (Call(_), Call(_))
-    | (New(_), New(_))
-    | (Seq(_), Seq(_))
-    | (Ident(_), Ident(_))
-    | (Lit(_), Lit(_))
-    | (Tpl(_), Tpl(_))
-    | (TaggedTpl(_), TaggedTpl(_))
-    | (Arrow(_), Arrow(_))
-    | (Class(_), Class(_))
-    | (Yield(_), Yield(_))
-    | (MetaProp(_), MetaProp(_))
-    | (Await(_), Await(_))
-    | (JSXMember(_), JSXMember(_))
-    | (JSXNamespacedName(_), JSXNamespacedName(_))
-    | (JSXEmpty(_), JSXEmpty(_))
-    | (JSXElement(_), JSXElement(_))
-    | (JSXFragment(_), JSXFragment(_))
-    | (TsTypeAssertion(_), TsTypeAssertion(_))
-    | (TsConstAssertion(_), TsConstAssertion(_))
-    | (TsNonNull(_), TsNonNull(_))
-    | (TsTypeCast(_), TsTypeCast(_))
-    | (TsAs(_), TsAs(_))
-    | (PrivateName(_), PrivateName(_))
-    | (OptChain(_), OptChain(_))
-    | (Invalid(_), Invalid(_)) => expr1 == expr2,
-    _ => false,
-  }
-}
-
-impl<T> PartialOrd for SpanDropped<T>
-where
-  T: std::fmt::Debug + Eq + PartialEq,
-{
-  fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-    Some(self.cmp(other))
-  }
-}
-
-impl<T> Ord for SpanDropped<T>
-where
-  T: std::fmt::Debug + Eq + PartialEq,
-{
-  fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-    let SpanDropped(ref self_inner) = self;
-    let SpanDropped(ref other_inner) = other;
-    let self_debug = format!("{:?}", self_inner);
-    let other_debug = format!("{:?}", other_inner);
-    self_debug.cmp(&other_debug)
-  }
-}
+//impl<T> Ord for SpanDropped<T>
+//where
+//T: std::fmt::Debug + Eq + PartialEq,
+//{
+//fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+//let SpanDropped(ref self_inner) = self;
+//let SpanDropped(ref other_inner) = other;
+//let self_debug = format!("{:?}", self_inner);
+//let other_debug = format!("{:?}", other_inner);
+//self_debug.cmp(&other_debug)
+//}
+//}
 
 /// Provides a additional method to drop spans.
 pub(crate) trait DropSpan {
-  fn drop_span(self) -> SpanDropped<Self>
-  where
-    Self: Sized + std::fmt::Debug + Eq + PartialEq;
+  fn drop_span(self) -> Self;
 }
 
 impl DropSpan for Expr {
-  fn drop_span(self) -> SpanDropped<Self> {
+  fn drop_span(self) -> Self {
     let mut dropper = SpanDropper;
-    let dropped = dropper.fold_expr(self);
-    SpanDropped(dropped)
+    dropper.fold_expr(self)
   }
 }

--- a/src/test_util.rs
+++ b/src/test_util.rs
@@ -68,7 +68,6 @@ pub fn assert_lint_err_on_line<T: LintRule + 'static>(
   let rule = T::new();
   let rule_code = rule.code();
   let diagnostics = lint(rule, source);
-  dbg!(&diagnostics);
   assert!(diagnostics.len() == 1);
   assert_diagnostic(&diagnostics[0], rule_code, line, col);
 }

--- a/src/test_util.rs
+++ b/src/test_util.rs
@@ -68,6 +68,7 @@ pub fn assert_lint_err_on_line<T: LintRule + 'static>(
   let rule = T::new();
   let rule_code = rule.code();
   let diagnostics = lint(rule, source);
+  dbg!(&diagnostics);
   assert!(diagnostics.len() == 1);
   assert_diagnostic(&diagnostics[0], rule_code, line, col);
 }


### PR DESCRIPTION
~This is WORK IN PROGRESS~

This PR adds [no-dupe-else-if - Rules - ESLint - Pluggable JavaScript linter](https://eslint.org/docs/rules/no-dupe-else-if) rule.

The original implementation is [here](https://github.com/eslint/eslint/blob/master/lib/rules/no-dupe-else-if.js), and it's so complicated.
I did my best to port the original implementation, but the code got dirty, although all the tests are passed.

Also I'm concerned about bad time complexity and cloning `Vec` many times, which may cause bad performance.
