### PR TITLE
no-extra-semi

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -894,9 +894,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_ast"
-version = "0.22.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ea8a035c2a77f4034266f19f6129a2146f3871ce4503a9baf8c069135bc43ba"
+checksum = "da76cf57795cac33c72ee8950eb0b07a4c921d6b78a959216d6ad0e36d477024"
 dependencies = [
  "enum_kind",
  "num-bigint",
@@ -908,9 +908,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_parser"
-version = "0.26.1"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a7acfce58d7bbadd2e6dcb8e914c9d0fd0e6f8717a0ec40fd37e4ba2437aefc"
+checksum = "00871b8900ab4c64b66c81787c95e511e46fb25b54db481a98ab1905160e1edd"
 dependencies = [
  "either",
  "enum_kind",
@@ -942,9 +942,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_visit"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "571731480f3d9c6aa9d1f76563bd923823f28eb38e2e49822e1ffe9db3959c12"
+checksum = "d9ce020872b2c0e6b4b65edbb39f523377a67c4532cdde68efbeaa27fade1e44"
 dependencies = [
  "num-bigint",
  "swc_atoms",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,9 +19,9 @@ name = "dlint"
 lazy_static = "1.4.0"
 swc_atoms = "0.2.2"
 swc_common = { version = "=0.6.1" }
-swc_ecma_ast = { version = "=0.22.0" }
-swc_ecma_parser = { version = "=0.26.1" }
-swc_ecma_visit = { version = "=0.7.0" }
+swc_ecma_ast = { version = "=0.23.0" }
+swc_ecma_parser = { version = "=0.27.0" }
+swc_ecma_visit = { version = "=0.8.0" }
 regex = "1.3.6"
 
 [dev-dependencies]

--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ See [`./benchmarks/`](./benchmarks/) directory for more info.*
 - [`no-explicit-any`](https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-explicit-any.md)
 - [`no-extra-boolean-cast`](https://eslint.org/docs/rules/no-extra-boolean-cast)
 - [`no-extra-non-null-assertion`](https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-extra-non-null-assertion.md)
+- [`no-extra-semi`](https://eslint.org/docs/rules/no-extra-semi)
 - [`no-func-assign`](https://eslint.org/docs/rules/no-func-assign)
 - [`no-inferrable-types`](https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-inferrable-types.md)
 - [`no-misused-new`](https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-misused-new.md)

--- a/src/rules/mod.rs
+++ b/src/rules/mod.rs
@@ -36,6 +36,7 @@ pub mod no_ex_assign;
 pub mod no_explicit_any;
 pub mod no_extra_boolean_cast;
 pub mod no_extra_non_null_assertion;
+pub mod no_extra_semi;
 pub mod no_func_assign;
 pub mod no_inferrable_types;
 pub mod no_misused_new;
@@ -102,6 +103,7 @@ pub fn get_recommended_rules() -> Vec<Box<dyn LintRule>> {
     no_explicit_any::NoExplicitAny::new(),
     no_extra_boolean_cast::NoExtraBooleanCast::new(),
     no_extra_non_null_assertion::NoExtraNonNullAssertion::new(),
+    no_extra_semi::NoExtraSemi::new(),
     no_func_assign::NoFuncAssign::new(),
     no_misused_new::NoMisusedNew::new(),
     no_namespace::NoNamespace::new(),
@@ -164,6 +166,7 @@ pub fn get_all_rules() -> Vec<Box<dyn LintRule>> {
     no_explicit_any::NoExplicitAny::new(),
     no_extra_boolean_cast::NoExtraBooleanCast::new(),
     no_extra_non_null_assertion::NoExtraNonNullAssertion::new(),
+    no_extra_semi::NoExtraSemi::new(),
     no_func_assign::NoFuncAssign::new(),
     no_misused_new::NoMisusedNew::new(),
     no_namespace::NoNamespace::new(),

--- a/src/rules/no_extra_semi.rs
+++ b/src/rules/no_extra_semi.rs
@@ -1,0 +1,107 @@
+#![allow(unused, dead_code)]
+// Copyright 2020 the Deno authors. All rights reserved. MIT license.
+use super::Context;
+use super::LintRule;
+use swc_ecma_ast::{EmptyStmt, VarDecl};
+use swc_ecma_visit::Node;
+use swc_ecma_visit::Visit;
+
+pub struct NoExtraSemi;
+
+impl LintRule for NoExtraSemi {
+  fn new() -> Box<Self> {
+    Box::new(NoExtraSemi)
+  }
+
+  fn code(&self) -> &'static str {
+    "no-extra-semi"
+  }
+
+  fn lint_module(&self, context: Context, module: swc_ecma_ast::Module) {
+    let mut visitor = NoExtraSemiVisitor::new(context);
+    visitor.visit_module(&module, &module);
+  }
+}
+
+struct NoExtraSemiVisitor {
+  context: Context,
+}
+
+impl NoExtraSemiVisitor {
+  pub fn new(context: Context) -> Self {
+    Self { context }
+  }
+}
+
+impl Visit for NoExtraSemiVisitor {
+  fn visit_module(
+    &mut self,
+    module: &swc_ecma_ast::Module,
+    _parent: &dyn Node,
+  ) {
+    // TODO(magurotuna)
+    dbg!(module);
+  }
+
+  fn visit_empty_stmt(&mut self, empty_stmt: &EmptyStmt, _parent: &dyn Node) {
+    // TODO(magurotuna)
+    dbg!(empty_stmt);
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use crate::test_util::*;
+
+  #[test]
+  fn hogepiyo() {
+    // TODO(magurotuna)
+    assert_lint_err::<NoExtraSemi>("class A { ; }", 0);
+    panic!();
+  }
+
+  #[test]
+  fn no_extra_semi_valid() {
+    assert_lint_ok::<NoExtraSemi>("var x = 5;");
+    assert_lint_ok::<NoExtraSemi>("function foo(){}");
+    assert_lint_ok::<NoExtraSemi>("for(;;);");
+    assert_lint_ok::<NoExtraSemi>("while(0);");
+    assert_lint_ok::<NoExtraSemi>("do;while(0);");
+    assert_lint_ok::<NoExtraSemi>("for(a in b);");
+    assert_lint_ok::<NoExtraSemi>("for(a of b);");
+    assert_lint_ok::<NoExtraSemi>("if(true);");
+    assert_lint_ok::<NoExtraSemi>("if(true); else;");
+    assert_lint_ok::<NoExtraSemi>("foo: ;");
+    assert_lint_ok::<NoExtraSemi>("with(foo);");
+    assert_lint_ok::<NoExtraSemi>("class A { }");
+    assert_lint_ok::<NoExtraSemi>("var A = class { };");
+    assert_lint_ok::<NoExtraSemi>("class A { a() { this; } }");
+    assert_lint_ok::<NoExtraSemi>("var A = class { a() { this; } };");
+    assert_lint_ok::<NoExtraSemi>("class A { } a;");
+  }
+
+  #[test]
+  fn no_extra_semi_invalid() {
+    assert_lint_err::<NoExtraSemi>("var x = 5;;", 0);
+    assert_lint_err::<NoExtraSemi>("function foo(){};", 0);
+    assert_lint_err::<NoExtraSemi>("for(;;);;", 0);
+    assert_lint_err::<NoExtraSemi>("while(0);;", 0);
+    assert_lint_err::<NoExtraSemi>("do;while(0);;", 0);
+    assert_lint_err::<NoExtraSemi>("for(a in b);;", 0);
+    assert_lint_err::<NoExtraSemi>("for(a of b);;", 0);
+    assert_lint_err::<NoExtraSemi>("if(true);;", 0);
+    assert_lint_err::<NoExtraSemi>("if(true){} else;;", 0);
+    assert_lint_err::<NoExtraSemi>("if(true){;} else {;}", 0);
+    assert_lint_err::<NoExtraSemi>("foo:;;", 0);
+    assert_lint_err::<NoExtraSemi>("with(foo);;", 0);
+    assert_lint_err::<NoExtraSemi>("with(foo){;}", 0);
+    assert_lint_err::<NoExtraSemi>("class A { ; }", 0);
+    assert_lint_err::<NoExtraSemi>("class A { /*a*/; }", 0);
+    assert_lint_err::<NoExtraSemi>("class A { ; a() {} }", 0);
+    assert_lint_err::<NoExtraSemi>("class A { a() {}; }", 0);
+    assert_lint_err::<NoExtraSemi>("class A { a() {}; b() {} }", 0);
+    assert_lint_err::<NoExtraSemi>("class A {; a() {}; b() {}; }", 0);
+    assert_lint_err::<NoExtraSemi>("class A { a() {}; get b() {} }", 0);
+  }
+}

--- a/src/rules/no_extra_semi.rs
+++ b/src/rules/no_extra_semi.rs
@@ -1,8 +1,10 @@
-#![allow(unused, dead_code)]
 // Copyright 2020 the Deno authors. All rights reserved. MIT license.
 use super::Context;
 use super::LintRule;
-use swc_ecma_ast::{EmptyStmt, VarDecl};
+use swc_ecma_ast::{
+  DoWhileStmt, EmptyStmt, ForInStmt, ForOfStmt, ForStmt, IfStmt, LabeledStmt,
+  Stmt, WhileStmt, WithStmt,
+};
 use swc_ecma_visit::Node;
 use swc_ecma_visit::Visit;
 
@@ -34,18 +36,104 @@ impl NoExtraSemiVisitor {
 }
 
 impl Visit for NoExtraSemiVisitor {
-  fn visit_module(
-    &mut self,
-    module: &swc_ecma_ast::Module,
-    _parent: &dyn Node,
-  ) {
-    // TODO(magurotuna)
-    dbg!(module);
+  fn visit_empty_stmt(&mut self, empty_stmt: &EmptyStmt, _parent: &dyn Node) {
+    self.context.add_diagnostic(
+      empty_stmt.span,
+      "no-extra-semi",
+      "Unnecessary semicolon.",
+    );
   }
 
-  fn visit_empty_stmt(&mut self, empty_stmt: &EmptyStmt, _parent: &dyn Node) {
-    // TODO(magurotuna)
-    dbg!(empty_stmt);
+  fn visit_for_stmt(&mut self, for_stmt: &ForStmt, parent: &dyn Node) {
+    if matches!(&*for_stmt.body, Stmt::Empty(_)) {
+      if let Some(ref init) = for_stmt.init {
+        swc_ecma_visit::visit_var_decl_or_expr(self, init, parent);
+      }
+      if let Some(ref test) = for_stmt.test {
+        swc_ecma_visit::visit_expr(self, test, parent);
+      }
+      if let Some(ref update) = for_stmt.update {
+        swc_ecma_visit::visit_expr(self, update, parent);
+      }
+    } else {
+      swc_ecma_visit::visit_for_stmt(self, for_stmt, parent);
+    }
+  }
+
+  fn visit_while_stmt(&mut self, while_stmt: &WhileStmt, parent: &dyn Node) {
+    if matches!(&*while_stmt.body, Stmt::Empty(_)) {
+      swc_ecma_visit::visit_expr(self, &*while_stmt.test, parent);
+    } else {
+      swc_ecma_visit::visit_while_stmt(self, while_stmt, parent);
+    }
+  }
+
+  fn visit_do_while_stmt(
+    &mut self,
+    do_while_stmt: &DoWhileStmt,
+    parent: &dyn Node,
+  ) {
+    if matches!(&*do_while_stmt.body, Stmt::Empty(_)) {
+      swc_ecma_visit::visit_expr(self, &*do_while_stmt.test, parent);
+    } else {
+      swc_ecma_visit::visit_do_while_stmt(self, do_while_stmt, parent);
+    }
+  }
+
+  fn visit_with_stmt(&mut self, with_stmt: &WithStmt, parent: &dyn Node) {
+    if matches!(&*with_stmt.body, Stmt::Empty(_)) {
+      swc_ecma_visit::visit_expr(self, &*with_stmt.obj, parent);
+    } else {
+      swc_ecma_visit::visit_with_stmt(self, with_stmt, parent);
+    }
+  }
+
+  fn visit_for_of_stmt(&mut self, for_of_stmt: &ForOfStmt, parent: &dyn Node) {
+    if matches!(&*for_of_stmt.body, Stmt::Empty(_)) {
+      swc_ecma_visit::visit_var_decl_or_pat(self, &for_of_stmt.left, parent);
+      swc_ecma_visit::visit_expr(self, &*for_of_stmt.right, parent);
+    } else {
+      swc_ecma_visit::visit_for_of_stmt(self, for_of_stmt, parent);
+    }
+  }
+
+  fn visit_for_in_stmt(&mut self, for_in_stmt: &ForInStmt, parent: &dyn Node) {
+    if matches!(&*for_in_stmt.body, Stmt::Empty(_)) {
+      swc_ecma_visit::visit_var_decl_or_pat(self, &for_in_stmt.left, parent);
+      swc_ecma_visit::visit_expr(self, &*for_in_stmt.right, parent);
+    } else {
+      swc_ecma_visit::visit_for_in_stmt(self, for_in_stmt, parent);
+    }
+  }
+
+  fn visit_if_stmt(&mut self, if_stmt: &IfStmt, parent: &dyn Node) {
+    swc_ecma_visit::visit_expr(self, &*if_stmt.test, parent);
+    match &*if_stmt.cons {
+      Stmt::Empty(_) => {}
+      cons => {
+        swc_ecma_visit::visit_stmt(self, cons, parent);
+      }
+    }
+    match if_stmt.alt.as_ref().map(|alt| &**alt) {
+      None | Some(Stmt::Empty(_)) => {}
+      Some(alt) => {
+        swc_ecma_visit::visit_stmt(self, alt, parent);
+      }
+    }
+  }
+
+  fn visit_labeled_stmt(
+    &mut self,
+    labeled_stmt: &LabeledStmt,
+    parent: &dyn Node,
+  ) {
+    swc_ecma_visit::visit_ident(self, &labeled_stmt.label, parent);
+    match &*labeled_stmt.body {
+      Stmt::Empty(_) => {}
+      body => {
+        swc_ecma_visit::visit_stmt(self, body, parent);
+      }
+    }
   }
 }
 
@@ -53,13 +141,6 @@ impl Visit for NoExtraSemiVisitor {
 mod tests {
   use super::*;
   use crate::test_util::*;
-
-  #[test]
-  fn hogepiyo() {
-    // TODO(magurotuna)
-    assert_lint_err::<NoExtraSemi>("class A { ; }", 0);
-    panic!();
-  }
 
   #[test]
   fn no_extra_semi_valid() {
@@ -83,25 +164,28 @@ mod tests {
 
   #[test]
   fn no_extra_semi_invalid() {
-    assert_lint_err::<NoExtraSemi>("var x = 5;;", 0);
-    assert_lint_err::<NoExtraSemi>("function foo(){};", 0);
-    assert_lint_err::<NoExtraSemi>("for(;;);;", 0);
-    assert_lint_err::<NoExtraSemi>("while(0);;", 0);
-    assert_lint_err::<NoExtraSemi>("do;while(0);;", 0);
-    assert_lint_err::<NoExtraSemi>("for(a in b);;", 0);
-    assert_lint_err::<NoExtraSemi>("for(a of b);;", 0);
-    assert_lint_err::<NoExtraSemi>("if(true);;", 0);
-    assert_lint_err::<NoExtraSemi>("if(true){} else;;", 0);
-    assert_lint_err::<NoExtraSemi>("if(true){;} else {;}", 0);
-    assert_lint_err::<NoExtraSemi>("foo:;;", 0);
-    assert_lint_err::<NoExtraSemi>("with(foo);;", 0);
-    assert_lint_err::<NoExtraSemi>("with(foo){;}", 0);
-    assert_lint_err::<NoExtraSemi>("class A { ; }", 0);
-    assert_lint_err::<NoExtraSemi>("class A { /*a*/; }", 0);
-    assert_lint_err::<NoExtraSemi>("class A { ; a() {} }", 0);
-    assert_lint_err::<NoExtraSemi>("class A { a() {}; }", 0);
-    assert_lint_err::<NoExtraSemi>("class A { a() {}; b() {} }", 0);
-    assert_lint_err::<NoExtraSemi>("class A {; a() {}; b() {}; }", 0);
-    assert_lint_err::<NoExtraSemi>("class A { a() {}; get b() {} }", 0);
+    assert_lint_err::<NoExtraSemi>("var x = 5;;", 10);
+    assert_lint_err::<NoExtraSemi>("function foo(){};", 16);
+    assert_lint_err::<NoExtraSemi>("for(;;);;", 8);
+    assert_lint_err::<NoExtraSemi>("while(0);;", 9);
+    assert_lint_err::<NoExtraSemi>("do;while(0);;", 12);
+    assert_lint_err::<NoExtraSemi>("for(a in b);;", 12);
+    assert_lint_err::<NoExtraSemi>("for(a of b);;", 12);
+    assert_lint_err::<NoExtraSemi>("if(true);;", 9);
+    assert_lint_err::<NoExtraSemi>("if(true){} else;;", 16);
+    assert_lint_err_n::<NoExtraSemi>("if(true){;} else {;}", vec![9, 18]);
+    assert_lint_err::<NoExtraSemi>("foo:;;", 5);
+    assert_lint_err::<NoExtraSemi>("with(foo);;", 10);
+    assert_lint_err::<NoExtraSemi>("with(foo){;}", 10);
+    assert_lint_err::<NoExtraSemi>("class A { ; }", 10);
+    assert_lint_err::<NoExtraSemi>("class A { /*a*/; }", 15);
+    assert_lint_err::<NoExtraSemi>("class A { ; a() {} }", 10);
+    assert_lint_err::<NoExtraSemi>("class A { a() {}; }", 16);
+    assert_lint_err::<NoExtraSemi>("class A { a() {}; b() {} }", 16);
+    assert_lint_err_n::<NoExtraSemi>(
+      "class A {; a() {}; b() {}; }",
+      vec![9, 17, 25],
+    );
+    assert_lint_err::<NoExtraSemi>("class A { a() {}; get b() {} }", 16);
   }
 }

--- a/src/rules/no_extra_semi.rs
+++ b/src/rules/no_extra_semi.rs
@@ -114,7 +114,7 @@ impl Visit for NoExtraSemiVisitor {
         swc_ecma_visit::visit_stmt(self, cons, parent);
       }
     }
-    match if_stmt.alt.as_ref().map(|alt| &**alt) {
+    match if_stmt.alt.as_deref() {
       None | Some(Stmt::Empty(_)) => {}
       Some(alt) => {
         swc_ecma_visit::visit_stmt(self, alt, parent);

--- a/src/rules/no_extra_semi.rs
+++ b/src/rules/no_extra_semi.rs
@@ -154,6 +154,7 @@ mod tests {
     assert_lint_ok::<NoExtraSemi>("if(true);");
     assert_lint_ok::<NoExtraSemi>("if(true); else;");
     assert_lint_ok::<NoExtraSemi>("foo: ;");
+    assert_lint_ok::<NoExtraSemi>("foo: bar: ;");
     assert_lint_ok::<NoExtraSemi>("with(foo);");
     assert_lint_ok::<NoExtraSemi>("class A { }");
     assert_lint_ok::<NoExtraSemi>("var A = class { };");
@@ -187,5 +188,101 @@ mod tests {
       vec![9, 17, 25],
     );
     assert_lint_err::<NoExtraSemi>("class A { a() {}; get b() {} }", 16);
+
+    assert_lint_err_on_line::<NoExtraSemi>(
+      r#"
+for (let i = 0; i < n; i++) {
+  for (;;);;
+}
+"#,
+      3,
+      11,
+    );
+    assert_lint_err_on_line::<NoExtraSemi>(
+      r#"
+while (a) {
+  while (b);;
+}
+"#,
+      3,
+      12,
+    );
+    assert_lint_err_on_line::<NoExtraSemi>(
+      r#"
+do {
+  do {
+    ;
+  } while(a);
+} while(b);
+"#,
+      4,
+      4,
+    );
+    assert_lint_err_on_line::<NoExtraSemi>(
+      r#"
+with(a) {
+  with(b) {
+    ;
+  }
+}
+"#,
+      4,
+      4,
+    );
+    assert_lint_err_on_line::<NoExtraSemi>(
+      r#"
+for (const a of b) {
+  for (const c of d) {
+    ;
+  }
+}
+"#,
+      4,
+      4,
+    );
+    assert_lint_err_on_line::<NoExtraSemi>(
+      r#"
+for (const a in b) {
+  for (const c in d) {
+    ;
+  }
+}
+"#,
+      4,
+      4,
+    );
+    assert_lint_err_on_line::<NoExtraSemi>(
+      r#"
+if (a) {
+  if (b) {
+    ;
+  } else;
+}
+"#,
+      4,
+      4,
+    );
+    assert_lint_err_on_line::<NoExtraSemi>(
+      r#"
+foo: {
+  bar: {
+    ;
+  }
+}
+"#,
+      4,
+      4,
+    );
+    assert_lint_err_on_line::<NoExtraSemi>(
+      r#"
+class A {
+  foo() {
+    class B { ; }
+  }
+}
+"#,
+      4,
+      14,
+    );
   }
 }


### PR DESCRIPTION
~WORK IN PROGRESS~

~waiting for swc's patch to be completed.~

This PR adds the [`no-extra-semi`](https://eslint.org/docs/rules/no-extra-semi) rule.
Updating `swc` is required to parse empty statements in class properly.