### PR TITLE
chore(no-extra-non-null-assertion): add to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ See [`./benchmarks/`](./benchmarks/) directory for more info.*
 - [`no-ex-assign`](https://eslint.org/docs/rules/no-ex-assign)
 - [`no-explicit-any`](https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-explicit-any.md)
 - [`no-extra-boolean-cast`](https://eslint.org/docs/rules/no-extra-boolean-cast)
+- [`no-extra-non-null-assertion`](https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-extra-non-null-assertion.md)
 - [`no-func-assign`](https://eslint.org/docs/rules/no-func-assign)
 - [`no-inferrable-types`](https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-inferrable-types.md)
 - [`no-misused-new`](https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-misused-new.md)


### PR DESCRIPTION
I found `no-extra-non-null-assertion` was not mentioned in README. I've just added it.