### PR TITLE
adjacent-overload-signatures

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ See [`./benchmarks/`](./benchmarks/) directory for more info.*
 
 ## Supported rules
 
+- [`adjacent-overload-signatures`](https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/adjacent-overload-signatures.md)
 - [`ban-ts-comment`](https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/ban-ts-comment.md)
 - `ban-ts-ignore`
 - [`ban-types`](https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/ban-types.md)

--- a/src/rules/adjacent_overload_signatures.rs
+++ b/src/rules/adjacent_overload_signatures.rs
@@ -1,0 +1,138 @@
+// Copyright 2020 the Deno authors. All rights reserved. MIT license.
+use super::Context;
+use super::LintRule;
+use crate::swc_common::comments::Comment;
+use crate::swc_common::comments::CommentKind;
+use crate::swc_ecma_ast;
+
+pub struct AdjacentOverloadSignatures;
+
+impl AdjacentOverloadSignatures {
+  fn lint_comment(&self, context: &Context, comment: &Comment) {
+    if comment.kind != CommentKind::Line {
+      return;
+    }
+
+    lazy_static! {
+      static ref BTC_REGEX: regex::Regex =
+        regex::Regex::new(r#"^/*\s*@ts-(expect-error|ignore|nocheck)$"#)
+          .unwrap();
+    }
+
+    if BTC_REGEX.is_match(&comment.text) {
+      context.add_diagnostic(
+        comment.span,
+        "ban-ts-comment",
+        "ts directives are not allowed",
+      );
+    }
+  }
+}
+
+impl LintRule for AdjacentOverloadSignatures {
+  fn new() -> Box<Self> {
+    Box::new(AdjacentOverloadSignatures)
+  }
+
+  fn code(&self) -> &'static str {
+    "ban-ts-comment"
+  }
+
+  fn lint_module(&self, context: Context, _module: swc_ecma_ast::Module) {
+    context.leading_comments.iter().for_each(|ref_multi| {
+      for comment in ref_multi.value() {
+        self.lint_comment(&context, comment);
+      }
+    });
+    context.trailing_comments.iter().for_each(|ref_multi| {
+      for comment in ref_multi.value() {
+        self.lint_comment(&context, comment);
+      }
+    });
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use crate::test_util::*;
+
+  #[test]
+  fn ban_ts_comment_valid() {
+    assert_lint_ok_n::<AdjacentOverloadSignatures>(vec![
+      r#"// just a comment containing @ts-expect-error somewhere"#,
+      r#"/* @ts-expect-error */"#,
+      r#"/** @ts-expect-error */"#,
+      r#"/*
+// @ts-expect-error in a block
+*/
+"#,
+    ]);
+
+    assert_lint_ok_n::<AdjacentOverloadSignatures>(vec![
+      r#"// just a comment containing @ts-ignore somewhere"#,
+      r#"/* @ts-ignore */"#,
+      r#"/** @ts-ignore */"#,
+      r#"/*
+// @ts-ignore in a block
+*/
+"#,
+    ]);
+
+    assert_lint_ok_n::<AdjacentOverloadSignatures>(vec![
+      r#"// just a comment containing @ts-nocheck somewhere"#,
+      r#"/* @ts-nocheck */"#,
+      r#"/** @ts-nocheck */"#,
+      r#"/*
+// @ts-nocheck in a block
+*/
+"#,
+    ]);
+
+    assert_lint_ok_n::<AdjacentOverloadSignatures>(vec![
+      r#"// just a comment containing @ts-check somewhere"#,
+      r#"/* @ts-check */"#,
+      r#"/** @ts-check */"#,
+      r#"/*
+// @ts-check in a block
+*/
+"#,
+    ]);
+
+    assert_lint_ok::<AdjacentOverloadSignatures>(
+      r#"if (false) {
+// @ts-ignore: Unreachable code error
+console.log('hello');
+}"#,
+    );
+    assert_lint_ok::<AdjacentOverloadSignatures>(
+      r#"if (false) {
+// @ts-expect-error: Unreachable code error
+console.log('hello');
+}"#,
+    );
+    assert_lint_ok::<AdjacentOverloadSignatures>(
+      r#"if (false) {
+// @ts-nocheck: Unreachable code error
+console.log('hello');
+}"#,
+    );
+
+    assert_lint_ok::<AdjacentOverloadSignatures>(
+      r#"// @ts-expect-error: Suppress next line"#,
+    );
+    assert_lint_ok::<AdjacentOverloadSignatures>(
+      r#"// @ts-ignore: Suppress next line"#,
+    );
+    assert_lint_ok::<AdjacentOverloadSignatures>(
+      r#"// @ts-nocheck: Suppress next line"#,
+    );
+  }
+
+  #[test]
+  fn ban_ts_comment_invalid() {
+    assert_lint_err::<AdjacentOverloadSignatures>(r#"// @ts-expect-error"#, 0);
+    assert_lint_err::<AdjacentOverloadSignatures>(r#"// @ts-ignore"#, 0);
+    assert_lint_err::<AdjacentOverloadSignatures>(r#"// @ts-nocheck"#, 0);
+  }
+}

--- a/src/rules/adjacent_overload_signatures.rs
+++ b/src/rules/adjacent_overload_signatures.rs
@@ -94,7 +94,7 @@ impl ExtractMethod for ModuleItem {
       _ => None,
     };
 
-    method_name.map(|mn| Method::Method(mn))
+    method_name.map(Method::Method)
   }
 }
 

--- a/src/rules/adjacent_overload_signatures.rs
+++ b/src/rules/adjacent_overload_signatures.rs
@@ -58,81 +58,684 @@ mod tests {
   use crate::test_util::*;
 
   #[test]
-  fn ban_ts_comment_valid() {
-    assert_lint_ok_n::<AdjacentOverloadSignatures>(vec![
-      r#"// just a comment containing @ts-expect-error somewhere"#,
-      r#"/* @ts-expect-error */"#,
-      r#"/** @ts-expect-error */"#,
-      r#"/*
-// @ts-expect-error in a block
-*/
-"#,
-    ]);
-
-    assert_lint_ok_n::<AdjacentOverloadSignatures>(vec![
-      r#"// just a comment containing @ts-ignore somewhere"#,
-      r#"/* @ts-ignore */"#,
-      r#"/** @ts-ignore */"#,
-      r#"/*
-// @ts-ignore in a block
-*/
-"#,
-    ]);
-
-    assert_lint_ok_n::<AdjacentOverloadSignatures>(vec![
-      r#"// just a comment containing @ts-nocheck somewhere"#,
-      r#"/* @ts-nocheck */"#,
-      r#"/** @ts-nocheck */"#,
-      r#"/*
-// @ts-nocheck in a block
-*/
-"#,
-    ]);
-
-    assert_lint_ok_n::<AdjacentOverloadSignatures>(vec![
-      r#"// just a comment containing @ts-check somewhere"#,
-      r#"/* @ts-check */"#,
-      r#"/** @ts-check */"#,
-      r#"/*
-// @ts-check in a block
-*/
-"#,
-    ]);
-
+  fn adjacent_overload_signatures_valid() {
     assert_lint_ok::<AdjacentOverloadSignatures>(
-      r#"if (false) {
-// @ts-ignore: Unreachable code error
-console.log('hello');
-}"#,
+      r#"
+function error(a: string);
+function error(b: number);
+function error(ab: string | number) {}
+export { error };
+      "#,
     );
     assert_lint_ok::<AdjacentOverloadSignatures>(
-      r#"if (false) {
-// @ts-expect-error: Unreachable code error
-console.log('hello');
-}"#,
+      r#"
+import { connect } from 'react-redux';
+export interface ErrorMessageModel {
+  message: string;
+}
+function mapStateToProps() {}
+function mapDispatchToProps() {}
+export default connect(mapStateToProps, mapDispatchToProps)(ErrorMessage);
+      "#,
     );
     assert_lint_ok::<AdjacentOverloadSignatures>(
-      r#"if (false) {
-// @ts-nocheck: Unreachable code error
-console.log('hello');
-}"#,
-    );
-
-    assert_lint_ok::<AdjacentOverloadSignatures>(
-      r#"// @ts-expect-error: Suppress next line"#,
+      r#"
+export const foo = 'a',
+  bar = 'b';
+export interface Foo {}
+export class Foo {}
+    "#,
     );
     assert_lint_ok::<AdjacentOverloadSignatures>(
-      r#"// @ts-ignore: Suppress next line"#,
+      r#"
+export interface Foo {}
+export const foo = 'a',
+  bar = 'b';
+export class Foo {}
+    "#,
     );
     assert_lint_ok::<AdjacentOverloadSignatures>(
-      r#"// @ts-nocheck: Suppress next line"#,
+      r#"
+const foo = 'a',
+  bar = 'b';
+interface Foo {}
+class Foo {}
+    "#,
+    );
+    assert_lint_ok::<AdjacentOverloadSignatures>(
+      r#"
+interface Foo {}
+const foo = 'a',
+  bar = 'b';
+class Foo {}
+    "#,
+    );
+    assert_lint_ok::<AdjacentOverloadSignatures>(
+      r#"
+export class Foo {}
+export class Bar {}
+export type FooBar = Foo | Bar;
+    "#,
+    );
+    assert_lint_ok::<AdjacentOverloadSignatures>(
+      r#"
+export interface Foo {}
+export class Foo {}
+export class Bar {}
+export type FooBar = Foo | Bar;
+    "#,
+    );
+    assert_lint_ok::<AdjacentOverloadSignatures>(
+      r#"
+export function foo(s: string);
+export function foo(n: number);
+export function foo(sn: string | number) {}
+export function bar(): void {}
+export function baz(): void {}
+    "#,
+    );
+    assert_lint_ok::<AdjacentOverloadSignatures>(
+      r#"
+function foo(s: string);
+function foo(n: number);
+function foo(sn: string | number) {}
+function bar(): void {}
+function baz(): void {}
+    "#,
+    );
+    assert_lint_ok::<AdjacentOverloadSignatures>(
+      r#"
+declare function foo(s: string);
+declare function foo(n: number);
+declare function foo(sn: string | number);
+declare function bar(): void;
+declare function baz(): void;
+    "#,
+    );
+    assert_lint_ok::<AdjacentOverloadSignatures>(
+      r#"
+declare module 'Foo' {
+  export function foo(s: string): void;
+  export function foo(n: number): void;
+  export function foo(sn: string | number): void;
+  export function bar(): void;
+  export function baz(): void;
+}
+    "#,
+    );
+    assert_lint_ok::<AdjacentOverloadSignatures>(
+      r#"
+declare namespace Foo {
+  export function foo(s: string): void;
+  export function foo(n: number): void;
+  export function foo(sn: string | number): void;
+  export function bar(): void;
+  export function baz(): void;
+}
+    "#,
+    );
+    assert_lint_ok::<AdjacentOverloadSignatures>(
+      r#"
+type Foo = {
+  foo(s: string): void;
+  foo(n: number): void;
+  foo(sn: string | number): void;
+  bar(): void;
+  baz(): void;
+};
+    "#,
+    );
+    assert_lint_ok::<AdjacentOverloadSignatures>(
+      r#"
+type Foo = {
+  foo(s: string): void;
+  ['foo'](n: number): void;
+  foo(sn: string | number): void;
+  bar(): void;
+  baz(): void;
+};
+    "#,
+    );
+    assert_lint_ok::<AdjacentOverloadSignatures>(
+      r#"
+interface Foo {
+  (s: string): void;
+  (n: number): void;
+  (sn: string | number): void;
+  foo(n: number): void;
+  bar(): void;
+  baz(): void;
+}
+    "#,
+    );
+    assert_lint_ok::<AdjacentOverloadSignatures>(
+      r#"
+interface Foo {
+  foo(s: string): void;
+  foo(n: number): void;
+  foo(sn: string | number): void;
+  bar(): void;
+  baz(): void;
+}
+    "#,
+    );
+    assert_lint_ok::<AdjacentOverloadSignatures>(
+      r#"
+interface Foo {
+  foo(s: string): void;
+  ['foo'](n: number): void;
+  foo(sn: string | number): void;
+  bar(): void;
+  baz(): void;
+}
+    "#,
+    );
+    assert_lint_ok::<AdjacentOverloadSignatures>(
+      r#"
+interface Foo {
+  foo(): void;
+  bar: {
+    baz(s: string): void;
+    baz(n: number): void;
+    baz(sn: string | number): void;
+  };
+}
+    "#,
+    );
+    assert_lint_ok::<AdjacentOverloadSignatures>(
+      r#"
+interface Foo {
+  new (s: string);
+  new (n: number);
+  new (sn: string | number);
+  foo(): void;
+}
+    "#,
+    );
+    assert_lint_ok::<AdjacentOverloadSignatures>(
+      r#"
+class Foo {
+  constructor(s: string);
+  constructor(n: number);
+  constructor(sn: string | number) {}
+  bar(): void {}
+  baz(): void {}
+}
+    "#,
+    );
+    assert_lint_ok::<AdjacentOverloadSignatures>(
+      r#"
+class Foo {
+  foo(s: string): void;
+  foo(n: number): void;
+  foo(sn: string | number): void {}
+  bar(): void {}
+  baz(): void {}
+}
+    "#,
+    );
+    assert_lint_ok::<AdjacentOverloadSignatures>(
+      r#"
+class Foo {
+  foo(s: string): void;
+  ['foo'](n: number): void;
+  foo(sn: string | number): void {}
+  bar(): void {}
+  baz(): void {}
+}
+    "#,
+    );
+    assert_lint_ok::<AdjacentOverloadSignatures>(
+      r#"
+class Foo {
+  name: string;
+  foo(s: string): void;
+  foo(n: number): void;
+  foo(sn: string | number): void {}
+  bar(): void {}
+  baz(): void {}
+}
+    "#,
+    );
+    assert_lint_ok::<AdjacentOverloadSignatures>(
+      r#"
+class Foo {
+  name: string;
+  static foo(s: string): void;
+  static foo(n: number): void;
+  static foo(sn: string | number): void {}
+  bar(): void {}
+  baz(): void {}
+}
+    "#,
+    );
+    assert_lint_ok::<AdjacentOverloadSignatures>(
+      r#"
+class Test {
+  static test() {}
+  untest() {}
+  test() {}
+}
+    "#,
+    );
+    assert_lint_ok::<AdjacentOverloadSignatures>(
+      r#"export default function <T>(foo: T) {}"#,
+    );
+    assert_lint_ok::<AdjacentOverloadSignatures>(
+      r#"export default function named<T>(foo: T) {}"#,
+    );
+    assert_lint_ok::<AdjacentOverloadSignatures>(
+      r#"
+interface Foo {
+  [Symbol.toStringTag](): void;
+  [Symbol.iterator](): void;
+}
+    "#,
     );
   }
 
   #[test]
-  fn ban_ts_comment_invalid() {
-    assert_lint_err::<AdjacentOverloadSignatures>(r#"// @ts-expect-error"#, 0);
-    assert_lint_err::<AdjacentOverloadSignatures>(r#"// @ts-ignore"#, 0);
-    assert_lint_err::<AdjacentOverloadSignatures>(r#"// @ts-nocheck"#, 0);
+  fn adjacent_overload_signatures_invalid() {
+    assert_lint_err_on_line::<AdjacentOverloadSignatures>(
+      r#"
+export function foo(s: string);
+export function foo(n: number);
+export function bar(): void {}
+export function baz(): void {}
+export function foo(sn: string | number) {}
+      "#,
+      0,
+      0,
+    );
+    assert_lint_err_on_line::<AdjacentOverloadSignatures>(
+      r#"
+export function foo(s: string);
+export function foo(n: number);
+export type bar = number;
+export type baz = number | string;
+export function foo(sn: string | number) {}
+      "#,
+      0,
+      0,
+    );
+    assert_lint_err_on_line::<AdjacentOverloadSignatures>(
+      r#"
+function foo(s: string);
+function foo(n: number);
+function bar(): void {}
+function baz(): void {}
+function foo(sn: string | number) {}
+      "#,
+      0,
+      0,
+    );
+    assert_lint_err_on_line::<AdjacentOverloadSignatures>(
+      r#"
+function foo(s: string);
+function foo(n: number);
+type bar = number;
+type baz = number | string;
+function foo(sn: string | number) {}
+      "#,
+      0,
+      0,
+    );
+    assert_lint_err_on_line::<AdjacentOverloadSignatures>(
+      r#"
+function foo(s: string) {}
+function foo(n: number) {}
+const a = '';
+const b = '';
+function foo(sn: string | number) {}
+      "#,
+      0,
+      0,
+    );
+    assert_lint_err_on_line::<AdjacentOverloadSignatures>(
+      r#"
+function foo(s: string) {}
+function foo(n: number) {}
+class Bar {}
+function foo(sn: string | number) {}
+      "#,
+      0,
+      0,
+    );
+    assert_lint_err_on_line::<AdjacentOverloadSignatures>(
+      r#"
+function foo(s: string) {}
+function foo(n: number) {}
+function foo(sn: string | number) {}
+class Bar {
+  foo(s: string);
+  foo(n: number);
+  name: string;
+  foo(sn: string | number) {}
+}
+      "#,
+      0,
+      0,
+    );
+    assert_lint_err_on_line::<AdjacentOverloadSignatures>(
+      r#"
+declare function foo(s: string);
+declare function foo(n: number);
+declare function bar(): void;
+declare function baz(): void;
+declare function foo(sn: string | number);
+      "#,
+      0,
+      0,
+    );
+    assert_lint_err_on_line::<AdjacentOverloadSignatures>(
+      r#"
+declare function foo(s: string);
+declare function foo(n: number);
+const a = '';
+const b = '';
+declare function foo(sn: string | number);
+      "#,
+      0,
+      0,
+    );
+    assert_lint_err_on_line::<AdjacentOverloadSignatures>(
+      r#"
+declare module 'Foo' {
+  export function foo(s: string): void;
+  export function foo(n: number): void;
+  export function bar(): void;
+  export function baz(): void;
+  export function foo(sn: string | number): void;
+}
+      "#,
+      0,
+      0,
+    );
+    assert_lint_err_on_line::<AdjacentOverloadSignatures>(
+      r#"
+declare module 'Foo' {
+  export function foo(s: string): void;
+  export function foo(n: number): void;
+  export function foo(sn: string | number): void;
+  function baz(s: string): void;
+  export function bar(): void;
+  function baz(n: number): void;
+  function baz(sn: string | number): void;
+}
+      "#,
+      0,
+      0,
+    );
+    assert_lint_err_on_line::<AdjacentOverloadSignatures>(
+      r#"
+declare namespace Foo {
+  export function foo(s: string): void;
+  export function foo(n: number): void;
+  export function bar(): void;
+  export function baz(): void;
+  export function foo(sn: string | number): void;
+}
+      "#,
+      0,
+      0,
+    );
+    assert_lint_err_on_line::<AdjacentOverloadSignatures>(
+      r#"
+declare namespace Foo {
+  export function foo(s: string): void;
+  export function foo(n: number): void;
+  export function foo(sn: string | number): void;
+  function baz(s: string): void;
+  export function bar(): void;
+  function baz(n: number): void;
+  function baz(sn: string | number): void;
+}
+      "#,
+      0,
+      0,
+    );
+    assert_lint_err_on_line::<AdjacentOverloadSignatures>(
+      r#"
+type Foo = {
+  foo(s: string): void;
+  foo(n: number): void;
+  bar(): void;
+  baz(): void;
+  foo(sn: string | number): void;
+};
+      "#,
+      0,
+      0,
+    );
+    assert_lint_err_on_line::<AdjacentOverloadSignatures>(
+      r#"
+type Foo = {
+  foo(s: string): void;
+  ['foo'](n: number): void;
+  bar(): void;
+  baz(): void;
+  foo(sn: string | number): void;
+};
+      "#,
+      0,
+      0,
+    );
+    assert_lint_err_on_line::<AdjacentOverloadSignatures>(
+      r#"
+type Foo = {
+  foo(s: string): void;
+  name: string;
+  foo(n: number): void;
+  foo(sn: string | number): void;
+  bar(): void;
+  baz(): void;
+};
+      "#,
+      0,
+      0,
+    );
+    assert_lint_err_on_line::<AdjacentOverloadSignatures>(
+      r#"
+interface Foo {
+  (s: string): void;
+  foo(n: number): void;
+  (n: number): void;
+  (sn: string | number): void;
+  bar(): void;
+  baz(): void;
+}
+      "#,
+      0,
+      0,
+    );
+    assert_lint_err_on_line::<AdjacentOverloadSignatures>(
+      r#"
+interface Foo {
+  foo(s: string): void;
+  foo(n: number): void;
+  bar(): void;
+  baz(): void;
+  foo(sn: string | number): void;
+}
+      "#,
+      0,
+      0,
+    );
+    assert_lint_err_on_line::<AdjacentOverloadSignatures>(
+      r#"
+interface Foo {
+  foo(s: string): void;
+  ['foo'](n: number): void;
+  bar(): void;
+  baz(): void;
+  foo(sn: string | number): void;
+}
+      "#,
+      0,
+      0,
+    );
+    assert_lint_err_on_line::<AdjacentOverloadSignatures>(
+      r#"
+interface Foo {
+  foo(s: string): void;
+  'foo'(n: number): void;
+  bar(): void;
+  baz(): void;
+  foo(sn: string | number): void;
+}
+      "#,
+      0,
+      0,
+    );
+    assert_lint_err_on_line::<AdjacentOverloadSignatures>(
+      r#"
+interface Foo {
+  foo(s: string): void;
+  name: string;
+  foo(n: number): void;
+  foo(sn: string | number): void;
+  bar(): void;
+  baz(): void;
+}
+      "#,
+      0,
+      0,
+    );
+    assert_lint_err_on_line::<AdjacentOverloadSignatures>(
+      r#"
+interface Foo {
+  foo(): void;
+  bar: {
+    baz(s: string): void;
+    baz(n: number): void;
+    foo(): void;
+    baz(sn: string | number): void;
+  };
+}
+      "#,
+      0,
+      0,
+    );
+    assert_lint_err_on_line::<AdjacentOverloadSignatures>(
+      r#"
+interface Foo {
+  new (s: string);
+  new (n: number);
+  foo(): void;
+  bar(): void;
+  new (sn: string | number);
+}
+      "#,
+      0,
+      0,
+    );
+    assert_lint_err_on_line::<AdjacentOverloadSignatures>(
+      r#"
+interface Foo {
+  new (s: string);
+  foo(): void;
+  new (n: number);
+  bar(): void;
+  new (sn: string | number);
+}
+      "#,
+      0,
+      0,
+    );
+    assert_lint_err_on_line::<AdjacentOverloadSignatures>(
+      r#"
+class Foo {
+  constructor(s: string);
+  constructor(n: number);
+  bar(): void {}
+  baz(): void {}
+  constructor(sn: string | number) {}
+}
+      "#,
+      0,
+      0,
+    );
+    assert_lint_err_on_line::<AdjacentOverloadSignatures>(
+      r#"
+class Foo {
+  foo(s: string): void;
+  foo(n: number): void;
+  bar(): void {}
+  baz(): void {}
+  foo(sn: string | number): void {}
+}
+      "#,
+      0,
+      0,
+    );
+    assert_lint_err_on_line::<AdjacentOverloadSignatures>(
+      r#"
+class Foo {
+  foo(s: string): void;
+  ['foo'](n: number): void;
+  bar(): void {}
+  baz(): void {}
+  foo(sn: string | number): void {}
+}
+      "#,
+      0,
+      0,
+    );
+    assert_lint_err_on_line::<AdjacentOverloadSignatures>(
+      r#"
+class Foo {
+  // prettier-ignore
+  "foo"(s: string): void;
+  foo(n: number): void;
+  bar(): void {}
+  baz(): void {}
+  foo(sn: string | number): void {}
+}
+      "#,
+      0,
+      0,
+    );
+    assert_lint_err_on_line::<AdjacentOverloadSignatures>(
+      r#"
+class Foo {
+  constructor(s: string);
+  name: string;
+  constructor(n: number);
+  constructor(sn: string | number) {}
+  bar(): void {}
+  baz(): void {}
+}
+      "#,
+      0,
+      0,
+    );
+    assert_lint_err_on_line::<AdjacentOverloadSignatures>(
+      r#"
+class Foo {
+  foo(s: string): void;
+  name: string;
+  foo(n: number): void;
+  foo(sn: string | number): void {}
+  bar(): void {}
+  baz(): void {}
+}
+      "#,
+      0,
+      0,
+    );
+    assert_lint_err_on_line::<AdjacentOverloadSignatures>(
+      r#"
+class Foo {
+  static foo(s: string): void;
+  name: string;
+  static foo(n: number): void;
+  static foo(sn: string | number): void {}
+  bar(): void {}
+  baz(): void {}
+}
+      "#,
+      0,
+      0,
+    );
   }
 }

--- a/src/rules/mod.rs
+++ b/src/rules/mod.rs
@@ -3,6 +3,7 @@ use crate::linter::Context;
 use crate::swc_ecma_ast;
 use std::sync::Arc;
 
+pub mod adjacent_overload_signatures;
 pub mod ban_ts_comment;
 pub mod ban_ts_ignore;
 pub mod ban_types;
@@ -79,6 +80,7 @@ pub trait LintRule {
 
 pub fn get_recommended_rules() -> Vec<Box<dyn LintRule>> {
   vec![
+    adjacent_overload_signatures::AdjacentOverloadSignatures::new(),
     ban_ts_comment::BanTsComment::new(),
     ban_untagged_ignore::BanUntaggedIgnore::new(),
     ban_types::BanTypes::new(),
@@ -136,6 +138,7 @@ pub fn get_recommended_rules() -> Vec<Box<dyn LintRule>> {
 
 pub fn get_all_rules() -> Vec<Box<dyn LintRule>> {
   vec![
+    adjacent_overload_signatures::AdjacentOverloadSignatures::new(),
     ban_ts_comment::BanTsComment::new(),
     ban_ts_ignore::BanTsIgnore::new(),
     ban_types::BanTypes::new(),

--- a/src/rules/no_dupe_keys.rs
+++ b/src/rules/no_dupe_keys.rs
@@ -1,12 +1,8 @@
 // Copyright 2020 the Deno authors. All rights reserved. MIT license.
 use super::Context;
 use super::LintRule;
-use crate::swc_ecma_ast::Prop;
-use crate::swc_ecma_ast::Prop::*;
-use crate::swc_ecma_ast::PropName;
-use crate::swc_ecma_ast::PropName::*;
-use crate::swc_ecma_ast::PropOrSpread::{Prop as PropVariant, Spread};
-use crate::swc_ecma_ast::{Module, ObjectLit, PropOrSpread};
+use crate::swc_ecma_ast::{Module, ObjectLit};
+use crate::swc_util::Key;
 use std::collections::{BTreeSet, HashSet};
 use swc_ecma_visit::{Node, Visit};
 
@@ -60,43 +56,6 @@ impl Visit for NoDupeKeysVisitor {
         "no-dupe-keys",
         format!("Duplicate key '{}'", key).as_str(),
       );
-    }
-  }
-}
-
-trait Key {
-  fn get_key(&self) -> Option<String>;
-}
-
-impl Key for PropOrSpread {
-  fn get_key(&self) -> Option<String> {
-    match self {
-      PropVariant(p) => (&**p).get_key(),
-      Spread(_) => None,
-    }
-  }
-}
-
-impl Key for Prop {
-  fn get_key(&self) -> Option<String> {
-    match self {
-      KeyValue(key_value) => key_value.key.get_key(),
-      Getter(getter) => getter.key.get_key(),
-      Setter(setter) => setter.key.get_key(),
-      Method(method) => method.key.get_key(),
-      Shorthand(_) => None,
-      Assign(_) => None,
-    }
-  }
-}
-
-impl Key for PropName {
-  fn get_key(&self) -> Option<String> {
-    match self {
-      Ident(identifier) => Some(identifier.sym.to_string()),
-      Str(str) => Some(str.value.to_string()),
-      Num(num) => Some(num.to_string()),
-      Computed(_) => None,
     }
   }
 }

--- a/src/test_util.rs
+++ b/src/test_util.rs
@@ -67,6 +67,7 @@ pub fn assert_lint_err_on_line<T: LintRule + 'static>(
   let rule = T::new();
   let rule_code = rule.code();
   let diagnostics = lint(rule, source);
+  dbg!(&diagnostics);
   assert!(diagnostics.len() == 1);
   assert_diagnostic(&diagnostics[0], rule_code, line, col);
 }

--- a/src/test_util.rs
+++ b/src/test_util.rs
@@ -67,7 +67,6 @@ pub fn assert_lint_err_on_line<T: LintRule + 'static>(
   let rule = T::new();
   let rule_code = rule.code();
   let diagnostics = lint(rule, source);
-  dbg!(&diagnostics);
   assert!(diagnostics.len() == 1);
   assert_diagnostic(&diagnostics[0], rule_code, line, col);
 }


### PR DESCRIPTION
~~WORK IN PROGRESS~~

This PR adds the [`adjacent-overload-signatures`](https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/adjacent-overload-signatures.md) rule.