### PR TITLE
chore: add debug logging with basic timers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -194,7 +194,9 @@ version = "0.1.16"
 dependencies = [
  "clap",
  "dprint-plugin-typescript",
+ "env_logger",
  "lazy_static",
+ "log",
  "regex",
  "swc_atoms",
  "swc_ecma_visit",
@@ -240,6 +242,19 @@ dependencies = [
  "proc-macro2",
  "swc_macros_common",
  "syn",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44533bbbb3bb3c1fa17d9f2e4e38bbbaf8396ba82193c4cb1b6445d711445d36"
+dependencies = [
+ "atty",
+ "humantime",
+ "log",
+ "regex",
+ "termcolor",
 ]
 
 [[package]]
@@ -293,6 +308,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3deed196b6e7f9e44a2ae8d94225d80302d81208b1bb673fd21fe634645c85a9"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "humantime"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df004cfca50ef23c36850aaaa59ad52cc70d0e90243c3c7737a4dd32dc7a3c4f"
+dependencies = [
+ "quick-error",
 ]
 
 [[package]]
@@ -520,6 +544,12 @@ checksum = "beae6331a816b1f65d04c45b078fd8e6c93e8071771f41b8163255bbd8d7c8fa"
 dependencies = [
  "unicode-xid",
 ]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,10 +18,12 @@ name = "dlint"
 [dependencies]
 dprint-plugin-typescript = { version = "=0.19.8" }
 lazy_static = "1.4.0"
+log = "0.4.8"
 swc_atoms = "0.2.2"
 swc_ecma_visit = { version = "=0.8.0" }
 regex = "1.3.6"
 
 [dev-dependencies]
 clap = { version = "2.33.1" }
+env_logger = "0.7.1"
 termcolor = "1.1.0"

--- a/examples/dlint/main.rs
+++ b/examples/dlint/main.rs
@@ -5,7 +5,6 @@ use deno_lint::diagnostic::LintDiagnostic;
 use deno_lint::linter::LinterBuilder;
 use deno_lint::rules::get_recommended_rules;
 use deno_lint::swc_util::get_default_ts_config;
-use env_logger;
 use std::fmt;
 use std::io::Write;
 use termcolor::Color::{Ansi256, Red};

--- a/examples/dlint/main.rs
+++ b/examples/dlint/main.rs
@@ -5,6 +5,7 @@ use deno_lint::diagnostic::LintDiagnostic;
 use deno_lint::linter::LinterBuilder;
 use deno_lint::rules::get_recommended_rules;
 use deno_lint::swc_util::get_default_ts_config;
+use env_logger;
 use std::fmt;
 use std::io::Write;
 use termcolor::Color::{Ansi256, Red};
@@ -107,6 +108,8 @@ pub fn format_diagnostic(diagnostic: &LintDiagnostic) -> String {
 fn main() {
   #[cfg(windows)]
   enable_ansi();
+
+  env_logger::init();
 
   let rules = get_recommended_rules();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,9 @@
 #[macro_use]
 extern crate lazy_static;
 
+#[macro_use]
+extern crate log;
+
 pub mod diagnostic;
 pub mod linter;
 pub mod rules;


### PR DESCRIPTION
Closes https://github.com/denoland/deno_lint/issues/225

Adds basic logging using `log` crate taking measurements for critical methods.

Output can be tested in example by using `RUST_LOG=debug target/debug/examples/dlint <files>`