### PR TITLE
Add EditorConfig file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,24 @@
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+charset = utf-8
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 2
+max_line_length = 80
+
+[*.toml]
+indent_size = 4
+
+[*.md]
+max_line_length = unset
+
+[*.{lock,out}] # make editor neutral to .out and .lock files
+end_of_line = unset
+insert_final_newline = unset
+trim_trailing_whitespace = unset
+indent_style = unset
+indent_size = unset
+max_line_length = unset


### PR DESCRIPTION
Fixes #233 
This is based upon the [`.editorconfig`](https://github.com/denoland/deno/blob/master/.editorconfig) of the Deno repo, extended to also ignore the `Cargo.lock` file and use 4 spaces in `.toml` files, as is currently done in `Cargo.toml`.