### PR TITLE
feat: add explicit-module-boundary-types

### DIFF
--- a/src/rules/explicit_module_boundary_types.rs
+++ b/src/rules/explicit_module_boundary_types.rs
@@ -1,14 +1,15 @@
 // Copyright 2020 the Deno authors. All rights reserved. MIT license.
 use super::Context;
 use super::LintRule;
-use crate::swc_ecma_ast;
 use crate::swc_common::Span;
+use crate::swc_ecma_ast;
 use crate::swc_ecma_visit::Node;
 use crate::swc_ecma_visit::Visit;
 
 use std::sync::Arc;
 use swc_ecma_ast::{
-  ClassDecl, ClassExpr, Decl, DefaultDecl, Module, ModuleDecl, Function, Expr, VarDecl, ArrowExpr, Pat, TsTypeAnn, TsType, TsKeywordTypeKind,
+  ArrowExpr, ClassDecl, ClassExpr, Decl, DefaultDecl, Expr, Function, Module,
+  ModuleDecl, Pat, TsKeywordTypeKind, TsType, TsTypeAnn, VarDecl,
 };
 
 pub struct ExplicitModuleBoundaryTypes;
@@ -89,12 +90,12 @@ impl ExplicitModuleBoundaryTypesVisitor {
 
   fn check_pat(&self, pat: &Pat) {
     match pat {
-        Pat::Ident(ident) => self.check_ann(&ident.type_ann, ident.span),
-        Pat::Array(array) => self.check_ann(&array.type_ann, array.span),
-        Pat::Rest(rest) => self.check_ann(&rest.type_ann, rest.span),
-        Pat::Object(object) => self.check_ann(&object.type_ann, object.span),
-        Pat::Assign(assign) => self.check_ann(&assign.type_ann, assign.span),
-        _ => {}
+      Pat::Ident(ident) => self.check_ann(&ident.type_ann, ident.span),
+      Pat::Array(array) => self.check_ann(&array.type_ann, array.span),
+      Pat::Rest(rest) => self.check_ann(&rest.type_ann, rest.span),
+      Pat::Object(object) => self.check_ann(&object.type_ann, object.span),
+      Pat::Assign(assign) => self.check_ann(&assign.type_ann, assign.span),
+      _ => {}
     };
   }
 

--- a/src/rules/explicit_module_boundary_types.rs
+++ b/src/rules/explicit_module_boundary_types.rs
@@ -1,0 +1,179 @@
+// Copyright 2020 the Deno authors. All rights reserved. MIT license.
+use super::Context;
+use super::LintRule;
+use crate::swc_ecma_ast;
+use crate::swc_common::Span;
+use crate::swc_ecma_visit::Node;
+use crate::swc_ecma_visit::Visit;
+
+use std::sync::Arc;
+use swc_ecma_ast::{
+  ClassDecl, ClassExpr, Decl, DefaultDecl, Module, ModuleDecl, Function, Expr, VarDecl, ArrowExpr, Pat, TsTypeAnn, TsType, TsKeywordTypeKind,
+};
+
+pub struct ExplicitModuleBoundaryTypes;
+
+impl LintRule for ExplicitModuleBoundaryTypes {
+  fn new() -> Box<Self> {
+    Box::new(ExplicitModuleBoundaryTypes)
+  }
+
+  fn code(&self) -> &'static str {
+    "explicit-module-boundary-types"
+  }
+
+  fn lint_module(&self, context: Arc<Context>, module: &Module) {
+    let mut visitor = ExplicitModuleBoundaryTypesVisitor::new(context);
+    visitor.visit_module(module, module);
+  }
+}
+
+struct ExplicitModuleBoundaryTypesVisitor {
+  context: Arc<Context>,
+}
+
+impl ExplicitModuleBoundaryTypesVisitor {
+  pub fn new(context: Arc<Context>) -> Self {
+    Self { context }
+  }
+  fn check_class_decl(&self, _span: Span, _decl: &ClassDecl) {}
+
+  fn check_class_expr(&self, _expr: &ClassExpr) {}
+
+  fn check_fn(&self, function: &Function) {
+    if function.return_type.is_none() {
+      self.context.add_diagnostic(
+        function.span,
+        "explicit-module-boundary-types",
+        "Missing return type on function",
+      );
+    }
+    for param in &function.params {
+      self.check_pat(&param.pat);
+    }
+  }
+
+  fn check_arrow(&self, arrow: &ArrowExpr) {
+    if arrow.return_type.is_none() {
+      self.context.add_diagnostic(
+        arrow.span,
+        "explicit-module-boundary-types",
+        "Missing return type on function",
+      );
+    }
+    for pat in &arrow.params {
+      self.check_pat(&pat);
+    }
+  }
+
+  fn check_ann(&self, ann: &Option<TsTypeAnn>, span: Span) {
+    if let Some(ann) = ann {
+      let ts_type = ann.type_ann.as_ref();
+      if let TsType::TsKeywordType(keyword_type) = ts_type {
+        if TsKeywordTypeKind::TsAnyKeyword == keyword_type.kind {
+          self.context.add_diagnostic(
+            span,
+            "explicit-module-boundary-types",
+            "All arguments should be typed",
+          );
+        }
+      }
+    } else {
+      self.context.add_diagnostic(
+        span,
+        "explicit-module-boundary-types",
+        "All arguments should be typed",
+      );
+    }
+  }
+
+  fn check_pat(&self, pat: &Pat) {
+    match pat {
+        Pat::Ident(ident) => self.check_ann(&ident.type_ann, ident.span),
+        Pat::Array(array) => self.check_ann(&array.type_ann, array.span),
+        Pat::Rest(rest) => self.check_ann(&rest.type_ann, rest.span),
+        Pat::Object(object) => self.check_ann(&object.type_ann, object.span),
+        Pat::Assign(assign) => self.check_ann(&assign.type_ann, assign.span),
+        _ => {}
+    };
+  }
+
+  fn check_var_decl(&self, var: &VarDecl) {
+    for declarator in &var.decls {
+      if let Some(expr) = &declarator.init {
+        if let Expr::Arrow(arrow) = expr.as_ref() {
+          self.check_arrow(arrow);
+        }
+      }
+    }
+  }
+}
+
+impl Visit for ExplicitModuleBoundaryTypesVisitor {
+  fn visit_module_decl(
+    &mut self,
+    module_decl: &ModuleDecl,
+    _parent: &dyn Node,
+  ) {
+    println!("{:#?}\n\n", module_decl);
+    match module_decl {
+      ModuleDecl::ExportDecl(export) => match &export.decl {
+        Decl::Class(decl) => self.check_class_decl(export.span, decl),
+        Decl::Fn(decl) => self.check_fn(&decl.function),
+        Decl::Var(var) => self.check_var_decl(var),
+        _ => {}
+      },
+      ModuleDecl::ExportDefaultDecl(export) => match &export.decl {
+        DefaultDecl::Class(expr) => self.check_class_expr(expr),
+        DefaultDecl::Fn(expr) => self.check_fn(&expr.function),
+        _ => {}
+      },
+      _ => {}
+    }
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use crate::test_util::*;
+
+  #[test]
+  fn explicit_module_boundary_types_valid() {
+    assert_lint_ok_n::<ExplicitModuleBoundaryTypes>(vec![
+      "function test() { return }",
+      "export var fn = function (): number { return 1; }",
+      "export var arrowFn = (arg: string): string => `test ${arg}`",
+      "export var arrowFn = (arg: unknown): string => `test ${arg}`",
+      // "class Test { method() { return; } }",
+    ]);
+  }
+
+  #[test]
+  fn explicit_module_boundary_types_invalid() {
+    assert_lint_err::<ExplicitModuleBoundaryTypes>(
+      "export function test() { return; }",
+      7,
+    );
+    assert_lint_err::<ExplicitModuleBoundaryTypes>(
+      "export default function () { return 1; }",
+      15,
+    );
+    assert_lint_err::<ExplicitModuleBoundaryTypes>(
+      "export var arrowFn = () => 'test';",
+      21,
+    );
+    assert_lint_err::<ExplicitModuleBoundaryTypes>(
+      "export var arrowFn = (arg): string => `test ${arg}`;",
+      22,
+    );
+    assert_lint_err::<ExplicitModuleBoundaryTypes>(
+      "export var arrowFn = (arg: any): string => `test ${arg}`;",
+      22,
+    );
+    // assert_lint_err::<ExplicitModuleBoundaryTypes>(
+    //   "export class Test { method() { return; } }",
+    //   0,
+    // );
+  }
+}

--- a/src/rules/mod.rs
+++ b/src/rules/mod.rs
@@ -13,6 +13,7 @@ pub mod constructor_super;
 pub mod default_param_last;
 pub mod eqeqeq;
 pub mod explicit_function_return_type;
+pub mod explicit_module_boundary_types;
 pub mod for_direction;
 pub mod getter_return;
 pub mod no_array_constructor;
@@ -152,6 +153,7 @@ pub fn get_all_rules() -> Vec<Box<dyn LintRule>> {
     default_param_last::DefaultParamLast::new(),
     eqeqeq::Eqeqeq::new(),
     explicit_function_return_type::ExplicitFunctionReturnType::new(),
+    explicit_module_boundary_types::ExplicitModuleBoundaryTypes::new(),
     for_direction::ForDirection::new(),
     getter_return::GetterReturn::new(),
     no_array_constructor::NoArrayConstructor::new(),


### PR DESCRIPTION
[Specification](https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/explicit-module-boundary-types.md)

What is currently working:
- [x] functions
- [x] arrows
- [x] methods