### PR TITLE
chore: remove unnecessary allocation

### DIFF
--- a/src/linter.rs
+++ b/src/linter.rs
@@ -248,8 +248,12 @@ impl Linter {
     comments.with_leading(module.span.lo(), |module_leading_comments| {
       for comment in module_leading_comments.iter() {
         if comment.kind == CommentKind::Line {
-          let text = comment.text.trim().to_string();
-          if self.ignore_file_directives.contains(&text) {
+          let text = comment.text.trim();
+          if self
+            .ignore_file_directives
+            .iter()
+            .any(|directive| directive == text)
+          {
             return true;
           }
         }


### PR DESCRIPTION
This is a so trivial patch; unnecessary string allocation has been removed.

With regard to replacing `contains()` with `iter().any()`, I referred to [the std library document](https://doc.rust-lang.org/std/primitive.slice.html#method.contains) .

> If you do not have an `&T`, but just an `&U` such that `T: Borrow<U>` (e.g. `String: Borrow<str>`), you can use `iter().any`
