### PR TITLE
Chore: fix and unify visibility

### DIFF
--- a/examples/dlint/main.rs
+++ b/examples/dlint/main.rs
@@ -4,7 +4,6 @@ use clap::Arg;
 use deno_lint::diagnostic::LintDiagnostic;
 use deno_lint::linter::LinterBuilder;
 use deno_lint::rules::get_recommended_rules;
-use deno_lint::swc_util::get_default_ts_config;
 use std::fmt;
 use std::io::Write;
 use termcolor::Color::{Ansi256, Red};
@@ -134,7 +133,6 @@ fn main() {
 
     let mut linter = LinterBuilder::default()
       .rules(get_recommended_rules())
-      .syntax(get_default_ts_config())
       .build();
 
     let file_diagnostics = linter

--- a/src/control_flow/mod.rs
+++ b/src/control_flow/mod.rs
@@ -9,12 +9,12 @@ use swc_ecmascript::{
   visit::{noop_visit_type, Node, Visit, VisitWith},
 };
 
-pub(crate) struct ControlFlow {
+pub struct ControlFlow {
   meta: HashMap<BytePos, Metadata>,
 }
 
 impl ControlFlow {
-  pub(crate) fn analyze(m: &Module) -> Self {
+  pub fn analyze(m: &Module) -> Self {
     let mut v = Analyzer {
       scope: Scope::new(None, BlockKind::Function),
       info: Default::default(),
@@ -27,14 +27,14 @@ impl ControlFlow {
   ///
   /// - All statements (including stmt.span())
   /// - [SwitchCase]
-  pub(crate) fn meta(&self, lo: BytePos) -> Option<&Metadata> {
+  pub fn meta(&self, lo: BytePos) -> Option<&Metadata> {
     self.meta.get(&lo)
   }
 }
 
 /// Kind of a basic block.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) enum BlockKind {
+pub enum BlockKind {
   /// Function's body
   Function,
   Block,
@@ -47,14 +47,14 @@ pub(crate) enum BlockKind {
 }
 
 #[derive(Debug, Default, Clone)]
-pub(crate) struct Metadata {
-  pub(crate) unreachable: bool,
+pub struct Metadata {
+  pub unreachable: bool,
   done: Option<Done>,
   // path: Vec<BlockKind>,
 }
 
 impl Metadata {
-  // pub(crate) fn path(&self) -> &[BlockKind] {
+  // pub fn path(&self) -> &[BlockKind] {
   //   &self.path
   // }
 }
@@ -95,7 +95,7 @@ enum Done {
 }
 
 impl<'a> Scope<'a> {
-  pub(crate) fn new(parent: Option<&'a Scope<'a>>, kind: BlockKind) -> Self {
+  pub fn new(parent: Option<&'a Scope<'a>>, kind: BlockKind) -> Self {
     Self {
       _parent: parent,
       _kind: kind,

--- a/src/control_flow/mod.rs
+++ b/src/control_flow/mod.rs
@@ -9,12 +9,12 @@ use swc_ecmascript::{
   visit::{noop_visit_type, Node, Visit, VisitWith},
 };
 
-pub struct ControlFlow {
+pub(crate) struct ControlFlow {
   meta: HashMap<BytePos, Metadata>,
 }
 
 impl ControlFlow {
-  pub fn analyze(m: &Module) -> Self {
+  pub(crate) fn analyze(m: &Module) -> Self {
     let mut v = Analyzer {
       scope: Scope::new(None, BlockKind::Function),
       info: Default::default(),
@@ -27,14 +27,14 @@ impl ControlFlow {
   ///
   /// - All statements (including stmt.span())
   /// - [SwitchCase]
-  pub fn meta(&self, lo: BytePos) -> Option<&Metadata> {
+  pub(crate) fn meta(&self, lo: BytePos) -> Option<&Metadata> {
     self.meta.get(&lo)
   }
 }
 
 /// Kind of a basic block.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub enum BlockKind {
+pub(crate) enum BlockKind {
   /// Function's body
   Function,
   Block,
@@ -47,14 +47,14 @@ pub enum BlockKind {
 }
 
 #[derive(Debug, Default, Clone)]
-pub struct Metadata {
-  pub unreachable: bool,
+pub(crate) struct Metadata {
+  pub(crate) unreachable: bool,
   done: Option<Done>,
   // path: Vec<BlockKind>,
 }
 
 impl Metadata {
-  // pub fn path(&self) -> &[BlockKind] {
+  // pub(crate) fn path(&self) -> &[BlockKind] {
   //   &self.path
   // }
 }
@@ -95,7 +95,7 @@ enum Done {
 }
 
 impl<'a> Scope<'a> {
-  pub fn new(parent: Option<&'a Scope<'a>>, kind: BlockKind) -> Self {
+  pub(crate) fn new(parent: Option<&'a Scope<'a>>, kind: BlockKind) -> Self {
     Self {
       _parent: parent,
       _kind: kind,

--- a/src/js_regex/mod.rs
+++ b/src/js_regex/mod.rs
@@ -4,7 +4,7 @@ mod reader;
 mod unicode;
 mod validator;
 
-pub(crate) use validator::{EcmaRegexValidator, EcmaVersion};
+pub use validator::{EcmaRegexValidator, EcmaVersion};
 
 #[cfg(test)]
 mod tests {

--- a/src/js_regex/mod.rs
+++ b/src/js_regex/mod.rs
@@ -4,7 +4,7 @@ mod reader;
 mod unicode;
 mod validator;
 
-pub use validator::{EcmaRegexValidator, EcmaVersion};
+pub(crate) use validator::{EcmaRegexValidator, EcmaVersion};
 
 #[cfg(test)]
 mod tests {

--- a/src/js_regex/reader.rs
+++ b/src/js_regex/reader.rs
@@ -3,7 +3,7 @@
 use std::collections::VecDeque;
 
 #[derive(Debug, Default)]
-pub(crate) struct Reader {
+pub struct Reader {
   unicode: bool,
   src: String,
   index: usize,
@@ -12,7 +12,7 @@ pub(crate) struct Reader {
 }
 
 impl Reader {
-  pub(crate) fn new() -> Self {
+  pub fn new() -> Self {
     Self {
       unicode: false,
       src: "".to_owned(),
@@ -22,20 +22,19 @@ impl Reader {
     }
   }
 
-  #[allow(dead_code)]
-  pub(crate) fn source(&self) -> &str {
+  pub fn source(&self) -> &str {
     &self.src
   }
 
-  pub(crate) fn index(&self) -> usize {
+  pub fn index(&self) -> usize {
     self.index
   }
 
-  pub(crate) fn code_point_with_offset(&self, offset: usize) -> Option<char> {
+  pub fn code_point_with_offset(&self, offset: usize) -> Option<char> {
     self.cps.get(offset).cloned()
   }
 
-  pub(crate) fn reset(
+  pub fn reset(
     &mut self,
     source: &str,
     start: usize,
@@ -61,7 +60,7 @@ impl Reader {
     }
   }
 
-  pub(crate) fn advance(&mut self) {
+  pub fn advance(&mut self) {
     if self.cps.get(0).is_some() {
       self.index += 1;
       self.cps.pop_front();
@@ -71,7 +70,7 @@ impl Reader {
     }
   }
 
-  pub(crate) fn eat(&mut self, cp: char) -> bool {
+  pub fn eat(&mut self, cp: char) -> bool {
     let opt = self.cps.get(0);
     if opt.is_some() && *opt.unwrap() == cp {
       self.advance();
@@ -81,7 +80,7 @@ impl Reader {
     }
   }
 
-  pub(crate) fn eat2(&mut self, cp1: char, cp2: char) -> bool {
+  pub fn eat2(&mut self, cp1: char, cp2: char) -> bool {
     let (opt1, opt2) = (self.cps.get(0), self.cps.get(1));
     if opt1.is_some()
       && opt2.is_some()
@@ -96,7 +95,7 @@ impl Reader {
     }
   }
 
-  pub(crate) fn eat3(&mut self, cp1: char, cp2: char, cp3: char) -> bool {
+  pub fn eat3(&mut self, cp1: char, cp2: char, cp3: char) -> bool {
     let (opt1, opt2, opt3) =
       (self.cps.get(0), self.cps.get(1), self.cps.get(2));
     if opt1.is_some()

--- a/src/js_regex/reader.rs
+++ b/src/js_regex/reader.rs
@@ -22,6 +22,7 @@ impl Reader {
     }
   }
 
+  #[allow(dead_code)]
   pub fn source(&self) -> &str {
     &self.src
   }

--- a/src/js_regex/reader.rs
+++ b/src/js_regex/reader.rs
@@ -3,7 +3,7 @@
 use std::collections::VecDeque;
 
 #[derive(Debug, Default)]
-pub struct Reader {
+pub(crate) struct Reader {
   unicode: bool,
   src: String,
   index: usize,
@@ -12,7 +12,7 @@ pub struct Reader {
 }
 
 impl Reader {
-  pub fn new() -> Self {
+  pub(crate) fn new() -> Self {
     Self {
       unicode: false,
       src: "".to_owned(),
@@ -22,19 +22,20 @@ impl Reader {
     }
   }
 
-  pub fn source(&self) -> &str {
+  #[allow(dead_code)]
+  pub(crate) fn source(&self) -> &str {
     &self.src
   }
 
-  pub fn index(&self) -> usize {
+  pub(crate) fn index(&self) -> usize {
     self.index
   }
 
-  pub fn code_point_with_offset(&self, offset: usize) -> Option<char> {
+  pub(crate) fn code_point_with_offset(&self, offset: usize) -> Option<char> {
     self.cps.get(offset).cloned()
   }
 
-  pub fn reset(
+  pub(crate) fn reset(
     &mut self,
     source: &str,
     start: usize,
@@ -60,7 +61,7 @@ impl Reader {
     }
   }
 
-  pub fn advance(&mut self) {
+  pub(crate) fn advance(&mut self) {
     if self.cps.get(0).is_some() {
       self.index += 1;
       self.cps.pop_front();
@@ -70,7 +71,7 @@ impl Reader {
     }
   }
 
-  pub fn eat(&mut self, cp: char) -> bool {
+  pub(crate) fn eat(&mut self, cp: char) -> bool {
     let opt = self.cps.get(0);
     if opt.is_some() && *opt.unwrap() == cp {
       self.advance();
@@ -80,7 +81,7 @@ impl Reader {
     }
   }
 
-  pub fn eat2(&mut self, cp1: char, cp2: char) -> bool {
+  pub(crate) fn eat2(&mut self, cp1: char, cp2: char) -> bool {
     let (opt1, opt2) = (self.cps.get(0), self.cps.get(1));
     if opt1.is_some()
       && opt2.is_some()
@@ -95,7 +96,7 @@ impl Reader {
     }
   }
 
-  pub fn eat3(&mut self, cp1: char, cp2: char, cp3: char) -> bool {
+  pub(crate) fn eat3(&mut self, cp1: char, cp2: char, cp3: char) -> bool {
     let (opt1, opt2, opt3) =
       (self.cps.get(0), self.cps.get(1), self.cps.get(2));
     if opt1.is_some()

--- a/src/js_regex/unicode.rs
+++ b/src/js_regex/unicode.rs
@@ -537,7 +537,7 @@ lazy_static! {
     );
 }
 
-pub(crate) fn is_valid_unicode_property(
+pub fn is_valid_unicode_property(
   version: EcmaVersion,
   name: &str,
   value: &str,
@@ -558,7 +558,7 @@ pub(crate) fn is_valid_unicode_property(
   }
 }
 
-pub(crate) fn is_valid_lone_unicode_property(
+pub fn is_valid_lone_unicode_property(
   version: EcmaVersion,
   value: &str,
 ) -> bool {
@@ -568,11 +568,11 @@ pub(crate) fn is_valid_lone_unicode_property(
       && BIN_PROPERTY_PATTERNS.es2019.contains(value))
 }
 
-pub(crate) fn is_large_id_start(cp: char) -> bool {
+pub fn is_large_id_start(cp: char) -> bool {
   is_in_range(cp as u32, &LARGE_ID_START_RANGES)
 }
 
-pub(crate) fn is_large_id_continue(cp: char) -> bool {
+pub fn is_large_id_continue(cp: char) -> bool {
   is_in_range(cp as u32, &LARGE_ID_CONTINUE_RANGES)
 }
 

--- a/src/js_regex/unicode.rs
+++ b/src/js_regex/unicode.rs
@@ -537,7 +537,7 @@ lazy_static! {
     );
 }
 
-pub fn is_valid_unicode_property(
+pub(crate) fn is_valid_unicode_property(
   version: EcmaVersion,
   name: &str,
   value: &str,
@@ -558,7 +558,7 @@ pub fn is_valid_unicode_property(
   }
 }
 
-pub fn is_valid_lone_unicode_property(
+pub(crate) fn is_valid_lone_unicode_property(
   version: EcmaVersion,
   value: &str,
 ) -> bool {
@@ -568,11 +568,11 @@ pub fn is_valid_lone_unicode_property(
       && BIN_PROPERTY_PATTERNS.es2019.contains(value))
 }
 
-pub fn is_large_id_start(cp: char) -> bool {
+pub(crate) fn is_large_id_start(cp: char) -> bool {
   is_in_range(cp as u32, &LARGE_ID_START_RANGES)
 }
 
-pub fn is_large_id_continue(cp: char) -> bool {
+pub(crate) fn is_large_id_continue(cp: char) -> bool {
   is_in_range(cp as u32, &LARGE_ID_CONTINUE_RANGES)
 }
 

--- a/src/js_regex/validator.rs
+++ b/src/js_regex/validator.rs
@@ -92,7 +92,8 @@ fn combine_surrogate_pair(lead: i64, trail: i64) -> i64 {
 }
 
 #[derive(Clone, Copy, Debug, Ord, PartialOrd, Eq, PartialEq, Hash)]
-pub enum EcmaVersion {
+#[allow(dead_code)]
+pub(crate) enum EcmaVersion {
   ES5,
   ES2015,
   ES2016,
@@ -104,7 +105,7 @@ pub enum EcmaVersion {
 }
 
 #[derive(Debug)]
-pub struct EcmaRegexValidator {
+pub(crate) struct EcmaRegexValidator {
   reader: Reader,
   strict: bool,
   ecma_version: EcmaVersion,
@@ -137,7 +138,7 @@ impl DerefMut for EcmaRegexValidator {
 }
 
 impl EcmaRegexValidator {
-  pub fn new(ecma_version: EcmaVersion) -> Self {
+  pub(crate) fn new(ecma_version: EcmaVersion) -> Self {
     EcmaRegexValidator {
       reader: Reader::new(),
       strict: false,
@@ -158,7 +159,7 @@ impl EcmaRegexValidator {
   }
 
   /// Validates flags of a EcmaScript regular expression.
-  pub fn validate_flags(&self, flags: &str) -> Result<(), String> {
+  pub(crate) fn validate_flags(&self, flags: &str) -> Result<(), String> {
     let mut existing_flags = HashSet::<char>::new();
 
     for flag in flags.chars() {
@@ -183,7 +184,7 @@ impl EcmaRegexValidator {
   }
 
   /// Validates the pattern of a EcmaScript regular expression.
-  pub fn validate_pattern(
+  pub(crate) fn validate_pattern(
     &mut self,
     source: &str,
     u_flag: bool,

--- a/src/js_regex/validator.rs
+++ b/src/js_regex/validator.rs
@@ -91,6 +91,7 @@ fn combine_surrogate_pair(lead: i64, trail: i64) -> i64 {
   (lead - 0xd800) * 0x400 + (trail - 0xdc00) + 0x10000
 }
 
+#[allow(dead_code)]
 #[derive(Clone, Copy, Debug, Ord, PartialOrd, Eq, PartialEq, Hash)]
 pub enum EcmaVersion {
   ES5,

--- a/src/js_regex/validator.rs
+++ b/src/js_regex/validator.rs
@@ -92,8 +92,7 @@ fn combine_surrogate_pair(lead: i64, trail: i64) -> i64 {
 }
 
 #[derive(Clone, Copy, Debug, Ord, PartialOrd, Eq, PartialEq, Hash)]
-#[allow(dead_code)]
-pub(crate) enum EcmaVersion {
+pub enum EcmaVersion {
   ES5,
   ES2015,
   ES2016,
@@ -105,7 +104,7 @@ pub(crate) enum EcmaVersion {
 }
 
 #[derive(Debug)]
-pub(crate) struct EcmaRegexValidator {
+pub struct EcmaRegexValidator {
   reader: Reader,
   strict: bool,
   ecma_version: EcmaVersion,
@@ -138,7 +137,7 @@ impl DerefMut for EcmaRegexValidator {
 }
 
 impl EcmaRegexValidator {
-  pub(crate) fn new(ecma_version: EcmaVersion) -> Self {
+  pub fn new(ecma_version: EcmaVersion) -> Self {
     EcmaRegexValidator {
       reader: Reader::new(),
       strict: false,
@@ -159,7 +158,7 @@ impl EcmaRegexValidator {
   }
 
   /// Validates flags of a EcmaScript regular expression.
-  pub(crate) fn validate_flags(&self, flags: &str) -> Result<(), String> {
+  pub fn validate_flags(&self, flags: &str) -> Result<(), String> {
     let mut existing_flags = HashSet::<char>::new();
 
     for flag in flags.chars() {
@@ -184,7 +183,7 @@ impl EcmaRegexValidator {
   }
 
   /// Validates the pattern of a EcmaScript regular expression.
-  pub(crate) fn validate_pattern(
+  pub fn validate_pattern(
     &mut self,
     source: &str,
     u_flag: bool,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,7 @@ mod js_regex;
 pub mod linter;
 pub mod rules;
 mod scopes;
-mod swc_util;
+pub mod swc_util;
 
 #[cfg(test)]
 mod test_util;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,11 +10,11 @@ extern crate log;
 
 mod control_flow;
 pub mod diagnostic;
-pub mod js_regex;
+mod js_regex;
 pub mod linter;
 pub mod rules;
 mod scopes;
-pub mod swc_util;
+mod swc_util;
 
 #[cfg(test)]
 mod test_util;

--- a/src/linter.rs
+++ b/src/linter.rs
@@ -38,6 +38,12 @@ pub struct Context {
 }
 
 impl Context {
+  pub(crate) fn add_diagnostic(&self, span: Span, code: &str, message: &str) {
+    let diagnostic = self.create_diagnostic(span, code, message);
+    let mut diags = self.diagnostics.lock().unwrap();
+    diags.push(diagnostic);
+  }
+
   fn create_diagnostic(
     &self,
     span: Span,
@@ -71,12 +77,6 @@ impl Context {
     let end = Instant::now();
     debug!("Context::create_diagnostic took {:?}", end - start);
     diagnostic
-  }
-
-  fn add_diagnostic(&self, span: Span, code: &str, message: &str) {
-    let diagnostic = self.create_diagnostic(span, code, message);
-    let mut diags = self.diagnostics.lock().unwrap();
-    diags.push(diagnostic);
   }
 }
 

--- a/src/linter.rs
+++ b/src/linter.rs
@@ -38,7 +38,7 @@ pub struct Context {
 }
 
 impl Context {
-  pub fn create_diagnostic(
+  fn create_diagnostic(
     &self,
     span: Span,
     code: &str,
@@ -73,7 +73,7 @@ impl Context {
     diagnostic
   }
 
-  pub fn add_diagnostic(&self, span: Span, code: &str, message: &str) {
+  fn add_diagnostic(&self, span: Span, code: &str, message: &str) {
     let diagnostic = self.create_diagnostic(span, code, message);
     let mut diags = self.diagnostics.lock().unwrap();
     diags.push(diagnostic);

--- a/src/linter.rs
+++ b/src/linter.rs
@@ -29,12 +29,12 @@ pub struct Context {
   pub file_name: String,
   pub diagnostics: Arc<Mutex<Vec<LintDiagnostic>>>,
   pub source_map: Arc<SourceMap>,
-  pub leading_comments: HashMap<BytePos, Vec<Comment>>,
-  pub trailing_comments: HashMap<BytePos, Vec<Comment>>,
+  pub(crate) leading_comments: HashMap<BytePos, Vec<Comment>>,
+  pub(crate) trailing_comments: HashMap<BytePos, Vec<Comment>>,
   pub ignore_directives: Vec<IgnoreDirective>,
   /// Arc as it's not modified
-  pub scope: Arc<Scope>,
-  pub control_flow: Arc<ControlFlow>,
+  pub(crate) scope: Arc<Scope>,
+  pub(crate) control_flow: Arc<ControlFlow>,
 }
 
 impl Context {

--- a/src/rules/adjacent_overload_signatures.rs
+++ b/src/rules/adjacent_overload_signatures.rs
@@ -35,7 +35,7 @@ struct AdjacentOverloadSignaturesVisitor {
 }
 
 impl AdjacentOverloadSignaturesVisitor {
-  pub fn new(context: Arc<Context>) -> Self {
+  fn new(context: Arc<Context>) -> Self {
     Self { context }
   }
 

--- a/src/rules/ban_types.rs
+++ b/src/rules/ban_types.rs
@@ -32,7 +32,7 @@ struct BanTypesVisitor {
 }
 
 impl BanTypesVisitor {
-  pub fn new(context: Arc<Context>) -> Self {
+  fn new(context: Arc<Context>) -> Self {
     Self { context }
   }
 }

--- a/src/rules/constructor_super.rs
+++ b/src/rules/constructor_super.rs
@@ -1,7 +1,5 @@
 use std::sync::Arc;
 
-pub struct ConstructorSuper;
-
 use super::Context;
 use super::LintRule;
 use swc_ecmascript::ast::{
@@ -10,6 +8,8 @@ use swc_ecmascript::ast::{
 use swc_ecmascript::visit::noop_visit_type;
 use swc_ecmascript::visit::Node;
 use swc_ecmascript::visit::Visit;
+
+pub struct ConstructorSuper;
 
 // This rule currently differs from the ESlint implementation
 // as there is currently no way of handling code paths in dlint
@@ -37,7 +37,7 @@ struct ConstructorSuperVisitor {
 }
 
 impl ConstructorSuperVisitor {
-  pub fn new(context: Arc<Context>) -> Self {
+  fn new(context: Arc<Context>) -> Self {
     Self { context }
   }
   fn check_constructor(&self, constructor: &Constructor, class: &Class) {

--- a/src/rules/default_param_last.rs
+++ b/src/rules/default_param_last.rs
@@ -34,7 +34,7 @@ struct DefaultParamLastVisitor {
 }
 
 impl DefaultParamLastVisitor {
-  pub fn new(context: Arc<Context>) -> Self {
+  fn new(context: Arc<Context>) -> Self {
     Self { context }
   }
 }

--- a/src/rules/eqeqeq.rs
+++ b/src/rules/eqeqeq.rs
@@ -34,7 +34,7 @@ struct EqeqeqVisitor {
 }
 
 impl EqeqeqVisitor {
-  pub fn new(context: Arc<Context>) -> Self {
+  fn new(context: Arc<Context>) -> Self {
     Self { context }
   }
 }

--- a/src/rules/explicit_function_return_type.rs
+++ b/src/rules/explicit_function_return_type.rs
@@ -33,7 +33,7 @@ struct ExplicitFunctionReturnTypeVisitor {
 }
 
 impl ExplicitFunctionReturnTypeVisitor {
-  pub fn new(context: Arc<Context>) -> Self {
+  fn new(context: Arc<Context>) -> Self {
     Self { context }
   }
 }

--- a/src/rules/explicit_module_boundary_types.rs
+++ b/src/rules/explicit_module_boundary_types.rs
@@ -34,7 +34,7 @@ struct ExplicitModuleBoundaryTypesVisitor {
 }
 
 impl ExplicitModuleBoundaryTypesVisitor {
-  pub fn new(context: Arc<Context>) -> Self {
+  fn new(context: Arc<Context>) -> Self {
     Self { context }
   }
 

--- a/src/rules/for_direction.rs
+++ b/src/rules/for_direction.rs
@@ -43,7 +43,7 @@ struct ForDirectionVisitor {
 }
 
 impl ForDirectionVisitor {
-  pub fn new(context: Arc<Context>) -> Self {
+  fn new(context: Arc<Context>) -> Self {
     Self { context }
   }
 

--- a/src/rules/getter_return.rs
+++ b/src/rules/getter_return.rs
@@ -41,7 +41,7 @@ struct GetterReturnVisitor {
 }
 
 impl GetterReturnVisitor {
-  pub fn new(context: Arc<Context>) -> Self {
+  fn new(context: Arc<Context>) -> Self {
     Self { context }
   }
 

--- a/src/rules/no_array_constructor.rs
+++ b/src/rules/no_array_constructor.rs
@@ -35,11 +35,11 @@ struct NoArrayConstructorVisitor {
 }
 
 impl NoArrayConstructorVisitor {
-  pub fn new(context: Arc<Context>) -> Self {
+  fn new(context: Arc<Context>) -> Self {
     Self { context }
   }
 
-  pub fn check_args(&self, args: Vec<ExprOrSpread>, span: Span) {
+  fn check_args(&self, args: Vec<ExprOrSpread>, span: Span) {
     if args.len() != 1 {
       self.context.add_diagnostic(
         span,

--- a/src/rules/no_async_promise_executor.rs
+++ b/src/rules/no_async_promise_executor.rs
@@ -35,7 +35,7 @@ struct NoAsyncPromiseExecutorVisitor {
 }
 
 impl NoAsyncPromiseExecutorVisitor {
-  pub fn new(context: Arc<Context>) -> Self {
+  fn new(context: Arc<Context>) -> Self {
     Self { context }
   }
 }

--- a/src/rules/no_case_declarations.rs
+++ b/src/rules/no_case_declarations.rs
@@ -37,7 +37,7 @@ struct NoCaseDeclarationsVisitor {
 }
 
 impl NoCaseDeclarationsVisitor {
-  pub fn new(context: Arc<Context>) -> Self {
+  fn new(context: Arc<Context>) -> Self {
     Self { context }
   }
 }

--- a/src/rules/no_class_assign.rs
+++ b/src/rules/no_class_assign.rs
@@ -35,7 +35,7 @@ struct NoClassAssignVisitor {
 }
 
 impl NoClassAssignVisitor {
-  pub fn new(context: Arc<Context>) -> Self {
+  fn new(context: Arc<Context>) -> Self {
     Self { context }
   }
 }

--- a/src/rules/no_compare_neg_zero.rs
+++ b/src/rules/no_compare_neg_zero.rs
@@ -32,7 +32,7 @@ struct NoCompareNegZeroVisitor {
 }
 
 impl NoCompareNegZeroVisitor {
-  pub fn new(context: Arc<Context>) -> Self {
+  fn new(context: Arc<Context>) -> Self {
     Self { context }
   }
 }

--- a/src/rules/no_cond_assign.rs
+++ b/src/rules/no_cond_assign.rs
@@ -30,7 +30,7 @@ struct NoCondAssignVisitor {
 }
 
 impl NoCondAssignVisitor {
-  pub fn new(context: Arc<Context>) -> Self {
+  fn new(context: Arc<Context>) -> Self {
     Self { context }
   }
 

--- a/src/rules/no_const_assign.rs
+++ b/src/rules/no_const_assign.rs
@@ -40,7 +40,7 @@ struct NoConstAssignVisitor {
 }
 
 impl NoConstAssignVisitor {
-  pub fn new(context: Arc<Context>) -> Self {
+  fn new(context: Arc<Context>) -> Self {
     Self { context }
   }
 

--- a/src/rules/no_constant_condition.rs
+++ b/src/rules/no_constant_condition.rs
@@ -31,7 +31,7 @@ struct NoConstantConditionVisitor {
 }
 
 impl NoConstantConditionVisitor {
-  pub fn new(context: Arc<Context>) -> Self {
+  fn new(context: Arc<Context>) -> Self {
     Self { context }
   }
 

--- a/src/rules/no_control_regex.rs
+++ b/src/rules/no_control_regex.rs
@@ -38,7 +38,7 @@ struct NoControlRegexVisitor {
 }
 
 impl NoControlRegexVisitor {
-  pub fn new(context: Arc<Context>) -> Self {
+  fn new(context: Arc<Context>) -> Self {
     Self { context }
   }
 

--- a/src/rules/no_debugger.rs
+++ b/src/rules/no_debugger.rs
@@ -33,7 +33,7 @@ struct NoDebuggerVisitor {
 }
 
 impl NoDebuggerVisitor {
-  pub fn new(context: Arc<Context>) -> Self {
+  fn new(context: Arc<Context>) -> Self {
     Self { context }
   }
 }

--- a/src/rules/no_delete_var.rs
+++ b/src/rules/no_delete_var.rs
@@ -36,7 +36,7 @@ struct NoDeleteVarVisitor {
 }
 
 impl NoDeleteVarVisitor {
-  pub fn new(context: Arc<Context>) -> Self {
+  fn new(context: Arc<Context>) -> Self {
     Self { context }
   }
 }

--- a/src/rules/no_dupe_args.rs
+++ b/src/rules/no_dupe_args.rs
@@ -39,7 +39,7 @@ struct NoDupeArgsVisitor {
 }
 
 impl NoDupeArgsVisitor {
-  pub fn new(context: Arc<Context>) -> Self {
+  fn new(context: Arc<Context>) -> Self {
     Self { context }
   }
 

--- a/src/rules/no_dupe_else_if.rs
+++ b/src/rules/no_dupe_else_if.rs
@@ -35,7 +35,7 @@ struct NoDupeElseIfVisitor {
 }
 
 impl NoDupeElseIfVisitor {
-  pub fn new(context: Arc<Context>) -> Self {
+  fn new(context: Arc<Context>) -> Self {
     Self {
       context,
       checked_span: HashSet::new(),

--- a/src/rules/no_dupe_keys.rs
+++ b/src/rules/no_dupe_keys.rs
@@ -30,7 +30,7 @@ struct NoDupeKeysVisitor {
 }
 
 impl NoDupeKeysVisitor {
-  pub fn new(context: Arc<Context>) -> Self {
+  fn new(context: Arc<Context>) -> Self {
     Self { context }
   }
 }

--- a/src/rules/no_duplicate_case.rs
+++ b/src/rules/no_duplicate_case.rs
@@ -35,7 +35,7 @@ struct NoDuplicateCaseVisitor {
 }
 
 impl NoDuplicateCaseVisitor {
-  pub fn new(context: Arc<Context>) -> Self {
+  fn new(context: Arc<Context>) -> Self {
     Self { context }
   }
 }

--- a/src/rules/no_empty.rs
+++ b/src/rules/no_empty.rs
@@ -30,7 +30,7 @@ struct NoEmptyVisitor {
 }
 
 impl NoEmptyVisitor {
-  pub fn new(context: Arc<Context>) -> Self {
+  fn new(context: Arc<Context>) -> Self {
     Self { context }
   }
 }

--- a/src/rules/no_empty_character_class.rs
+++ b/src/rules/no_empty_character_class.rs
@@ -34,7 +34,7 @@ struct NoEmptyCharacterClassVisitor {
 }
 
 impl NoEmptyCharacterClassVisitor {
-  pub fn new(context: Arc<Context>) -> Self {
+  fn new(context: Arc<Context>) -> Self {
     Self { context }
   }
 }

--- a/src/rules/no_empty_interface.rs
+++ b/src/rules/no_empty_interface.rs
@@ -33,7 +33,7 @@ struct NoEmptyInterfaceVisitor {
 }
 
 impl NoEmptyInterfaceVisitor {
-  pub fn new(context: Arc<Context>) -> Self {
+  fn new(context: Arc<Context>) -> Self {
     Self { context }
   }
 }

--- a/src/rules/no_empty_pattern.rs
+++ b/src/rules/no_empty_pattern.rs
@@ -34,7 +34,7 @@ struct NoEmptyPatternVisitor {
 }
 
 impl NoEmptyPatternVisitor {
-  pub fn new(context: Arc<Context>) -> Self {
+  fn new(context: Arc<Context>) -> Self {
     Self { context }
   }
 }

--- a/src/rules/no_eval.rs
+++ b/src/rules/no_eval.rs
@@ -36,7 +36,7 @@ struct NoEvalVisitor {
 }
 
 impl NoEvalVisitor {
-  pub fn new(context: Arc<Context>) -> Self {
+  fn new(context: Arc<Context>) -> Self {
     Self { context }
   }
 }

--- a/src/rules/no_ex_assign.rs
+++ b/src/rules/no_ex_assign.rs
@@ -34,7 +34,7 @@ struct NoExAssignVisitor {
 }
 
 impl NoExAssignVisitor {
-  pub fn new(context: Arc<Context>) -> Self {
+  fn new(context: Arc<Context>) -> Self {
     Self { context }
   }
 }

--- a/src/rules/no_explicit_any.rs
+++ b/src/rules/no_explicit_any.rs
@@ -33,7 +33,7 @@ struct NoExplicitAnyVisitor {
 }
 
 impl NoExplicitAnyVisitor {
-  pub fn new(context: Arc<Context>) -> Self {
+  fn new(context: Arc<Context>) -> Self {
     Self { context }
   }
 }

--- a/src/rules/no_extra_non_null_assertion.rs
+++ b/src/rules/no_extra_non_null_assertion.rs
@@ -37,7 +37,7 @@ struct NoExtraNonNullAssertionVisitor {
 }
 
 impl NoExtraNonNullAssertionVisitor {
-  pub fn new(context: Arc<Context>) -> Self {
+  fn new(context: Arc<Context>) -> Self {
     Self { context }
   }
 

--- a/src/rules/no_extra_semi.rs
+++ b/src/rules/no_extra_semi.rs
@@ -37,7 +37,7 @@ struct NoExtraSemiVisitor {
 }
 
 impl NoExtraSemiVisitor {
-  pub fn new(context: Arc<Context>) -> Self {
+  fn new(context: Arc<Context>) -> Self {
     Self { context }
   }
 }

--- a/src/rules/no_func_assign.rs
+++ b/src/rules/no_func_assign.rs
@@ -35,7 +35,7 @@ struct NoFuncAssignVisitor {
 }
 
 impl NoFuncAssignVisitor {
-  pub fn new(context: Arc<Context>) -> Self {
+  fn new(context: Arc<Context>) -> Self {
     Self { context }
   }
 }

--- a/src/rules/no_inferrable_types.rs
+++ b/src/rules/no_inferrable_types.rs
@@ -34,7 +34,7 @@ struct NoInferrableTypesVisitor {
 }
 
 impl NoInferrableTypesVisitor {
-  pub fn new(context: Arc<Context>) -> Self {
+  fn new(context: Arc<Context>) -> Self {
     Self { context }
   }
 

--- a/src/rules/no_invalid_regexp.rs
+++ b/src/rules/no_invalid_regexp.rs
@@ -48,7 +48,7 @@ struct NoInvalidRegexpVisitor {
 }
 
 impl NoInvalidRegexpVisitor {
-  pub fn new(context: Arc<Context>) -> Self {
+  fn new(context: Arc<Context>) -> Self {
     Self {
       context,
       validator: EcmaRegexValidator::new(EcmaVersion::ES2018),

--- a/src/rules/no_irregular_whitespace.rs
+++ b/src/rules/no_irregular_whitespace.rs
@@ -83,7 +83,7 @@ struct NoIrregularWhitespaceVisitor {
 }
 
 impl NoIrregularWhitespaceVisitor {
-  pub fn default() -> Self {
+  fn default() -> Self {
     Self { ranges: vec![] }
   }
 }

--- a/src/rules/no_mixed_spaces_and_tabs.rs
+++ b/src/rules/no_mixed_spaces_and_tabs.rs
@@ -98,7 +98,7 @@ struct NoMixedSpacesAndTabsVisitor {
 }
 
 impl NoMixedSpacesAndTabsVisitor {
-  pub fn default() -> Self {
+  fn default() -> Self {
     Self { ranges: vec![] }
   }
 }

--- a/src/rules/no_namespace.rs
+++ b/src/rules/no_namespace.rs
@@ -33,7 +33,7 @@ struct NoNamespaceVisitor {
 }
 
 impl NoNamespaceVisitor {
-  pub fn new(context: Arc<Context>) -> Self {
+  fn new(context: Arc<Context>) -> Self {
     Self { context }
   }
 }

--- a/src/rules/no_new_symbol.rs
+++ b/src/rules/no_new_symbol.rs
@@ -34,7 +34,7 @@ struct NoNewSymbolVisitor {
 }
 
 impl NoNewSymbolVisitor {
-  pub fn new(context: Arc<Context>) -> Self {
+  fn new(context: Arc<Context>) -> Self {
     Self { context }
   }
 }

--- a/src/rules/no_non_null_asserted_optional_chain.rs
+++ b/src/rules/no_non_null_asserted_optional_chain.rs
@@ -34,7 +34,7 @@ struct NoNonNullAssertedOptionalChainVisitor {
 }
 
 impl NoNonNullAssertedOptionalChainVisitor {
-  pub fn new(context: Arc<Context>) -> Self {
+  fn new(context: Arc<Context>) -> Self {
     Self { context }
   }
 

--- a/src/rules/no_non_null_assertion.rs
+++ b/src/rules/no_non_null_assertion.rs
@@ -31,7 +31,7 @@ struct NoNonNullAssertionVisitor {
 }
 
 impl NoNonNullAssertionVisitor {
-  pub fn new(context: Arc<Context>) -> Self {
+  fn new(context: Arc<Context>) -> Self {
     Self { context }
   }
 }

--- a/src/rules/no_obj_calls.rs
+++ b/src/rules/no_obj_calls.rs
@@ -38,7 +38,7 @@ struct NoObjCallsVisitor {
 }
 
 impl NoObjCallsVisitor {
-  pub fn new(context: Arc<Context>) -> Self {
+  fn new(context: Arc<Context>) -> Self {
     Self { context }
   }
 

--- a/src/rules/no_octal.rs
+++ b/src/rules/no_octal.rs
@@ -33,7 +33,7 @@ struct NoOctalVisitor {
 }
 
 impl NoOctalVisitor {
-  pub fn new(context: Arc<Context>) -> Self {
+  fn new(context: Arc<Context>) -> Self {
     Self { context }
   }
 }

--- a/src/rules/no_prototype_builtins.rs
+++ b/src/rules/no_prototype_builtins.rs
@@ -1,6 +1,7 @@
 // Copyright 2020 the Deno authors. All rights reserved. MIT license.
 use super::Context;
 use super::LintRule;
+use std::sync::Arc;
 use swc_ecmascript::ast::CallExpr;
 use swc_ecmascript::ast::Expr;
 use swc_ecmascript::ast::ExprOrSuper;
@@ -8,10 +9,8 @@ use swc_ecmascript::visit::noop_visit_type;
 use swc_ecmascript::visit::Node;
 use swc_ecmascript::visit::Visit;
 
-pub const BANNED_PROPERTIES: &[&str] =
+const BANNED_PROPERTIES: &[&str] =
   &["hasOwnProperty", "isPrototypeOf", "propertyIsEnumberable"];
-
-use std::sync::Arc;
 
 pub struct NoPrototypeBuiltins;
 
@@ -39,7 +38,7 @@ struct NoPrototypeBuiltinsVisitor {
 }
 
 impl NoPrototypeBuiltinsVisitor {
-  pub fn new(context: Arc<Context>) -> Self {
+  fn new(context: Arc<Context>) -> Self {
     Self { context }
   }
 }

--- a/src/rules/no_regex_spaces.rs
+++ b/src/rules/no_regex_spaces.rs
@@ -36,7 +36,7 @@ struct NoRegexSpacesVisitor {
 }
 
 impl NoRegexSpacesVisitor {
-  pub fn new(context: Arc<Context>) -> Self {
+  fn new(context: Arc<Context>) -> Self {
     Self { context }
   }
 

--- a/src/rules/no_self_assign.rs
+++ b/src/rules/no_self_assign.rs
@@ -46,7 +46,7 @@ struct NoSelfAssignVisitor {
 }
 
 impl NoSelfAssignVisitor {
-  pub fn new(context: Arc<Context>) -> Self {
+  fn new(context: Arc<Context>) -> Self {
     Self { context }
   }
 

--- a/src/rules/no_setter_return.rs
+++ b/src/rules/no_setter_return.rs
@@ -39,7 +39,7 @@ struct NoSetterReturnVisitor {
 }
 
 impl NoSetterReturnVisitor {
-  pub fn new(context: Arc<Context>) -> Self {
+  fn new(context: Arc<Context>) -> Self {
     Self { context }
   }
 

--- a/src/rules/no_sparse_arrays.rs
+++ b/src/rules/no_sparse_arrays.rs
@@ -33,7 +33,7 @@ struct NoSparseArraysVisitor {
 }
 
 impl NoSparseArraysVisitor {
-  pub fn new(context: Arc<Context>) -> Self {
+  fn new(context: Arc<Context>) -> Self {
     Self { context }
   }
 }

--- a/src/rules/no_this_alias.rs
+++ b/src/rules/no_this_alias.rs
@@ -34,7 +34,7 @@ struct NoThisAliasVisitor {
 }
 
 impl NoThisAliasVisitor {
-  pub fn new(context: Arc<Context>) -> Self {
+  fn new(context: Arc<Context>) -> Self {
     Self { context }
   }
 }

--- a/src/rules/no_throw_literal.rs
+++ b/src/rules/no_throw_literal.rs
@@ -34,7 +34,7 @@ struct NoThrowLiteralVisitor {
 }
 
 impl NoThrowLiteralVisitor {
-  pub fn new(context: Arc<Context>) -> Self {
+  fn new(context: Arc<Context>) -> Self {
     Self { context }
   }
 }

--- a/src/rules/no_unexpected_multiline.rs
+++ b/src/rules/no_unexpected_multiline.rs
@@ -61,7 +61,7 @@ struct NoUnexpectedMultilineVisitor {
 }
 
 impl NoUnexpectedMultilineVisitor {
-  pub fn new(context: Arc<Context>) -> Self {
+  fn new(context: Arc<Context>) -> Self {
     Self {
       context,
       current_node_is_optional: false,

--- a/src/rules/no_unreachable.rs
+++ b/src/rules/no_unreachable.rs
@@ -35,7 +35,7 @@ struct NoUnreachableVisitor {
 }
 
 impl NoUnreachableVisitor {
-  pub fn new(context: Arc<Context>) -> Self {
+  fn new(context: Arc<Context>) -> Self {
     Self { context }
   }
 }

--- a/src/rules/no_unsafe_finally.rs
+++ b/src/rules/no_unsafe_finally.rs
@@ -29,7 +29,7 @@ struct NoUnsafeFinallyVisitor {
 }
 
 impl NoUnsafeFinallyVisitor {
-  pub fn new(context: Arc<Context>) -> Self {
+  fn new(context: Arc<Context>) -> Self {
     Self { context }
   }
 }

--- a/src/rules/no_unsafe_negation.rs
+++ b/src/rules/no_unsafe_negation.rs
@@ -37,7 +37,7 @@ struct NoUnsafeNegationVisitor {
 }
 
 impl NoUnsafeNegationVisitor {
-  pub fn new(context: Arc<Context>) -> Self {
+  fn new(context: Arc<Context>) -> Self {
     Self { context }
   }
 }

--- a/src/rules/no_unused_labels.rs
+++ b/src/rules/no_unused_labels.rs
@@ -43,7 +43,7 @@ struct NoUnusedLabelsVisitor {
 }
 
 impl NoUnusedLabelsVisitor {
-  pub fn new(context: Arc<Context>) -> Self {
+  fn new(context: Arc<Context>) -> Self {
     Self {
       context,
       label_scopes: vec![],

--- a/src/rules/no_var.rs
+++ b/src/rules/no_var.rs
@@ -35,7 +35,7 @@ struct NoVarVisitor {
 }
 
 impl NoVarVisitor {
-  pub fn new(context: Arc<Context>) -> Self {
+  fn new(context: Arc<Context>) -> Self {
     Self { context }
   }
 }

--- a/src/rules/no_with.rs
+++ b/src/rules/no_with.rs
@@ -34,7 +34,7 @@ struct NoWithVisitor {
 }
 
 impl NoWithVisitor {
-  pub fn new(context: Arc<Context>) -> Self {
+  fn new(context: Arc<Context>) -> Self {
     Self { context }
   }
 }

--- a/src/rules/prefer_as_const.rs
+++ b/src/rules/prefer_as_const.rs
@@ -35,7 +35,7 @@ struct PreferAsConstVisitor {
 }
 
 impl PreferAsConstVisitor {
-  pub fn new(context: Arc<Context>) -> Self {
+  fn new(context: Arc<Context>) -> Self {
     Self { context }
   }
 

--- a/src/rules/prefer_namespace_keyword.rs
+++ b/src/rules/prefer_namespace_keyword.rs
@@ -34,7 +34,7 @@ struct PreferNamespaceKeywordVisitor {
 }
 
 impl PreferNamespaceKeywordVisitor {
-  pub fn new(context: Arc<Context>) -> Self {
+  fn new(context: Arc<Context>) -> Self {
     Self { context }
   }
 }

--- a/src/rules/require_yield.rs
+++ b/src/rules/require_yield.rs
@@ -41,7 +41,7 @@ struct RequireYieldVisitor {
 }
 
 impl RequireYieldVisitor {
-  pub fn new(context: Arc<Context>) -> Self {
+  fn new(context: Arc<Context>) -> Self {
     Self {
       context,
       yield_stack: vec![],

--- a/src/rules/single_var_declarator.rs
+++ b/src/rules/single_var_declarator.rs
@@ -34,7 +34,7 @@ struct SingleVarDeclaratorVisitor {
 }
 
 impl SingleVarDeclaratorVisitor {
-  pub fn new(context: Arc<Context>) -> Self {
+  fn new(context: Arc<Context>) -> Self {
     Self { context }
   }
 }

--- a/src/rules/use_isnan.rs
+++ b/src/rules/use_isnan.rs
@@ -33,7 +33,7 @@ struct UseIsNaNVisitor {
 }
 
 impl UseIsNaNVisitor {
-  pub fn new(context: Arc<Context>) -> Self {
+  fn new(context: Arc<Context>) -> Self {
     Self { context }
   }
 }

--- a/src/rules/valid_typeof.rs
+++ b/src/rules/valid_typeof.rs
@@ -32,7 +32,7 @@ struct ValidTypeofVisitor {
 }
 
 impl ValidTypeofVisitor {
-  pub fn new(context: Arc<Context>) -> Self {
+  fn new(context: Arc<Context>) -> Self {
     Self { context }
   }
 }

--- a/src/scopes.rs
+++ b/src/scopes.rs
@@ -22,36 +22,34 @@ pub struct Scope {
 
 impl Scope {
   // Get all declarations with a symbol.
-  #[allow(dead_code)]
-  pub(crate) fn ids_with_symbol(&self, sym: &JsWord) -> Option<&Vec<Id>> {
+  pub fn ids_with_symbol(&self, sym: &JsWord) -> Option<&Vec<Id>> {
     self.symbols.get(sym)
   }
 
-  pub(crate) fn var(&self, id: &Id) -> Option<&Var> {
+  pub fn var(&self, id: &Id) -> Option<&Var> {
     self.vars.get(id)
   }
 }
 
 #[derive(Debug)]
-pub(crate) struct Var {
+pub struct Var {
   path: Vec<ScopeKind>,
   kind: BindingKind,
 }
 
 impl Var {
   /// Empty path means root scope.
-  #[allow(dead_code)]
-  pub(crate) fn path(&self) -> &[ScopeKind] {
+  pub fn path(&self) -> &[ScopeKind] {
     &self.path
   }
 
-  pub(crate) fn kind(&self) -> BindingKind {
+  pub fn kind(&self) -> BindingKind {
     self.kind
   }
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
-pub(crate) enum BindingKind {
+pub enum BindingKind {
   Var,
   Const,
   Let,
@@ -63,7 +61,7 @@ pub(crate) enum BindingKind {
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
-pub(crate) enum ScopeKind {
+pub enum ScopeKind {
   // Module,
   Arrow,
   Function,
@@ -75,7 +73,7 @@ pub(crate) enum ScopeKind {
   Catch,
 }
 
-pub(crate) fn analyze(module: &Module) -> Scope {
+pub fn analyze(module: &Module) -> Scope {
   let mut scope = Scope {
     vars: Default::default(),
     symbols: Default::default(),

--- a/src/scopes.rs
+++ b/src/scopes.rs
@@ -22,34 +22,36 @@ pub struct Scope {
 
 impl Scope {
   // Get all declarations with a symbol.
-  pub fn ids_with_symbol(&self, sym: &JsWord) -> Option<&Vec<Id>> {
+  #[allow(dead_code)]
+  pub(crate) fn ids_with_symbol(&self, sym: &JsWord) -> Option<&Vec<Id>> {
     self.symbols.get(sym)
   }
 
-  pub fn var(&self, id: &Id) -> Option<&Var> {
+  pub(crate) fn var(&self, id: &Id) -> Option<&Var> {
     self.vars.get(id)
   }
 }
 
 #[derive(Debug)]
-pub struct Var {
+pub(crate) struct Var {
   path: Vec<ScopeKind>,
   kind: BindingKind,
 }
 
 impl Var {
   /// Empty path means root scope.
-  pub fn path(&self) -> &[ScopeKind] {
+  #[allow(dead_code)]
+  pub(crate) fn path(&self) -> &[ScopeKind] {
     &self.path
   }
 
-  pub fn kind(&self) -> BindingKind {
+  pub(crate) fn kind(&self) -> BindingKind {
     self.kind
   }
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
-pub enum BindingKind {
+pub(crate) enum BindingKind {
   Var,
   Const,
   Let,
@@ -61,7 +63,7 @@ pub enum BindingKind {
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
-pub enum ScopeKind {
+pub(crate) enum ScopeKind {
   // Module,
   Arrow,
   Function,
@@ -73,7 +75,7 @@ pub enum ScopeKind {
   Catch,
 }
 
-pub fn analyze(module: &Module) -> Scope {
+pub(crate) fn analyze(module: &Module) -> Scope {
   let mut scope = Scope {
     vars: Default::default(),
     symbols: Default::default(),

--- a/src/scopes.rs
+++ b/src/scopes.rs
@@ -22,6 +22,7 @@ pub struct Scope {
 
 impl Scope {
   // Get all declarations with a symbol.
+  #[allow(dead_code)]
   pub fn ids_with_symbol(&self, sym: &JsWord) -> Option<&Vec<Id>> {
     self.symbols.get(sym)
   }
@@ -39,6 +40,7 @@ pub struct Var {
 
 impl Var {
   /// Empty path means root scope.
+  #[allow(dead_code)]
   pub fn path(&self) -> &[ScopeKind] {
     &self.path
   }

--- a/src/swc_util.rs
+++ b/src/swc_util.rs
@@ -315,7 +315,7 @@ impl Key for Lit {
 impl Key for Tpl {
   fn get_key(&self) -> Option<String> {
     if self.exprs.is_empty() {
-      self.quasis.iter().next().map(|q| q.raw.value.to_string())
+      self.quasis.get(0).map(|q| q.raw.value.to_string())
     } else {
       None
     }

--- a/src/swc_util.rs
+++ b/src/swc_util.rs
@@ -35,7 +35,7 @@ use swc_ecmascript::{
 };
 
 #[allow(unused)]
-pub(crate) fn get_default_es_config() -> Syntax {
+pub fn get_default_es_config() -> Syntax {
   let mut config = EsConfig::default();
   config.num_sep = true;
   config.class_private_props = false;
@@ -51,7 +51,7 @@ pub(crate) fn get_default_es_config() -> Syntax {
   Syntax::Es(config)
 }
 
-pub(crate) fn get_default_ts_config() -> Syntax {
+pub fn get_default_ts_config() -> Syntax {
   let mut ts_config = TsConfig::default();
   ts_config.dynamic_import = true;
   ts_config.decorators = true;

--- a/src/swc_util.rs
+++ b/src/swc_util.rs
@@ -35,7 +35,7 @@ use swc_ecmascript::{
 };
 
 #[allow(unused)]
-pub fn get_default_es_config() -> Syntax {
+pub(crate) fn get_default_es_config() -> Syntax {
   let mut config = EsConfig::default();
   config.num_sep = true;
   config.class_private_props = false;
@@ -51,8 +51,7 @@ pub fn get_default_es_config() -> Syntax {
   Syntax::Es(config)
 }
 
-#[allow(unused)]
-pub fn get_default_ts_config() -> Syntax {
+pub(crate) fn get_default_ts_config() -> Syntax {
   let mut ts_config = TsConfig::default();
   ts_config.dynamic_import = true;
   ts_config.decorators = true;
@@ -75,7 +74,7 @@ impl fmt::Display for SwcDiagnosticBuffer {
 }
 
 impl SwcDiagnosticBuffer {
-  pub fn from_swc_error(
+  pub(crate) fn from_swc_error(
     error_buffer: SwcErrorBuffer,
     parser: &AstParser,
   ) -> Self {
@@ -107,10 +106,10 @@ impl SwcDiagnosticBuffer {
 }
 
 #[derive(Clone)]
-pub struct SwcErrorBuffer(Arc<RwLock<Vec<Diagnostic>>>);
+pub(crate) struct SwcErrorBuffer(Arc<RwLock<Vec<Diagnostic>>>);
 
 impl SwcErrorBuffer {
-  pub fn default() -> Self {
+  pub(crate) fn default() -> Self {
     Self(Arc::new(RwLock::new(vec![])))
   }
 }
@@ -125,15 +124,15 @@ impl Emitter for SwcErrorBuffer {
 ///
 /// Allows to build more complicated parser by providing a callback
 /// to `parse_module`.
-pub struct AstParser {
-  pub buffered_error: SwcErrorBuffer,
-  pub source_map: Arc<SourceMap>,
-  pub handler: Handler,
-  pub globals: Globals,
+pub(crate) struct AstParser {
+  pub(crate) buffered_error: SwcErrorBuffer,
+  pub(crate) source_map: Arc<SourceMap>,
+  pub(crate) handler: Handler,
+  pub(crate) globals: Globals,
 }
 
 impl AstParser {
-  pub fn new() -> Self {
+  pub(crate) fn new() -> Self {
     let buffered_error = SwcErrorBuffer::default();
 
     let handler = Handler::with_emitter_and_flags(
@@ -153,7 +152,7 @@ impl AstParser {
     }
   }
 
-  pub fn parse_module(
+  pub(crate) fn parse_module(
     &self,
     file_name: &str,
     syntax: Syntax,
@@ -195,11 +194,11 @@ impl AstParser {
     (parse_result, comments)
   }
 
-  pub fn get_span_location(&self, span: Span) -> swc_common::Loc {
+  pub(crate) fn get_span_location(&self, span: Span) -> swc_common::Loc {
     self.source_map.lookup_char_pos(span.lo())
   }
 
-  // pub fn get_span_comments(
+  // pub(crate) fn get_span_comments(
   //   &self,
   //   span: Span,
   // ) -> Vec<swc_common::comments::Comment> {


### PR DESCRIPTION
Currently, there are some problems about visibility.

### 1. Items that are not required to be `pub` have public visibility

I think that from the crate consumers' point of view, the items that should be public are:

- `diagnostic::LintDiagnostic`
- `diagnostic::Location`
- `linter::Context`
- `linter::IgnoreDirective`
- `linter::Linter`
- `linter::LinterBuilder`
- `rules::LintRule`
- `rules::get_all_rules`
- `rules::get_recommended_rules`
- `rules::<rule-name>::<rule-struct>`
- `swc_util::SwcDiagnosticBuffer`

Therefore I have made the other items private.

### 2. Different visitors have different visibility for their constructors (some are `pub`, the others are private).

The visitors don't have to be public to crate consumers because they are the implementation detail of the rules and used by `lint_module` internally. So I have made all the items about `visitor` private.