### PR TITLE
example: use rayon for threaded execution

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -99,6 +99,53 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-channel"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ee0cc8804d5393478d743b035099520087a5186f3b93fa58cec08fa62407b6"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f02af974daeee82218205558e51ec8768b48cf524bd01d550abe5573a608285"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "maybe-uninit",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "058ed274caafc1f60c4997b5fc07bf7dc7cca454af7c6e81edffe5f33f70dace"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "crossbeam-utils",
+ "lazy_static",
+ "maybe-uninit",
+ "memoffset",
+ "scopeguard",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3c7c73a2d1e9fc0886a08b93e98eb643461230d5f1925e4036204d5f2e261a8"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "lazy_static",
+]
+
+[[package]]
 name = "darling"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -141,6 +188,7 @@ dependencies = [
  "env_logger",
  "lazy_static",
  "log",
+ "rayon",
  "regex",
  "serde",
  "serde_json",
@@ -328,10 +376,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "maybe-uninit"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00"
+
+[[package]]
 name = "memchr"
 version = "2.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3728d817d99e5ac407411fa471ff9800a778d88a24685968b36824eaf4bee400"
+
+[[package]]
+name = "memoffset"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c198b026e1bbf08a937e94c6c60f9ec4a2267f5b0d2eec9c1b21b061ce2be55f"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "new_debug_unreachable"
@@ -379,6 +442,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac267bcc07f48ee5f8935ab0d24f316fb722d7a1292e2913f0cc196b29ffd611"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05499f3756671c15885fee9034446956fff3f243d6077b91e5767df161f766b3"
+dependencies = [
+ "hermit-abi",
+ "libc",
 ]
 
 [[package]]
@@ -523,6 +596,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "rayon"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfd016f0c045ad38b5251be2c9c0ab806917f82da4d36b2a327e5166adad9270"
+dependencies = [
+ "autocfg",
+ "crossbeam-deque",
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91739a34c4355b5434ce54c9086c5895604a9c278586d1f1aa95e04f66b525a0"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-utils",
+ "lazy_static",
+ "num_cpus",
+]
+
+[[package]]
 name = "regex"
 version = "1.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -557,6 +655,12 @@ name = "scoped-tls"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea6a9290e3c9cf0f18145ef7ffa62d68ee0bf5fcd651017e586dc7fd5da448c2"
+
+[[package]]
+name = "scopeguard"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "serde"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,4 +32,5 @@ regex = "1.3.9"
 [dev-dependencies]
 clap = "2.33.1"
 env_logger = "0.7.1"
+rayon = "1.4.0"
 termcolor = "1.1.0"

--- a/benchmarks/benchmarks.ts
+++ b/benchmarks/benchmarks.ts
@@ -20,13 +20,14 @@ bench({
     b.start();
     const proc = Deno.run({
       cmd: ["./target/release/examples/dlint", ...files],
-      stdout: "piped",
-      stderr: "piped",
+      stdout: "inherit",
+      stderr: "inherit",
     });
-    const { success } = await proc.status();
 
     // No assert on success, cause dlint returns exit
     // code 1 if there's any problem.
+    //
+    await proc.status();
     //
     // if (!success) {
     //   await Deno.copy(proc.stdout!, Deno.stdout);
@@ -46,8 +47,8 @@ bench({
     const proc = Deno.run({
       cmd: ["npm", "run", "eslint", ...files],
       cwd: Deno.build.os === "windows" ? ".\\benchmarks" : "./benchmarks",
-      stdout: "null",
-      stderr: "null",
+      stdout: "inherit",
+      stderr: "inherit",
     });
     const { success } = await proc.status();
     if (!success) {

--- a/benchmarks/benchmarks.ts
+++ b/benchmarks/benchmarks.ts
@@ -2,8 +2,8 @@ import {
   BenchmarkTimer,
   bench,
   runBenchmarks,
-} from "https://deno.land/std@0.61.0/testing/bench.ts";
-import { expandGlobSync } from "https://deno.land/std@0.61.0/fs/expand_glob.ts";
+} from "https://deno.land/std@0.67.0/testing/bench.ts";
+import { expandGlobSync } from "https://deno.land/std@0.67.0/fs/expand_glob.ts";
 
 const RUN_COUNT = 5;
 
@@ -20,15 +20,20 @@ bench({
     b.start();
     const proc = Deno.run({
       cmd: ["./target/release/examples/dlint", ...files],
-      stdout: "null",
-      stderr: "null",
+      stdout: "piped",
+      stderr: "piped",
     });
     const { success } = await proc.status();
-    if (!success) {
-      // await Deno.copy(proc.stdout!, Deno.stdout);
-      // await Deno.copy(proc.stderr!, Deno.stderr);
-      throw Error("Failed to run deno_lint");
-    }
+
+    // No assert on success, cause dlint returns exit
+    // code 1 if there's any problem.
+    //
+    // if (!success) {
+    //   await Deno.copy(proc.stdout!, Deno.stdout);
+    //   await Deno.copy(proc.stderr!, Deno.stderr);
+    //   throw Error("Failed to run dlint");
+    // }
+
     b.stop();
   },
 });


### PR DESCRIPTION
This commit adds `rayon` dev dependency. 

It is used in `dlint` example to run linter on a threadpool.