### PR TITLE
feat: ignore rule in file

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,16 @@ function foo(): any {
 }
 ```
 
+You can also ignore certain diagnostics in the whole file
+
+```ts
+// deno-lint-ignore-file no-explicit-any no-empty
+
+function foo(): any {
+  // ...
+}
+```
+
 ### Diagnostics
 
 To ignore certain diagnostic `// deno-lint-ignore <codes...>` directive should be placed

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -117,4 +117,58 @@ mod lint_tests {
 
     assert_eq!(diagnostics.len(), 0);
   }
+
+  #[test]
+  fn file_directive_with_code() {
+    let diagnostics = lint(
+      r#"
+ // deno-lint-ignore-file no-explicit-any
+
+ function bar(p: any) {
+   // pass
+ }
+      "#,
+      false,
+      false,
+    );
+
+    assert_eq!(diagnostics.len(), 0);
+  }
+
+  #[test]
+  fn file_directive_with_code_unused() {
+    let diagnostics = lint(
+      r#"
+ // deno-lint-ignore-file no-explicit-any no-empty
+
+ function bar(p: any) {
+   // pass
+ }
+      "#,
+      false,
+      true,
+    );
+
+    assert_eq!(diagnostics.len(), 1);
+    assert_diagnostic(&diagnostics[0], "ban-unused-ignore", 2, 1);
+  }
+
+  #[test]
+  fn file_directive_with_code_higher_precedence() {
+    let diagnostics = lint(
+      r#"
+ // deno-lint-ignore-file no-explicit-any
+
+ // deno-lint-ignore no-explicit-any
+ function bar(p: any) {
+   // pass
+ }
+      "#,
+      false,
+      true,
+    );
+
+    assert_eq!(diagnostics.len(), 1);
+    assert_diagnostic(&diagnostics[0], "ban-unused-ignore", 4, 1);
+  }
 }


### PR DESCRIPTION
Closes https://github.com/denoland/deno_lint/issues/255

This PR adds support for ignoring rule in whole file, by allowing `// deno-lint-ignore-file` directive to take rule codes to be ignored.