### PR TITLE
no-undef: Ignore arguments

### DIFF
--- a/src/rules/no_undef.rs
+++ b/src/rules/no_undef.rs
@@ -158,6 +158,12 @@ impl NoUndefVisitor {
       return;
     }
 
+    // Implicitly defined
+    // See: https://github.com/denoland/deno_lint/issues/317
+    if ident.sym == *"arguments" {
+      return;
+    }
+
     // Ignore top level bindings declared in the file.
     if self.declared.contains(&ident.to_id()) {
       return;

--- a/src/rules/no_undef.rs
+++ b/src/rules/no_undef.rs
@@ -292,6 +292,8 @@ mod tests {
 
     assert_lint_ok::<NoUndef>("function myFunc(...foo) {  return foo;}");
 
+    assert_lint_ok::<NoUndef>("function myFunc() { console.log(arguments); }");
+
     // TODO(kdy1): Parse as jsx
     // assert_lint_ok::<NoUndef>(
     //   "var React, App, a=1; React.render(<App attr={a} />);",


### PR DESCRIPTION
This is very naive patch but it will be enough for most users as main purpose of the lint is catching typo.
Closes #317