### PR TITLE
no-unreachable: Fix false positive of switch

### DIFF
--- a/src/control_flow/mod.rs
+++ b/src/control_flow/mod.rs
@@ -321,12 +321,15 @@ impl Visit for Analyzer<'_> {
     let prev_done = self.scope.done;
     n.visit_children_with(self);
 
+    let has_default = n.cases.iter().any(|case| case.test.is_none());
+
     // SwitchStmt finishes execution if all cases finishes execution
-    let is_done = n
-      .cases
-      .iter()
-      .map(|case| case.span.lo)
-      .all(|lo| self.is_forced_done(lo));
+    let is_done = has_default
+      && n
+        .cases
+        .iter()
+        .map(|case| case.span.lo)
+        .all(|lo| self.is_forced_done(lo));
 
     // A switch statement is finisher or not.
     if is_done {

--- a/src/rules/no_unreachable.rs
+++ b/src/rules/no_unreachable.rs
@@ -208,6 +208,26 @@ mod tests {
   }
 
   #[test]
+  fn ok_10() {
+    assert_lint_ok::<NoUnreachable>(
+      r#"
+function normalize(type: string): string | undefined {
+  switch (type) {
+    case "urlencoded":
+      return "application/x-www-form-urlencoded";
+    case "multipart":
+      return "multipart/*";
+  }
+  if (type[0] === "+") {
+    return `*/*${type}`;
+  }
+  return type.includes("/") ? type : lookup(type);
+}
+"#,
+    );
+  }
+
+  #[test]
   fn ok_break_labeled() {
     assert_lint_ok::<NoUnreachable>(
       "A: {


### PR DESCRIPTION
This pr fixes the linter by checking if there's a default case.

Fixes #318