### PR TITLE
fix(defualt-param-last): handle nested violations

### DIFF
--- a/src/rules/default_param_last.rs
+++ b/src/rules/default_param_last.rs
@@ -108,6 +108,11 @@ mod tests {
       "const f = function f() {}",
       "const f = function f(a) {}",
       "const f = function f(a = 5) {}",
+      r#"
+class Foo {
+  bar(a, b = 2) {}
+}
+      "#,
     ]);
   }
 
@@ -142,6 +147,15 @@ mod tests {
     );
     assert_lint_err_on_line::<DefaultParamLast>(
       r#"
+class Foo {
+  bar(a = 2, b) {}
+}
+      "#,
+      3,
+      6,
+    );
+    assert_lint_err_on_line::<DefaultParamLast>(
+      r#"
 function f() {
   function g(a = 5, b) {}
 }
@@ -175,6 +189,19 @@ const f = () => {
 "#,
       3,
       13,
+    );
+    assert_lint_err_on_line::<DefaultParamLast>(
+      r#"
+class Foo {
+  bar(a, b = 1) {
+    class X {
+      y(c = 3, d) {}
+    }
+  }
+}
+      "#,
+      5,
+      8,
     );
   }
 }

--- a/src/rules/default_param_last.rs
+++ b/src/rules/default_param_last.rs
@@ -1,10 +1,11 @@
 // Copyright 2020 the Deno authors. All rights reserved. MIT license.
 use super::Context;
 use super::LintRule;
-use swc_ecmascript::ast::{Function, Pat};
-use swc_ecmascript::visit::noop_visit_type;
+use swc_common::Span;
+use swc_ecmascript::ast::{ArrowExpr, Function, Pat};
 use swc_ecmascript::visit::Node;
 use swc_ecmascript::visit::Visit;
+use swc_ecmascript::visit::{self, noop_visit_type};
 
 use std::sync::Arc;
 
@@ -37,33 +38,47 @@ impl DefaultParamLastVisitor {
   fn new(context: Arc<Context>) -> Self {
     Self { context }
   }
+
+  fn report(&self, span: Span) {
+    self.context.add_diagnostic(
+      span,
+      "default-param-last",
+      "default parameters should be at last",
+    );
+  }
+
+  fn check_params<'a, 'b, I>(&'a self, params: I)
+  where
+    I: Iterator<Item = &'b Pat>,
+  {
+    let mut has_seen_normal_param = false;
+    for param in params {
+      match param {
+        Pat::Assign(pat) => {
+          if has_seen_normal_param {
+            self.report(pat.span);
+          }
+        }
+        Pat::Rest(_) => {}
+        _ => {
+          has_seen_normal_param = true;
+        }
+      }
+    }
+  }
 }
 
 impl Visit for DefaultParamLastVisitor {
   noop_visit_type!();
 
-  fn visit_function(&mut self, function: &Function, _parent: &dyn Node) {
-    let mut has_normal_param = false;
-    let pat = function
-      .params
-      .iter()
-      .rev()
-      .find_map(|param| match &param.pat {
-        Pat::Assign(pat) => Some(pat),
-        _ => {
-          has_normal_param = true;
-          None
-        }
-      });
-    if has_normal_param {
-      if let Some(pat) = pat {
-        self.context.add_diagnostic(
-          pat.span,
-          "default-param-last",
-          "default parameters should be at last",
-        );
-      }
-    }
+  fn visit_function(&mut self, function: &Function, parent: &dyn Node) {
+    self.check_params(function.params.iter().rev().map(|p| &p.pat));
+    visit::visit_function(self, function, parent);
+  }
+
+  fn visit_arrow_expr(&mut self, arrow_expr: &ArrowExpr, parent: &dyn Node) {
+    self.check_params(arrow_expr.params.iter().rev());
+    visit::visit_arrow_expr(self, arrow_expr, parent);
   }
 }
 
@@ -72,13 +87,94 @@ mod tests {
   use super::*;
   use crate::test_util::*;
 
+  // Some tests are derived from
+  // https://github.com/eslint/eslint/blob/v7.9.0/tests/lib/rules/default-param-last.js
+  // MIT Licensed.
+
   #[test]
-  fn default_param_last_test() {
-    assert_lint_err::<DefaultParamLast>("function fn(a = 2, b) {}", 12);
+  fn default_param_last_valid() {
     assert_lint_ok_n::<DefaultParamLast>(vec![
-      "function fn(a = 2, b = 3) {}",
-      "function fn(a, b = 2) {}",
+      "function f() {}",
+      "function f(a) {}",
       "function fn(a, b) {}",
+      "function f(a = 5) {}",
+      "function fn(a = 2, b = 3) {}",
+      "function f(a, b = 5) {}",
+      "function f(a, b = 5, c = 5) {}",
+      "function f(a, b = 5, ...c) {}",
+      "const f = () => {}",
+      "const f = (a) => {}",
+      "const f = (a = 5) => {}",
+      "const f = function f() {}",
+      "const f = function f(a) {}",
+      "const f = function f(a = 5) {}",
     ]);
+  }
+
+  #[test]
+  fn default_param_last_invalid() {
+    assert_lint_err::<DefaultParamLast>("function f(a = 2, b) {}", 11);
+    assert_lint_err::<DefaultParamLast>("const f = function (a = 2, b) {}", 20);
+    assert_lint_err_n::<DefaultParamLast>(
+      "function f(a = 5, b = 6, c) {}",
+      vec![18, 11],
+    );
+    assert_lint_err_n::<DefaultParamLast>(
+      "function f(a = 5, b, c = 6, d) {}",
+      vec![21, 11],
+    );
+    assert_lint_err::<DefaultParamLast>("function f(a = 5, b, c = 5) {}", 11);
+    assert_lint_err::<DefaultParamLast>("const f = (a = 5, b, ...c) => {}", 11);
+    assert_lint_err::<DefaultParamLast>(
+      "const f = function f (a, b = 5, c) {}",
+      25,
+    );
+    assert_lint_err::<DefaultParamLast>("const f = (a = 5, { b }) => {}", 11);
+    assert_lint_err::<DefaultParamLast>("const f = ({ a } = {}, b) => {}", 11);
+    assert_lint_err::<DefaultParamLast>(
+      "const f = ({ a, b } = { a: 1, b: 2 }, c) => {}",
+      11,
+    );
+    assert_lint_err::<DefaultParamLast>("const f = ([a] = [], b) => {}", 11);
+    assert_lint_err::<DefaultParamLast>(
+      "const f = ([a, b] = [1, 2], c) => {}",
+      11,
+    );
+    assert_lint_err_on_line::<DefaultParamLast>(
+      r#"
+function f() {
+  function g(a = 5, b) {}
+}
+"#,
+      3,
+      13,
+    );
+    assert_lint_err_on_line::<DefaultParamLast>(
+      r#"
+const f = () => {
+  function g(a = 5, b) {}
+}
+"#,
+      3,
+      13,
+    );
+    assert_lint_err_on_line::<DefaultParamLast>(
+      r#"
+function f() {
+  const g = (a = 5, b) => {}
+}
+"#,
+      3,
+      13,
+    );
+    assert_lint_err_on_line::<DefaultParamLast>(
+      r#"
+const f = () => {
+  const g = (a = 5, b) => {}
+}
+"#,
+      3,
+      13,
+    );
   }
 }


### PR DESCRIPTION
Just like #327, `default-param-last` doesn't handle violations in nested functions, so I've fixed it.

Moreover, it doesn't check arrow functions. Fixed it as well.