### PR TITLE
test: print source code when assertion fails

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,20 +51,17 @@ mod lint_tests {
 
   #[test]
   fn warn_unknown_rules() {
-    let diagnostics = lint(
-      r#"
+    let src = r#"
  // deno-lint-ignore some-rule
  function foo() {
    // deno-lint-ignore some-rule-2 some-rule-3
    let bar_foo = true
  }
-      "#,
-      true,
-      false,
-    );
+      "#;
+    let diagnostics = lint(src, true, false);
 
-    assert_diagnostic(&diagnostics[0], "ban-unknown-rule-code", 2, 1);
-    assert_diagnostic(&diagnostics[1], "ban-unknown-rule-code", 4, 3);
+    assert_diagnostic(&diagnostics[0], "ban-unknown-rule-code", 2, 1, src);
+    assert_diagnostic(&diagnostics[1], "ban-unknown-rule-code", 4, 3, src);
   }
 
   #[test]
@@ -85,21 +82,18 @@ mod lint_tests {
 
   #[test]
   fn warn_unused_dir() {
-    let diagnostics = lint(
-      r#"
+    let src = r#"
  // deno-lint-ignore no-explicit-any
  function bar(p: boolean) {
    // deno-lint-ignore no-misused-new eqeqeq
    let foo_bar = false
  }
-      "#,
-      false,
-      true,
-    );
+      "#;
+    let diagnostics = lint(src, false, true);
 
     assert_eq!(diagnostics.len(), 2);
-    assert_diagnostic(&diagnostics[0], "ban-unused-ignore", 2, 1);
-    assert_diagnostic(&diagnostics[1], "ban-unused-ignore", 4, 3);
+    assert_diagnostic(&diagnostics[0], "ban-unused-ignore", 2, 1, src);
+    assert_diagnostic(&diagnostics[1], "ban-unused-ignore", 4, 3, src);
   }
 
   #[test]
@@ -137,38 +131,32 @@ mod lint_tests {
 
   #[test]
   fn file_directive_with_code_unused() {
-    let diagnostics = lint(
-      r#"
+    let src = r#"
  // deno-lint-ignore-file no-explicit-any no-empty
 
  function bar(p: any) {
    // pass
  }
-      "#,
-      false,
-      true,
-    );
+      "#;
+    let diagnostics = lint(src, false, true);
 
     assert_eq!(diagnostics.len(), 1);
-    assert_diagnostic(&diagnostics[0], "ban-unused-ignore", 2, 1);
+    assert_diagnostic(&diagnostics[0], "ban-unused-ignore", 2, 1, src);
   }
 
   #[test]
   fn file_directive_with_code_higher_precedence() {
-    let diagnostics = lint(
-      r#"
+    let src = r#"
  // deno-lint-ignore-file no-explicit-any
 
  // deno-lint-ignore no-explicit-any
  function bar(p: any) {
    // pass
  }
-      "#,
-      false,
-      true,
-    );
+      "#;
+    let diagnostics = lint(src, false, true);
 
     assert_eq!(diagnostics.len(), 1);
-    assert_diagnostic(&diagnostics[0], "ban-unused-ignore", 4, 1);
+    assert_diagnostic(&diagnostics[0], "ban-unused-ignore", 4, 1, src);
   }
 }


### PR DESCRIPTION
This patch allows tests to print source code when an assertion fails. It will show us which test case has failed.

Currently, if there are many test cases in one test function and one of them fails, it's a little difficult to know which test has failed. For example, we write many assertions in one function:

```rust
  #[test]
  fn no_with() {
    assert_lint_err::<NoWith>("with (someVar) { console.log('asdf'); }", 0);
    assert_lint_err::<NoWith>("with (foo) { }", 0);
    assert_lint_err_n::<NoWith>(
      "with (bar) { with (a) { } const a = 42; }",
      vec![0, 13],
    );
    assert_lint_err::<NoWith>("with (baz) { let b = 1; }", 0);
    assert_lint_err_n::<NoWith>(
      "with (a) { with (b) { console.log('oh no'); } }",
      vec![0, 11],
    );
    assert_lint_err::<NoWith>("with (x) { console.log('alice'); }", 0);
    assert_lint_err::<NoWith>("with (p) { console.log('bob'); }", 0);
    assert_lint_err::<NoWith>("with (abc) { const a = f(); }", 0);
  }
```

and run `cargo test no_with`, then we get:

```
---- rules::no_with::tests::no_with stdout ----
thread 'rules::no_with::tests::no_with' panicked at 'assertion failed: diagnostics.len() == expected.len()', src/test_util.rs:92:3
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

failures:
    rules::no_with::tests::no_with
```

This is not good - from this output, we can't tell which assrtion fails.

However, by this patch, the output will change to:

```
---- rules::no_with::tests::no_with stdout ----
thread 'rules::no_with::tests::no_with' panicked at 'assertion failed: `(left == right)`
  left: `1`,
 right: `2`: 2 diagnostics expected, but got 1.

source:
with (bar) { with (a) { } const a = 42; }
', src/test_util.rs:103:3
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

failures:
    rules::no_with::tests::no_with
```

Seeing this result, we can easily figure out that `with (bar) { with (a) { } const a = 42; }`has failed.
This would be really useful when developing a rule and its test, so I'd be happy to have this patch merged into master.
