### PR TITLE
fix(for-direction): handle nested for loops

### DIFF
--- a/src/rules/for_direction.rs
+++ b/src/rules/for_direction.rs
@@ -171,51 +171,59 @@ mod tests {
   use crate::test_util::*;
 
   #[test]
-  fn for_direction_ok() {
-    assert_lint_ok::<ForDirection>(
-      r#"
-for(let i = 0; i < 2; i++) {}
-for(let i = 0; i <= 2; i++) {}
-for(let i = 2; i > 2; i--) {}
-for(let i = 2; i >= 0; i--) {}
-
-for(let i = 0; i < 2; i += 1) {}
-for(let i = 0; i <= 2; i += 1) {}
-for(let i = 0; i < 2; i -= -1) {}
-for(let i = 0; i <= 2; i -= -1) {}
-
-for(let i = 2; i > 2; i -= 1) {}
-for(let i = 2; i >= 0; i -= 1) {}
-for(let i = 2; i > 2; i += -1) {}
-for(let i = 2; i >= 0; i += -1) {}
-
-for(let i = 0; i < 2;) {}
-for(let i = 0; i <= 2;) {}
-for(let i = 2; i > 2;) {}
-for(let i = 2; i >= 0;) {}
-
-for(let i = 0; i < 2; i |= 2) {}
-for(let i = 0; i <= 2; i %= 2) {}
-
-for(let i = 0; i < 2; j++) {}
-for(let i = 0; i <= 2; j--) {}
-for(let i = 2; i > 2; j++) {}
-for(let i = 2; i >= 0; j--) {}
-
-for(let i = 0; i !== 10; i++) {}
-for(let i = 0; i != 10; i++) {}
-for(let i = 0; i === 0; i++) {}
-for(let i = 0; i == 0; i++) {}
-      "#,
-    );
+  fn for_direction_valid() {
+    assert_lint_ok_n::<ForDirection>(vec![
+      // ++, --
+      "for(let i = 0; i < 2; i++) {}",
+      "for(let i = 0; i < 2; ++i) {}",
+      "for(let i = 0; i <= 2; i++) {}",
+      "for(let i = 0; i <= 2; ++i) {}",
+      "for(let i = 2; i > 2; i--) {}",
+      "for(let i = 2; i > 2; --i) {}",
+      "for(let i = 2; i >= 0; i--) {}",
+      "for(let i = 2; i >= 0; --i) {}",
+      // +=, -=
+      "for(let i = 0; i < 2; i += 1) {}",
+      "for(let i = 0; i <= 2; i += 1) {}",
+      "for(let i = 0; i < 2; i -= -1) {}",
+      "for(let i = 0; i <= 2; i -= -1) {}",
+      "for(let i = 2; i > 2; i -= 1) {}",
+      "for(let i = 2; i >= 0; i -= 1) {}",
+      "for(let i = 2; i > 2; i += -1) {}",
+      "for(let i = 2; i >= 0; i += -1) {}",
+      // no update
+      "for(let i = 0; i < 2;) {}",
+      "for(let i = 0; i <= 2;) {}",
+      "for(let i = 2; i > 2;) {}",
+      "for(let i = 2; i >= 0;) {}",
+      // others
+      "for(let i = 0; i < 2; i |= 2) {}",
+      "for(let i = 0; i <= 2; i %= 2) {}",
+      "for(let i = 0; i < 2; j++) {}",
+      "for(let i = 0; i <= 2; j--) {}",
+      "for(let i = 2; i > 2; j++) {}",
+      "for(let i = 2; i >= 0; j--) {}",
+      "for(let i = 0; i !== 10; i++) {}",
+      "for(let i = 0; i != 10; i++) {}",
+      "for(let i = 0; i === 0; i++) {}",
+      "for(let i = 0; i == 0; i++) {}",
+      // nested
+      "for(let i = 0; i < 2; ++i) { for (let j = 0; j < 2; j++) {} }",
+    ]);
   }
 
   #[test]
-  fn for_direction() {
+  fn for_direction_invalid() {
+    // ++, --
     assert_lint_err::<ForDirection>("for(let i = 0; i < 2; i--) {}", 0);
+    assert_lint_err::<ForDirection>("for(let i = 0; i < 2; --i) {}", 0);
     assert_lint_err::<ForDirection>("for(let i = 0; i <= 2; i--) {}", 0);
+    assert_lint_err::<ForDirection>("for(let i = 0; i <= 2; --i) {}", 0);
     assert_lint_err::<ForDirection>("for(let i = 2; i > 2; i++) {}", 0);
+    assert_lint_err::<ForDirection>("for(let i = 2; i > 2; ++i) {}", 0);
     assert_lint_err::<ForDirection>("for(let i = 2; i >= 0; i++) {}", 0);
+    assert_lint_err::<ForDirection>("for(let i = 2; i >= 0; ++i) {}", 0);
+    // +=, -=
     assert_lint_err::<ForDirection>("for(let i = 0; i < 2; i -= 1) {}", 0);
     assert_lint_err::<ForDirection>("for(let i = 0; i <= 2; i -= 1) {}", 0);
     assert_lint_err::<ForDirection>("for(let i = 2; i > 2; i -= -1) {}", 0);
@@ -224,5 +232,15 @@ for(let i = 0; i == 0; i++) {}
     assert_lint_err::<ForDirection>("for(let i = 2; i >= 0; i += 1) {}", 0);
     assert_lint_err::<ForDirection>("for(let i = 0; i < 2; i += -1) {}", 0);
     assert_lint_err::<ForDirection>("for(let i = 0; i <= 2; i += -1) {}", 0);
+    // nested
+    assert_lint_err_on_line::<ForDirection>(
+      r#"
+for (let i = 0; i < 2; i++) {
+  for (let j = 0; j < 2; j--) {}
+}
+      "#,
+      3,
+      2,
+    );
   }
 }

--- a/src/rules/for_direction.rs
+++ b/src/rules/for_direction.rs
@@ -14,6 +14,7 @@ use swc_ecmascript::ast::UpdateOp;
 use swc_ecmascript::visit::noop_visit_type;
 use swc_ecmascript::visit::Node;
 use swc_ecmascript::visit::Visit;
+use swc_ecmascript::visit::VisitWith;
 
 use std::sync::Arc;
 
@@ -125,6 +126,8 @@ impl Visit for ForDirectionVisitor {
   noop_visit_type!();
 
   fn visit_for_stmt(&mut self, for_stmt: &ForStmt, _parent: &dyn Node) {
+    for_stmt.visit_children_with(self);
+
     if for_stmt.update.is_none() {
       return;
     }


### PR DESCRIPTION
This is a part of #330 

`for-direction` currently doesn't deal with nested for-loops. I have fixed it.