### PR TITLE
fix(no-array-constructor): handle nested stuff

### DIFF
--- a/src/rules/no_array_constructor.rs
+++ b/src/rules/no_array_constructor.rs
@@ -6,6 +6,7 @@ use swc_ecmascript::ast::{CallExpr, Expr, ExprOrSpread, ExprOrSuper, NewExpr};
 use swc_ecmascript::visit::noop_visit_type;
 use swc_ecmascript::visit::Node;
 use swc_ecmascript::visit::Visit;
+use swc_ecmascript::visit::VisitWith;
 
 use std::sync::Arc;
 
@@ -54,6 +55,7 @@ impl Visit for NoArrayConstructorVisitor {
   noop_visit_type!();
 
   fn visit_new_expr(&mut self, new_expr: &NewExpr, _parent: &dyn Node) {
+    new_expr.visit_children_with(self);
     if let Expr::Ident(ident) = &*new_expr.callee {
       let name = ident.sym.as_ref();
       if name != "Array" {
@@ -72,6 +74,7 @@ impl Visit for NoArrayConstructorVisitor {
   }
 
   fn visit_call_expr(&mut self, call_expr: &CallExpr, _parent: &dyn Node) {
+    call_expr.visit_children_with(self);
     if let ExprOrSuper::Expr(expr) = &call_expr.callee {
       if let Expr::Ident(ident) = expr.as_ref() {
         let name = ident.sym.as_ref();

--- a/src/rules/no_array_constructor.rs
+++ b/src/rules/no_array_constructor.rs
@@ -129,5 +129,26 @@ mod tests {
     assert_lint_err::<NoArrayConstructor>("new Array()", 0);
     assert_lint_err::<NoArrayConstructor>("new Array(x, y)", 0);
     assert_lint_err::<NoArrayConstructor>("new Array(0, 1, 2)", 0);
+    // nested
+    assert_lint_err_on_line::<NoArrayConstructor>(
+      r#"
+const a = new class {
+  foo() {
+    let arr = new Array();
+  }
+}();
+"#,
+      4,
+      14,
+    );
+    assert_lint_err_on_line::<NoArrayConstructor>(
+      r#"
+const a = (() => {
+  let arr = new Array();
+})();
+"#,
+      3,
+      12,
+    );
   }
 }


### PR DESCRIPTION
This is a part of #330 

This PR allows `no-array-constructor` to handle nested stuff.