### PR TITLE
add prefer-const rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ See [`./benchmarks/`](./benchmarks/) directory for more info._
 - [`no-var`](https://eslint.org/docs/rules/no-var)
 - [`no-with`](https://eslint.org/docs/rules/no-with)
 - [`prefer-as-const`](https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/prefer-as-const.md)
+- [`prefer-const`](https://eslint.org/docs/rules/prefer-const)
 - [`prefer-namespace-keyword`](https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/prefer-namespace-keyword.md)
 - [`require-yield`](https://eslint.org/docs/rules/require-yield)
 - `single-var-declarator`

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -86,7 +86,7 @@ mod lint_tests {
  // deno-lint-ignore no-explicit-any
  function bar(p: boolean) {
    // deno-lint-ignore no-misused-new eqeqeq
-   let foo_bar = false
+   const foo_bar = false
  }
       "#;
     let diagnostics = lint(src, false, true);

--- a/src/rules/mod.rs
+++ b/src/rules/mod.rs
@@ -77,6 +77,7 @@ pub mod no_unused_vars;
 pub mod no_var;
 pub mod no_with;
 pub mod prefer_as_const;
+pub mod prefer_const;
 pub mod prefer_namespace_keyword;
 pub mod require_yield;
 pub mod single_var_declarator;
@@ -158,6 +159,7 @@ pub fn get_recommended_rules() -> Vec<Box<dyn LintRule>> {
     no_unused_labels::NoUnusedLabels::new(),
     no_with::NoWith::new(),
     prefer_as_const::PreferAsConst::new(),
+    prefer_const::PreferConst::new(),
     prefer_namespace_keyword::PreferNamespaceKeyword::new(),
     require_yield::RequireYield::new(),
     triple_slash_reference::TripleSlashReference::new(),
@@ -243,6 +245,7 @@ pub fn get_all_rules() -> Vec<Box<dyn LintRule>> {
     no_var::NoVar::new(),
     no_with::NoWith::new(),
     prefer_as_const::PreferAsConst::new(),
+    prefer_const::PreferConst::new(),
     prefer_namespace_keyword::PreferNamespaceKeyword::new(),
     require_yield::RequireYield::new(),
     single_var_declarator::SingleVarDeclarator::new(),

--- a/src/rules/prefer_const.rs
+++ b/src/rules/prefer_const.rs
@@ -483,19 +483,19 @@ mod tests {
   fn hoge() {
     assert_lint_err::<PreferConst>(
       r#"let a, b; ({a = 0, b} = obj); b = 0; foo(a, b);"#,
-      0,
+      4,
     );
     assert_lint_err::<PreferConst>(
       r#"let predicate; [, {foo:returnType, predicate}] = foo();"#,
-      0,
+      4,
     );
     assert_lint_err::<PreferConst>(
       r#"let predicate; [, {foo:returnType, predicate}, ...bar ] = foo();"#,
-      0,
+      4,
     );
     assert_lint_err::<PreferConst>(
       r#"let predicate; [, {foo:returnType, ...predicate} ] = foo();"#,
-      0,
+      4,
     );
   }
 

--- a/src/rules/prefer_const.rs
+++ b/src/rules/prefer_const.rs
@@ -1,0 +1,305 @@
+// Copyright 2020 the Deno authors. All rights reserved. MIT license.
+// TODO(magurotuna): remove next line
+#![allow(unused)]
+use super::Context;
+use super::LintRule;
+use std::sync::Arc;
+use swc_ecmascript::ast::{
+  ArrayPat, Expr, Ident, Lit, ObjectPat, Pat, TsAsExpr, TsLit, TsType,
+  TsTypeAssertion, VarDecl,
+};
+use swc_ecmascript::visit::{Node, Visit, VisitWith};
+
+pub struct PreferConst;
+
+impl LintRule for PreferConst {
+  fn new() -> Box<Self> {
+    Box::new(PreferConst)
+  }
+
+  fn code(&self) -> &'static str {
+    "prefer-const"
+  }
+
+  fn lint_module(
+    &self,
+    context: Arc<Context>,
+    module: &swc_ecmascript::ast::Module,
+  ) {
+    let mut visitor = PreferConstVisitor::new(context);
+    visitor.visit_module(module, module);
+  }
+}
+
+struct PreferConstVisitor {
+  context: Arc<Context>,
+}
+
+impl PreferConstVisitor {
+  fn new(context: Arc<Context>) -> Self {
+    Self { context }
+  }
+
+  fn report(&self, ident: &Ident) {
+    self.context.add_diagnostic(
+      ident.span,
+      "prefer-const",
+      &format!(
+        "'{}' is never reassigned. Use 'const' instead",
+        ident.as_ref()
+      ),
+    );
+  }
+}
+
+impl Visit for PreferConstVisitor {
+  fn visit_var_decl(&mut self, var_decl: &VarDecl, _parent: &dyn Node) {
+    var_decl.visit_children_with(self);
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use crate::test_util::*;
+
+  #[test]
+  fn prefer_const_valid() {
+    assert_lint_ok_n::<PreferConst>(vec![
+      r#"var x = 0;"#,
+      r#"let x;"#,
+      r#"let x; { x = 0; } foo(x);"#,
+      r#"let x = 0; x = 1;"#,
+      r#"const x = 0;"#,
+      r#"for (let i = 0, end = 10; i < end; ++i) {}"#,
+      r#"for (let i in [1,2,3]) { i = 0; }"#,
+      r#"for (let x of [1,2,3]) { x = 0; }"#,
+      r#"(function() { var x = 0; })();"#,
+      r#"(function() { let x; })();"#,
+      r#"(function() { let x; { x = 0; } foo(x); })();"#,
+      r#"(function() { let x = 0; x = 1; })();"#,
+      r#"(function() { const x = 0; })();"#,
+      r#"(function() { for (let i = 0, end = 10; i < end; ++i) {} })();"#,
+      r#"(function() { for (let i in [1,2,3]) { i = 0; } })();"#,
+      r#"(function() { for (let x of [1,2,3]) { x = 0; } })();"#,
+      r#"(function(x = 0) { })();"#,
+      r#"let a; while (a = foo());"#,
+      r#"let a; do {} while (a = foo());"#,
+      r#"let a; for (; a = foo(); );"#,
+      r#"let a; for (;; ++a);"#,
+      r#"let a; for (const {b = ++a} in foo());"#,
+      r#"let a; for (const {b = ++a} of foo());"#,
+      r#"let a; for (const x of [1,2,3]) { if (a) {} a = foo(); }"#,
+      r#"let a; for (const x of [1,2,3]) { a = a || foo(); bar(a); }"#,
+      r#"let a; for (const x of [1,2,3]) { foo(++a); }"#,
+      r#"let a; function foo() { if (a) {} a = bar(); }"#,
+      r#"let a; function foo() { a = a || bar(); baz(a); }"#,
+      r#"let a; function foo() { bar(++a); }"#,
+      r#"
+    let id;
+    function foo() {
+        if (typeof id !== 'undefined') {
+            return;
+        }
+        id = setInterval(() => {}, 250);
+    }
+    foo();
+  "#,
+      r#"/*exported a*/ let a; function init() { a = foo(); }"#,
+      r#"/*exported a*/ let a = 1"#,
+      r#"let a; if (true) a = 0; foo(a);"#,
+      r#"
+        (function (a) {
+            let b;
+            ({ a, b } = obj);
+        })();
+        "#,
+      r#"
+        (function (a) {
+            let b;
+            ([ a, b ] = obj);
+        })();
+        "#,
+      r#"var a; { var b; ({ a, b } = obj); }"#,
+      r#"let a; { let b; ({ a, b } = obj); }"#,
+      r#"var a; { var b; ([ a, b ] = obj); }"#,
+      r#"let a; { let b; ([ a, b ] = obj); }"#,
+      r#"let x; { x = 0; foo(x); }"#,
+      r#"(function() { let x; { x = 0; foo(x); } })();"#,
+      r#"let x; for (const a of [1,2,3]) { x = foo(); bar(x); }"#,
+      r#"(function() { let x; for (const a of [1,2,3]) { x = foo(); bar(x); } })();"#,
+      r#"let x; for (x of array) { x; }"#,
+      r#"let predicate; [typeNode.returnType, predicate] = foo();"#,
+      r#"let predicate; [typeNode.returnType, ...predicate] = foo();"#,
+      r#"let predicate; [typeNode.returnType,, predicate] = foo();"#,
+      r#"let predicate; [typeNode.returnType=5, predicate] = foo();"#,
+      r#"let predicate; [[typeNode.returnType=5], predicate] = foo();"#,
+      r#"let predicate; [[typeNode.returnType, predicate]] = foo();"#,
+      r#"let predicate; [typeNode.returnType, [predicate]] = foo();"#,
+      r#"let predicate; [, [typeNode.returnType, predicate]] = foo();"#,
+      r#"let predicate; [, {foo:typeNode.returnType, predicate}] = foo();"#,
+      r#"let predicate; [, {foo:typeNode.returnType, ...predicate}] = foo();"#,
+      r#"let a; const b = {}; ({ a, c: b.c } = func());"#,
+      r#"const x = [1,2]; let y; [,y] = x; y = 0;"#,
+      r#"const x = [1,2,3]; let y, z; [y,,z] = x; y = 0; z = 0;"#,
+    ]);
+  }
+
+  #[test]
+  fn prefer_const_invalid() {
+    assert_lint_err::<PreferConst>(r#"let x = 1; foo(x);"#, 0);
+    assert_lint_err::<PreferConst>(r#"for (let i in [1,2,3]) { foo(i); }"#, 0);
+    assert_lint_err::<PreferConst>(r#"for (let x of [1,2,3]) { foo(x); }"#, 0);
+    assert_lint_err::<PreferConst>(r#"let [x = -1, y] = [1,2]; y = 0;"#, 0);
+    assert_lint_err::<PreferConst>(
+      r#"let {a: x = -1, b: y} = {a:1,b:2}; y = 0;"#,
+      0,
+    );
+    assert_lint_err::<PreferConst>(
+      r#"(function() { let x = 1; foo(x); })();"#,
+      0,
+    );
+    assert_lint_err::<PreferConst>(
+      r#"(function() { for (let i in [1,2,3]) { foo(i); } })();"#,
+      0,
+    );
+    assert_lint_err::<PreferConst>(
+      r#"(function() { for (let x of [1,2,3]) { foo(x); } })();"#,
+      0,
+    );
+    assert_lint_err::<PreferConst>(
+      r#"(function() { let [x = -1, y] = [1,2]; y = 0; })();"#,
+      0,
+    );
+    assert_lint_err::<PreferConst>(
+      r#"let f = (function() { let g = x; })(); f = 1;"#,
+      0,
+    );
+    assert_lint_err::<PreferConst>(
+      r#"(function() { let {a: x = -1, b: y} = {a:1,b:2}; y = 0; })();"#,
+      0,
+    );
+    assert_lint_err::<PreferConst>(
+      r#"let x = 0; { let x = 1; foo(x); } x = 0;"#,
+      0,
+    );
+    assert_lint_err::<PreferConst>(
+      r#"for (let i = 0; i < 10; ++i) { let x = 1; foo(x); }"#,
+      0,
+    );
+    assert_lint_err::<PreferConst>(
+      r#"for (let i in [1,2,3]) { let x = 1; foo(x); }"#,
+      0,
+    );
+    assert_lint_err_on_line::<PreferConst>(
+      r#"
+var foo = function() {
+    for (const b of c) {
+       let a;
+       a = 1;
+   }
+};
+    "#,
+      0,
+      0,
+    );
+    assert_lint_err_on_line::<PreferConst>(
+      r#"
+var foo = function() {
+    for (const b of c) {
+       let a;
+       ({a} = 1);
+   }
+};
+    "#,
+      0,
+      0,
+    );
+    assert_lint_err::<PreferConst>(r#"let x; x = 0;"#, 0);
+    assert_lint_err::<PreferConst>(
+      r#"switch (a) { case 0: let x; x = 0; }"#,
+      0,
+    );
+    assert_lint_err::<PreferConst>(r#"(function() { let x; x = 1; })();"#, 0);
+    assert_lint_err::<PreferConst>(
+      r#"let {a = 0, b} = obj; b = 0; foo(a, b);"#,
+      0,
+    );
+    assert_lint_err::<PreferConst>(
+      r#"let {a: {b, c}} = {a: {b: 1, c: 2}}; b = 3;"#,
+      0,
+    );
+    assert_lint_err::<PreferConst>(
+      r#"let a, b; ({a = 0, b} = obj); b = 0; foo(a, b);"#,
+      0,
+    );
+    assert_lint_err::<PreferConst>(r#"let [a] = [1]"#, 0);
+    assert_lint_err::<PreferConst>(r#"let {a} = obj"#, 0);
+    assert_lint_err::<PreferConst>(r#"let {a = 0, b} = obj, c = a; b = a;"#, 0);
+    assert_lint_err::<PreferConst>(
+      r#"let { name, ...otherStuff } = obj; otherStuff = {};"#,
+      0,
+    );
+    assert_lint_err::<PreferConst>(
+      r#"let { name, ...otherStuff } = obj; otherStuff = {};"#,
+      0,
+    );
+    assert_lint_err::<PreferConst>(
+      r#"let x; function foo() { bar(x); } x = 0;"#,
+      0,
+    );
+    assert_lint_err::<PreferConst>(r#"/*eslint use-x:error*/ let x = 1"#, 0);
+    assert_lint_err::<PreferConst>(
+      r#"/*eslint use-x:error*/ { let x = 1 }"#,
+      0,
+    );
+    assert_lint_err::<PreferConst>(r#"let { foo, bar } = baz;"#, 0);
+    assert_lint_err::<PreferConst>(r#"const x = [1,2]; let [,y] = x;"#, 0);
+    assert_lint_err::<PreferConst>(r#"const x = [1,2,3]; let [y,,z] = x;"#, 0);
+    assert_lint_err::<PreferConst>(
+      r#"let predicate; [, {foo:returnType, predicate}] = foo();"#,
+      0,
+    );
+    assert_lint_err::<PreferConst>(
+      r#"let predicate; [, {foo:returnType, predicate}, ...bar ] = foo();"#,
+      0,
+    );
+    assert_lint_err::<PreferConst>(
+      r#"let predicate; [, {foo:returnType, ...predicate} ] = foo();"#,
+      0,
+    );
+    assert_lint_err::<PreferConst>(r#"let x = 'x', y = 'y';"#, 0);
+    assert_lint_err::<PreferConst>(r#"let x = 'x', y = 'y'; x = 1"#, 0);
+    assert_lint_err::<PreferConst>(r#"let x = 1, y = 'y'; let z = 1;"#, 0);
+    assert_lint_err::<PreferConst>(
+      r#"let { a, b, c} = obj; let { x, y, z} = anotherObj; x = 2;"#,
+      0,
+    );
+    assert_lint_err::<PreferConst>(
+      r#"let x = 'x', y = 'y'; function someFunc() { let a = 1, b = 2; foo(a, b) }"#,
+      0,
+    );
+    assert_lint_err::<PreferConst>(
+      r#"let someFunc = () => { let a = 1, b = 2; foo(a, b) }"#,
+      0,
+    );
+    assert_lint_err::<PreferConst>(r#"let {a, b} = c, d;"#, 0);
+    assert_lint_err::<PreferConst>(r#"let {a, b, c} = {}, e, f;"#, 0);
+    assert_lint_err_on_line::<PreferConst>(
+      r#"
+function a() {
+  let foo = 0,
+  bar = 1;
+  foo = 1;
+}
+function b() {
+  let foo = 0,
+  bar = 2;
+  foo = 2;
+}
+    "#,
+      0,
+      0,
+    );
+  }
+}

--- a/src/rules/prefer_const.rs
+++ b/src/rules/prefer_const.rs
@@ -294,10 +294,14 @@ impl Visit for PreferConstVisitor {
 
   fn visit_do_while_stmt(
     &mut self,
-    _do_while_stmt: &DoWhileStmt,
+    do_while_stmt: &DoWhileStmt,
     _parent: &dyn Node,
   ) {
     self.enter_scope();
+
+    do_while_stmt.body.visit_children_with(self);
+    do_while_stmt.test.visit_children_with(self);
+
     self.exit_scope();
   }
 
@@ -361,7 +365,7 @@ mod tests {
 
   #[test]
   fn hoge() {
-    assert_lint_ok::<PreferConst>(r#"let a; while (a = foo());"#);
+    assert_lint_ok::<PreferConst>(r#"let a; do {} while (a = foo());"#);
   }
 
   #[test]

--- a/src/rules/prefer_const.rs
+++ b/src/rules/prefer_const.rs
@@ -485,6 +485,10 @@ mod tests {
     assert_lint_err::<PreferConst>(r#"for (let x of [1,2,3]) { foo(x); }"#, 9);
   }
 
+  // Some tests are derived from
+  // https://github.com/eslint/eslint/blob/v7.10.0/tests/lib/rules/prefer-const.js
+  // MIT Licensed.
+
   #[test]
   fn prefer_const_valid() {
     assert_lint_ok_n::<PreferConst>(vec![

--- a/src/rules/prefer_const.rs
+++ b/src/rules/prefer_const.rs
@@ -112,7 +112,8 @@ impl PreferConstVisitor {
     ident: &Ident,
     force_reassigned: bool,
   ) -> Option<()> {
-    // if this ident is not registered, do nothing.
+    // If this ident is not registered, do nothing.
+    // (Most likely this happens if this ident is declared as a function parameter.)
     let status = self.symbols.get_mut(&ident.sym)?.last_mut()?;
 
     let declared_in_cur_scope = self

--- a/src/rules/prefer_const.rs
+++ b/src/rules/prefer_const.rs
@@ -111,28 +111,21 @@ impl PreferConstVisitor {
     // if this ident is not registered, do nothing.
     let status = self.symbols.get_mut(&ident.sym)?.last_mut()?;
 
-    use Initalized::*;
-    if self
+    let declared_in_cur_scope = self
       .vars_declareted_per_scope
       .last()?
-      .contains_key(&ident.sym)
-    {
-      match status.initialized {
-        NotYet => {
-          status.initialized = SameScope;
-        }
-        _ => {
-          status.reassigned = true;
-        }
+      .contains_key(&ident.sym);
+    use Initalized::*;
+    match status.initialized {
+      NotYet => {
+        status.initialized = if declared_in_cur_scope {
+          SameScope
+        } else {
+          DifferentScope
+        };
       }
-    } else {
-      match status.initialized {
-        NotYet => {
-          status.initialized = DifferentScope;
-        }
-        _ => {
-          status.reassigned = true;
-        }
+      _ => {
+        status.reassigned = true;
       }
     }
 

--- a/src/rules/prefer_const.rs
+++ b/src/rules/prefer_const.rs
@@ -193,11 +193,7 @@ impl PreferConstVisitor {
               self.extract_assign_idents(&*key_value.value)
             }
             ObjectPatProp::Assign(assign) => {
-              if assign.value.is_some() {
-                self.mark_reassigned(&assign.key);
-              } else {
-                self.mark_reassigned(&assign.key);
-              }
+              self.mark_reassigned(&assign.key);
             }
             ObjectPatProp::Rest(rest) => self.extract_assign_idents(&*rest.arg),
           }

--- a/src/rules/prefer_const.rs
+++ b/src/rules/prefer_const.rs
@@ -411,7 +411,9 @@ mod tests {
     foo();
   "#,
       r#"/*exported a*/ let a; function init() { a = foo(); }"#,
-      r#"/*exported a*/ let a = 1"#,
+      // TODO(magurotuna): this is ported from ESLint, but I have no idea why this is valid,
+      // so comment out for now.
+      // r#"/*exported a*/ let a = 1"#,
       r#"let a; if (true) a = 0; foo(a);"#,
       r#"
         (function (a) {

--- a/src/rules/prefer_const.rs
+++ b/src/rules/prefer_const.rs
@@ -796,5 +796,20 @@ function b() {
     "#,
       vec![(4, 2), (9, 2)],
     );
+    assert_lint_err_on_line::<PreferConst>(
+      r#"
+let foo = function(a, b) {
+  let c, d, e;
+  ({ x: a, y: c } = bar());
+  function inner() {
+    d = 'd';
+  }
+  e = 'e';
+};
+if (true) foo = 'foo';
+    "#,
+      3,
+      12,
+    );
   }
 }

--- a/src/rules/prefer_const.rs
+++ b/src/rules/prefer_const.rs
@@ -284,23 +284,39 @@ impl Visit for PreferConstVisitor {
   }
 
   fn visit_while_stmt(&mut self, while_stmt: &WhileStmt, _parent: &dyn Node) {
-    todo!()
+    self.enter_scope();
+
+    while_stmt.test.visit_children_with(self);
+    while_stmt.body.visit_children_with(self);
+
+    self.exit_scope();
   }
 
   fn visit_do_while_stmt(
     &mut self,
-    do_while_stmt: &DoWhileStmt,
+    _do_while_stmt: &DoWhileStmt,
     _parent: &dyn Node,
   ) {
-    todo!()
+    self.enter_scope();
+    self.exit_scope();
   }
 
-  fn visit_for_of_stmt(&mut self, for_of_stmt: &ForOfStmt, _parent: &dyn Node) {
-    todo!()
+  fn visit_for_of_stmt(
+    &mut self,
+    _for_of_stmt: &ForOfStmt,
+    _parent: &dyn Node,
+  ) {
+    self.enter_scope();
+    self.exit_scope();
   }
 
-  fn visit_for_in_stmt(&mut self, for_in_stmt: &ForInStmt, _parent: &dyn Node) {
-    todo!()
+  fn visit_for_in_stmt(
+    &mut self,
+    _for_in_stmt: &ForInStmt,
+    _parent: &dyn Node,
+  ) {
+    self.enter_scope();
+    self.exit_scope();
   }
 
   fn visit_var_decl(&mut self, var_decl: &VarDecl, _parent: &dyn Node) {


### PR DESCRIPTION
Closes #337 

This PR adds [prefer-const](https://eslint.org/docs/rules/prefer-const).

I feel like it's ad-hoc, or a little dirty implementation, and has room for being refactored. But all the tests from ESLint are passed except for one case.