### PR TITLE
fix(no-case-declarations): handle nested switch statements

### DIFF
--- a/src/rules/no_case_declarations.rs
+++ b/src/rules/no_case_declarations.rs
@@ -76,8 +76,9 @@ impl Visit for NoCaseDeclarationsVisitor {
 mod tests {
   use super::*;
   use crate::test_util::*;
+
   #[test]
-  fn no_case_declarations_ok() {
+  fn no_case_declarations_valid() {
     assert_lint_ok::<NoCaseDeclarations>(
       r#"
 switch (foo) {
@@ -111,7 +112,7 @@ switch (foo) {
   }
 
   #[test]
-  fn no_case_declarations() {
+  fn no_case_declarations_invalid() {
     assert_lint_err_on_line::<NoCaseDeclarations>(
       r#"
 switch (foo) {

--- a/src/rules/no_case_declarations.rs
+++ b/src/rules/no_case_declarations.rs
@@ -172,8 +172,34 @@ switch (fncase) {
     );
     assert_lint_err_on_line::<NoCaseDeclarations>(
       r#"
+switch (fncase) {
+  default:
+    function fn() {
+
+    }
+    break;
+}
+    "#,
+      3,
+      2,
+    );
+    assert_lint_err_on_line::<NoCaseDeclarations>(
+      r#"
 switch (classcase) {
   case 1:
+    class Cl {
+      
+    }
+    break;
+}
+    "#,
+      3,
+      2,
+    );
+    assert_lint_err_on_line::<NoCaseDeclarations>(
+      r#"
+switch (classcase) {
+  default:
     class Cl {
       
     }


### PR DESCRIPTION
This is a part of #330 

Make it handles nested `switch` statements.