### PR TITLE
fix(prefer-const): refactor & handle hoisting

### DIFF
--- a/src/rules/prefer_const.rs
+++ b/src/rules/prefer_const.rs
@@ -182,20 +182,16 @@ impl Visit for VariableCollector {
   fn visit_function(&mut self, function: &Function, _: &dyn Node) {
     self.with_child_scope(function.span, |a| {
       for param in &function.params {
-        param.visit_with(function, a);
+        param.visit_children_with(a);
+        let idents: Vec<Ident> = find_ids(&param.pat);
+        for ident in idents {
+          a.insert_var(&ident, true, false, true);
+        }
       }
       if let Some(body) = &function.body {
         body.visit_children_with(a);
       }
     });
-  }
-
-  fn visit_param(&mut self, param: &Param, _: &dyn Node) {
-    param.visit_children_with(self);
-    let idents: Vec<Ident> = find_ids(&param.pat);
-    for ident in idents {
-      self.insert_var(&ident, true, false, true);
-    }
   }
 
   fn visit_block_stmt(&mut self, block_stmt: &BlockStmt, _: &dyn Node) {

--- a/src/rules/prefer_const.rs
+++ b/src/rules/prefer_const.rs
@@ -707,6 +707,25 @@ let global2 = 42;
   }
 
   #[test]
+  fn collector_works_for_3() {
+    let src = r#"
+let global1 = 0;
+for (global1 = 0; global1 < 10; ++global1) foo();
+let global2 = 42;
+    "#;
+    let v = collect(src);
+    let mut scope_iter = v.scopes.values();
+
+    let global_vars = variables(scope_iter.next().unwrap());
+    assert_eq!(vec!["global1", "global2"], global_vars);
+
+    let for_vars = variables(scope_iter.next().unwrap());
+    assert!(for_vars.is_empty());
+
+    assert!(scope_iter.next().is_none());
+  }
+
+  #[test]
   fn collector_works_for_of_1() {
     let src = r#"
 let global1;

--- a/src/rules/prefer_const.rs
+++ b/src/rules/prefer_const.rs
@@ -690,6 +690,39 @@ let global2 = 42;
 
     assert!(scope_iter.next().is_none());
   }
+
+  #[test]
+  fn collector_works_complex_1() {
+    let src = r#"
+let global1;
+function foo({ p1 = 0 }) {
+  while (cond) {
+    let while1 = true;
+    if (while1) {
+      break;
+    }
+    let [while2, { while3, key: while4 = 4 }] = bar();
+  }
+}
+let global2 = 42;
+    "#;
+    let v = collect(src);
+    let mut scope_iter = v.scopes.values();
+
+    let global_vars = variables(scope_iter.next().unwrap());
+    assert_eq!(vec!["global1", "global2"], global_vars);
+
+    let function_vars = variables(scope_iter.next().unwrap());
+    assert_eq!(vec!["p1"], function_vars);
+
+    let while_vars = variables(scope_iter.next().unwrap());
+    assert_eq!(vec!["while1", "while2", "while3", "while4"], while_vars);
+
+    let if_vars = variables(scope_iter.next().unwrap());
+    assert!(if_vars.is_empty());
+
+    assert!(scope_iter.next().is_none());
+  }
 }
 
 #[derive(PartialEq, Debug)]

--- a/src/rules/prefer_const.rs
+++ b/src/rules/prefer_const.rs
@@ -664,7 +664,6 @@ else baz();
 let global2 = 42;
     "#;
     let v = collect(src);
-    //dbg!(&v.scopes);
     let mut scope_iter = v.scopes.values();
 
     let global_vars = variables(scope_iter.next().unwrap());
@@ -1433,96 +1432,164 @@ mod tests {
 
   #[test]
   fn prefer_const_valid() {
-    assert_lint_ok_n::<PreferConst>(vec![
-      r#"var x = 0;"#,
-      r#"let x;"#,
-      r#"let x = 0; x += 1;"#,
-      r#"let x = 0; x -= 1;"#,
-      r#"let x = 0; x++;"#,
-      r#"let x = 0; ++x;"#,
-      r#"let x = 0; x--;"#,
-      r#"let x = 0; --x;"#,
-      r#"let x; { x = 0; } foo(x);"#,
-      r#"let x = 0; x = 1;"#,
-      r#"const x = 0;"#,
+    assert_lint_ok::<PreferConst>(r#"var x = 0;"#);
+    assert_lint_ok::<PreferConst>(r#"let x;"#);
+    assert_lint_ok::<PreferConst>(r#"let x = 0; x += 1;"#);
+    assert_lint_ok::<PreferConst>(r#"let x = 0; x -= 1;"#);
+    assert_lint_ok::<PreferConst>(r#"let x = 0; x++;"#);
+    assert_lint_ok::<PreferConst>(r#"let x = 0; ++x;"#);
+    assert_lint_ok::<PreferConst>(r#"let x = 0; x--;"#);
+    assert_lint_ok::<PreferConst>(r#"let x = 0; --x;"#);
+    assert_lint_ok::<PreferConst>(r#"let x; { x = 0; } foo(x);"#);
+    assert_lint_ok::<PreferConst>(r#"let x = 0; x = 1;"#);
+    assert_lint_ok::<PreferConst>(r#"const x = 0;"#);
+    assert_lint_ok::<PreferConst>(
       r#"for (let i = 0, end = 10; i < end; ++i) {}"#,
+    );
+    assert_lint_ok::<PreferConst>(
       r#"for (let i = 0, end = 10; i < end; i += 2) {}"#,
-      r#"for (let i in [1,2,3]) { i = 0; }"#,
-      r#"for (let x of [1,2,3]) { x = 0; }"#,
-      r#"(function() { var x = 0; })();"#,
-      r#"(function() { let x; })();"#,
+    );
+    assert_lint_ok::<PreferConst>(r#"for (let i in [1,2,3]) { i = 0; }"#);
+    assert_lint_ok::<PreferConst>(r#"for (let x of [1,2,3]) { x = 0; }"#);
+    assert_lint_ok::<PreferConst>(r#"(function() { var x = 0; })();"#);
+    assert_lint_ok::<PreferConst>(r#"(function() { let x; })();"#);
+    assert_lint_ok::<PreferConst>(
       r#"(function() { let x; { x = 0; } foo(x); })();"#,
-      r#"(function() { let x = 0; x = 1; })();"#,
-      r#"(function() { const x = 0; })();"#,
+    );
+    assert_lint_ok::<PreferConst>(r#"(function() { let x = 0; x = 1; })();"#);
+    assert_lint_ok::<PreferConst>(r#"(function() { const x = 0; })();"#);
+    assert_lint_ok::<PreferConst>(
       r#"(function() { for (let i = 0, end = 10; i < end; ++i) {} })();"#,
+    );
+    assert_lint_ok::<PreferConst>(
       r#"(function() { for (let i in [1,2,3]) { i = 0; } })();"#,
+    );
+    assert_lint_ok::<PreferConst>(
       r#"(function() { for (let x of [1,2,3]) { x = 0; } })();"#,
-      r#"(function(x = 0) { })();"#,
-      r#"let a; while (a = foo());"#,
-      r#"let a; do {} while (a = foo());"#,
-      r#"let a; for (; a = foo(); );"#,
-      r#"let a; for (;; ++a);"#,
-      r#"let a; for (const {b = ++a} in foo());"#,
-      r#"let a; for (const {b = ++a} of foo());"#,
+    );
+    assert_lint_ok::<PreferConst>(r#"(function(x = 0) { })();"#);
+    assert_lint_ok::<PreferConst>(r#"let a; while (a = foo());"#);
+    assert_lint_ok::<PreferConst>(r#"let a; do {} while (a = foo());"#);
+    assert_lint_ok::<PreferConst>(r#"let a; for (; a = foo(); );"#);
+    assert_lint_ok::<PreferConst>(r#"let a; for (;; ++a);"#);
+    assert_lint_ok::<PreferConst>(r#"let a; for (const {b = ++a} in foo());"#);
+    assert_lint_ok::<PreferConst>(r#"let a; for (const {b = ++a} of foo());"#);
+    assert_lint_ok::<PreferConst>(
       r#"let a; for (const x of [1,2,3]) { if (a) {} a = foo(); }"#,
+    );
+    assert_lint_ok::<PreferConst>(
       r#"let a; for (const x of [1,2,3]) { a = a || foo(); bar(a); }"#,
+    );
+    assert_lint_ok::<PreferConst>(
       r#"let a; for (const x of [1,2,3]) { foo(++a); }"#,
+    );
+    assert_lint_ok::<PreferConst>(
       r#"let a; function foo() { if (a) {} a = bar(); }"#,
+    );
+    assert_lint_ok::<PreferConst>(
       r#"let a; function foo() { a = a || bar(); baz(a); }"#,
-      r#"let a; function foo() { bar(++a); }"#,
+    );
+    assert_lint_ok::<PreferConst>(r#"let a; function foo() { bar(++a); }"#);
+    assert_lint_ok::<PreferConst>(
       r#"
-    let id;
-    function foo() {
-        if (typeof id !== 'undefined') {
-            return;
-        }
-        id = setInterval(() => {}, 250);
-    }
-    foo();
-  "#,
-      r#"let a; function init() { a = foo(); }"#,
-      r#"let a; if (true) a = 0; foo(a);"#,
+      let id;
+      function foo() {
+          if (typeof id !== 'undefined') {
+              return;
+          }
+          id = setInterval(() => {}, 250);
+      }
+      foo();
+      "#,
+    );
+    assert_lint_ok::<PreferConst>(r#"let a; function init() { a = foo(); }"#);
+    assert_lint_ok::<PreferConst>(r#"let a; if (true) a = 0; foo(a);"#);
+    assert_lint_ok::<PreferConst>(
       r#"
         (function (a) {
             let b;
             ({ a, b } = obj);
         })();
         "#,
+    );
+    assert_lint_ok::<PreferConst>(
       r#"
         (function (a) {
             let b;
             ([ a, b ] = obj);
         })();
         "#,
-      r#"var a; { var b; ({ a, b } = obj); }"#,
-      r#"let a; { let b; ({ a, b } = obj); }"#,
-      r#"var a; { var b; ([ a, b ] = obj); }"#,
-      r#"let a; { let b; ([ a, b ] = obj); }"#,
-      r#"let x; { x = 0; foo(x); }"#,
+    );
+    assert_lint_ok::<PreferConst>(r#"var a; { var b; ({ a, b } = obj); }"#);
+    assert_lint_ok::<PreferConst>(r#"let a; { let b; ({ a, b } = obj); }"#);
+    assert_lint_ok::<PreferConst>(r#"var a; { var b; ([ a, b ] = obj); }"#);
+    assert_lint_ok::<PreferConst>(r#"let a; { let b; ([ a, b ] = obj); }"#);
+    assert_lint_ok::<PreferConst>(r#"let x; { x = 0; foo(x); }"#);
+    assert_lint_ok::<PreferConst>(
       r#"(function() { let x; { x = 0; foo(x); } })();"#,
+    );
+    assert_lint_ok::<PreferConst>(
       r#"let x; for (const a of [1,2,3]) { x = foo(); bar(x); }"#,
+    );
+    assert_lint_ok::<PreferConst>(
       r#"(function() { let x; for (const a of [1,2,3]) { x = foo(); bar(x); } })();"#,
-      r#"let x; for (x of array) { x; }"#,
+    );
+    assert_lint_ok::<PreferConst>(r#"let x; for (x of array) { x; }"#);
+    assert_lint_ok::<PreferConst>(
       r#"let predicate; [typeNode.returnType, predicate] = foo();"#,
+    );
+    assert_lint_ok::<PreferConst>(
       r#"let predicate; [typeNode.returnType, ...predicate] = foo();"#,
+    );
+    assert_lint_ok::<PreferConst>(
       r#"let predicate; [typeNode.returnType,, predicate] = foo();"#,
+    );
+    assert_lint_ok::<PreferConst>(
       r#"let predicate; [typeNode.returnType=5, predicate] = foo();"#,
+    );
+    assert_lint_ok::<PreferConst>(
       r#"let predicate; [[typeNode.returnType=5], predicate] = foo();"#,
+    );
+    assert_lint_ok::<PreferConst>(
       r#"let predicate; [[typeNode.returnType, predicate]] = foo();"#,
+    );
+    assert_lint_ok::<PreferConst>(
       r#"let predicate; [typeNode.returnType, [predicate]] = foo();"#,
+    );
+    assert_lint_ok::<PreferConst>(
       r#"let predicate; [, [typeNode.returnType, predicate]] = foo();"#,
+    );
+    assert_lint_ok::<PreferConst>(
       r#"let predicate; [, {foo:typeNode.returnType, predicate}] = foo();"#,
+    );
+    assert_lint_ok::<PreferConst>(
       r#"let predicate; [, {foo:typeNode.returnType, ...predicate}] = foo();"#,
+    );
+    assert_lint_ok::<PreferConst>(
       r#"let a; const b = {}; ({ a, c: b.c } = func());"#,
+    );
+    assert_lint_ok::<PreferConst>(
       r#"const x = [1,2]; let y; [,y] = x; y = 0;"#,
+    );
+    assert_lint_ok::<PreferConst>(
       r#"const x = [1,2,3]; let y, z; [y,,z] = x; y = 0; z = 0;"#,
-      r#"try { foo(); } catch (e) {}"#,
+    );
+    assert_lint_ok::<PreferConst>(r#"try { foo(); } catch (e) {}"#);
+    assert_lint_ok::<PreferConst>(
       r#"let a; try { foo(); a = 1; } catch (e) {}"#,
+    );
+    assert_lint_ok::<PreferConst>(
       r#"let a; try { foo(); } catch (e) { a = 1; }"#,
-      // https://github.com/denoland/deno_lint/issues/358
+    );
+
+    // https://github.com/denoland/deno_lint/issues/358
+    assert_lint_ok::<PreferConst>(
       r#"let a; const b = (a = foo === bar || baz === qux);"#,
-      r#"let i = 0; b[i++] = 0;"#,
-      // hoisting
+    );
+    assert_lint_ok::<PreferConst>(r#"let i = 0; b[i++] = 0;"#);
+
+    // hoisting
+    assert_lint_ok::<PreferConst>(
       r#"
       function foo() {
         a += 1;
@@ -1530,6 +1597,8 @@ mod tests {
       let a = 1;
       foo();
       "#,
+    );
+    assert_lint_ok::<PreferConst>(
       r#"
       let a = 1;
       function foo() {
@@ -1544,7 +1613,14 @@ mod tests {
       a *= 2;
       console.log(a); // 2
       "#,
-    ]);
+    );
+
+    // https://github.com/denoland/deno_lint/issues/358#issuecomment-703587510
+    assert_lint_ok::<PreferConst>(r#"let a = 0; for (a in [1, 2, 3]) foo(a);"#);
+    assert_lint_ok::<PreferConst>(r#"let a = 0; for (a of [1, 2, 3]) foo(a);"#);
+    assert_lint_ok::<PreferConst>(
+      r#"let a = 0; for (a = 0; a < 10; a++) foo(a);"#,
+    );
   }
 
   #[test]

--- a/src/rules/prefer_const.rs
+++ b/src/rules/prefer_const.rs
@@ -722,6 +722,14 @@ mod tests {
       // https://github.com/denoland/deno_lint/issues/358
       r#"let a; const b = (a = foo === bar || baz === qux);"#,
       r#"let i = 0; b[i++] = 0;"#,
+      // hoisting
+      r#"
+      function foo() {
+        a += 1;
+      }
+      let a = 1;
+      foo();
+      "#,
     ]);
   }
 

--- a/src/rules/prefer_const.rs
+++ b/src/rules/prefer_const.rs
@@ -1,6 +1,4 @@
 // Copyright 2020 the Deno authors. All rights reserved. MIT license.
-// TODO(magurotuna): remove next line
-#![allow(unused)]
 use super::Context;
 use super::LintRule;
 use std::collections::BTreeMap;
@@ -10,11 +8,10 @@ use swc_atoms::JsWord;
 use swc_common::{Span, Spanned};
 use swc_ecmascript::ast::{
   ArrowExpr, AssignExpr, BlockStmt, BlockStmtOrExpr, CatchClause, Class,
-  ClassMember, Constructor, DoWhileStmt, Expr, ExprStmt, ForInStmt, ForOfStmt,
-  ForStmt, Function, Ident, IfStmt, Module, ObjectPatProp, Param,
-  ParamOrTsParamProp, Pat, PatOrExpr, Stmt, TsParamProp, TsParamPropParam,
-  UpdateExpr, VarDecl, VarDeclKind, VarDeclOrExpr, VarDeclOrPat, WhileStmt,
-  WithStmt,
+  Constructor, DoWhileStmt, Expr, ExprStmt, ForInStmt, ForOfStmt, ForStmt,
+  Function, Ident, IfStmt, Module, ObjectPatProp, ParamOrTsParamProp, Pat,
+  PatOrExpr, Stmt, TsParamPropParam, UpdateExpr, VarDecl, VarDeclKind,
+  VarDeclOrExpr, VarDeclOrPat, WhileStmt, WithStmt,
 };
 use swc_ecmascript::utils::find_ids;
 use swc_ecmascript::visit::noop_visit_type;
@@ -591,7 +588,7 @@ impl PreferConstVisitor {
     let mut cur_scope = self.scopes.get(&self.cur_scope).map(Arc::clone);
     let mut is_first_loop = true;
     while let Some(cur) = cur_scope {
-      let mut lock = cur.lock().unwrap();
+      let lock = cur.lock().unwrap();
       if let Some(var) = lock.variables.get(&ident.sym) {
         if is_first_loop {
           return var.is_param;

--- a/src/test_util.rs
+++ b/src/test_util.rs
@@ -4,6 +4,7 @@ use crate::diagnostic::LintDiagnostic;
 use crate::linter::LinterBuilder;
 use crate::rules::LintRule;
 use crate::swc_util;
+use swc_ecmascript::ast::Module;
 
 fn lint(rule: Box<dyn LintRule>, source: &str) -> Vec<LintDiagnostic> {
   let mut linter = LinterBuilder::default()
@@ -112,4 +113,12 @@ pub fn assert_lint_err_on_line_n<T: LintRule + 'static>(
     let (line, col) = expected[i];
     assert_diagnostic(&diagnostics[i], rule_code, line, col, source);
   }
+}
+
+pub fn parse(source_code: &str) -> Module {
+  let ast_parser = swc_util::AstParser::new();
+  let syntax = swc_util::get_default_ts_config();
+  let (parse_result, _comments) =
+    ast_parser.parse_module("file_name.ts", syntax, source_code);
+  parse_result.unwrap()
 }


### PR DESCRIPTION
~~WIP~~

Fixes #358 

This PR looks quite big, but the policy of this change is just simple.
It introduces a new visitor called `VariableCollector`, which is in charge of collecting variable declarations per scope. And the job of `PreferConstVisitor` has changed to visiting any assignments and updating the variable statuses (initialized, reassigned, etc.). This change is required to handle hoisting correctly.
(Previously `PreferConstVisitor` did both collecting declarations and visiting assignments by itself)

I've confirmed that the false positives that were reported against Deno's std are all fixed by this change.

