### PR TITLE
chore: enable prefer-const again

### DIFF
--- a/src/rules/mod.rs
+++ b/src/rules/mod.rs
@@ -162,6 +162,7 @@ pub fn get_recommended_rules() -> Vec<Box<dyn LintRule>> {
     no_unused_labels::NoUnusedLabels::new(),
     no_with::NoWith::new(),
     prefer_as_const::PreferAsConst::new(),
+    prefer_const::PreferConst::new(),
     prefer_namespace_keyword::PreferNamespaceKeyword::new(),
     require_yield::RequireYield::new(),
     triple_slash_reference::TripleSlashReference::new(),


### PR DESCRIPTION
I forgot to turn on `prefer-const` in #362 . I think it's ready to be landed 👍 