### PR TITLE
Adds `docs` Method for `no-unsafe-finally` Rule

### DIFF
--- a/src/rules/no_unsafe_finally.rs
+++ b/src/rules/no_unsafe_finally.rs
@@ -22,6 +22,48 @@ impl LintRule for NoUnsafeFinally {
     let mut visitor = NoUnsafeFinallyVisitor::new(context);
     visitor.visit_module(module, module);
   }
+
+  fn docs(&self) -> &'static str {
+    r#"Disallows the use of control flow statements within `finally` blocks.
+
+Use of the control flow statements (`return`, `throw`, `break` and `continue`) overrides the usage of any control flow statements that might have been used in the `try` or `catch` blocks, which is usually not the desired behaviour.
+
+### Invalid:
+```typescript
+let foo = function() {
+  try {
+    return 1;
+  } catch(err) {
+    return 2;
+  } finally {
+    return 3;
+  }
+};
+```
+```typescript
+let foo = function() {
+  try {
+    return 1;
+  } catch(err) {
+    return 2;
+  } finally {
+    throw new Error;
+  }
+};
+```
+### Valid:
+```typescript
+let foo = function() {
+  try {
+    return 1;
+  } catch(err) {
+    return 2;
+  } finally {
+    console.log("hola!");
+  }
+};
+```"#
+  }
 }
 
 struct NoUnsafeFinallyVisitor {


### PR DESCRIPTION
Adds the `docs` method to the `no-unsafe-finally` rule as per #159.