### PR TITLE
Add `docs` Method for `no-dupe-keys` Rule

### DIFF
--- a/src/rules/no_dupe_keys.rs
+++ b/src/rules/no_dupe_keys.rs
@@ -23,6 +23,39 @@ impl LintRule for NoDupeKeys {
     let mut visitor = NoDupeKeysVisitor::new(context);
     visitor.visit_module(module, module);
   }
+
+  fn docs(&self) -> &'static str {
+    r#"Disallows duplicate keys in object literals.
+
+Setting the same key multiple times in an object literal will override other assignments to that key and can cause unexpected behaviour.
+
+### Invalid:
+```typescript
+const foo = {
+  bar: "baz",
+  bar: "qux"
+};
+```
+```typescript
+const foo = {
+  "bar": "baz",
+  bar: "qux"
+};
+```
+```typescript
+const foo = {
+  0x1: "baz",
+  1: "qux"
+};
+```
+### Valid:
+```typescript
+var foo = {
+  bar: "baz",
+  quxx: "qux"
+};
+```"#
+  }
 }
 
 struct NoDupeKeysVisitor {


### PR DESCRIPTION
Adds the `docs` method for the `no-dupe-keys` rule as per #159.