### PR TITLE
fix(getter-return): use ControlFlow to check if getters return something

### DIFF
--- a/src/control_flow/mod.rs
+++ b/src/control_flow/mod.rs
@@ -106,11 +106,11 @@ struct Scope<'a> {
 enum Done {
   /// Return, Throw, or infinite loop
   Forced,
-  // Break or continue
+  /// Break or continue
   Break,
-  // Pass through a block, like a function's block statement which ends without returning a value
-  // or throwing an exception. Note that a node marked as `Done::Pass` won't prevent further execution, unlike
-  // `Done::Forced` and `Done::Break`.
+  /// Pass through a block, like a function's block statement which ends without returning a value
+  /// or throwing an exception. Note that a node marked as `Done::Pass` won't prevent further execution, unlike
+  /// `Done::Forced` and `Done::Break`.
   Pass,
 }
 

--- a/src/control_flow/mod.rs
+++ b/src/control_flow/mod.rs
@@ -66,6 +66,11 @@ impl Metadata {
       .done
       .map_or(false, |d| matches!(d, Done::Forced | Done::Break))
   }
+
+  /// Returns true if a node doesn't prevent further execution.
+  pub fn continues_execution(&self) -> bool {
+    self.done.map_or(true, |d| d == Done::Pass)
+  }
 }
 
 #[derive(Debug)]

--- a/src/control_flow/mod.rs
+++ b/src/control_flow/mod.rs
@@ -1194,27 +1194,4 @@ throw err;
     assert_flow!(flow, 54, false, Some(Done::Forced)); // return stmt
     assert_flow!(flow, 70, false, Some(Done::Forced)); // throw stmt
   }
-
-  #[test]
-  fn hoge() {
-    let src = r#"
-const obj = {
-  get root() {
-    let primary = this;
-    while (true) {
-      if (primary.parent !== undefined) {
-          primary = primary.parent;
-      } else {
-          return primary;
-      }
-    }
-    //return 'a';
-  }
-};
-      "#;
-    let module = parse(src);
-    let flow = ControlFlow::analyze(&module);
-    dbg!(flow);
-    panic!();
-  }
 }

--- a/src/control_flow/mod.rs
+++ b/src/control_flow/mod.rs
@@ -577,15 +577,19 @@ impl Visit for Analyzer<'_> {
 #[cfg(test)]
 mod tests {
   use super::*;
-  use crate::swc_util::{self, AstParser};
-  use swc_ecmascript::ast::Module;
+  use crate::test_util::*;
 
-  fn parse(source_code: &str) -> Module {
-    let ast_parser = AstParser::new();
-    let syntax = swc_util::get_default_ts_config();
-    let (parse_result, _) =
-      ast_parser.parse_module("file_name.ts", syntax, source_code);
-    parse_result.unwrap()
+  #[test]
+  fn piyo() {
+    let src = r#"
+function foo() {
+  return 1;
+}
+      "#;
+    let module = parse(src);
+    let flow = ControlFlow::analyze(&module);
+    dbg!(flow);
+    panic!();
   }
 
   #[test]
@@ -601,7 +605,7 @@ const obj = {
           return primary;
       }
     }
-    return 'a';
+    //return 'a';
   }
 };
       "#;

--- a/src/control_flow/mod.rs
+++ b/src/control_flow/mod.rs
@@ -630,20 +630,18 @@ impl Visit for Analyzer<'_> {
           self.scope.done = prev_done;
         }
       }
+    } else if matches!(try_block_done, Some(Done::Forced) | Some(Done::Break)) {
+      self.mark_as_done(n.span.lo, try_block_done.unwrap());
+    } else if let Some(finalizer) = &n.finalizer {
+      self.mark_as_done(
+        n.span.lo,
+        self
+          .get_done_reason(finalizer.span.lo)
+          .unwrap_or(Done::Pass),
+      );
+      self.scope.done = prev_done;
     } else {
-      if matches!(try_block_done, Some(Done::Forced) | Some(Done::Break)) {
-        self.mark_as_done(n.span.lo, try_block_done.unwrap());
-      } else if let Some(finalizer) = &n.finalizer {
-        self.mark_as_done(
-          n.span.lo,
-          self
-            .get_done_reason(finalizer.span.lo)
-            .unwrap_or(Done::Pass),
-        );
-        self.scope.done = prev_done;
-      } else {
-        self.scope.done = prev_done;
-      }
+      self.scope.done = prev_done;
     }
 
     self.scope.may_throw = old_throw;

--- a/src/control_flow/mod.rs
+++ b/src/control_flow/mod.rs
@@ -828,6 +828,42 @@ function foo() {
   }
 
   #[test]
+  fn for_in_1() {
+    let src = r#"
+function foo() {
+  for (let i in {}) {
+    return 1;
+  }
+  bar();
+}
+    "#;
+    let flow = analyze_flow(src);
+    dbg!(&flow);
+    assert_meta!(flow, 16, false, Some(Done::Pass)); // BlockStmt of `foo`
+    assert_meta!(flow, 38, false, Some(Done::Pass)); // BlockStmt of for-in
+    assert_meta!(flow, 44, false, Some(Done::Forced)); // return stmt
+    assert_meta!(flow, 60, false, None); // `bar();`
+  }
+
+  #[test]
+  fn for_of_1() {
+    let src = r#"
+function foo() {
+  for (let i of []) {
+    return 1;
+  }
+  bar();
+}
+    "#;
+    let flow = analyze_flow(src);
+    dbg!(&flow);
+    assert_meta!(flow, 16, false, Some(Done::Pass)); // BlockStmt of `foo`
+    assert_meta!(flow, 38, false, Some(Done::Pass)); // BlockStmt of for-of
+    assert_meta!(flow, 44, false, Some(Done::Forced)); // return stmt
+    assert_meta!(flow, 60, false, None); // `bar();`
+  }
+
+  #[test]
   fn piyo() {
     let src = "function foo() { var x = 1; for (x in {}) { return; } x = 2; }";
     let flow = analyze_flow(src);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@ extern crate lazy_static;
 #[macro_use]
 extern crate log;
 
+mod code_path_analysis;
 mod control_flow;
 pub mod diagnostic;
 mod globals;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,6 @@ extern crate lazy_static;
 #[macro_use]
 extern crate log;
 
-mod code_path_analysis;
 mod control_flow;
 pub mod diagnostic;
 mod globals;

--- a/src/rules/getter_return.rs
+++ b/src/rules/getter_return.rs
@@ -323,6 +323,24 @@ Object.defineProperty(foo, 'bar', {
 });
       "#,
     ]);
+
+    // https://github.com/denoland/deno_lint/issues/348
+    assert_lint_ok::<GetterReturn>(
+      r#"
+const obj = {
+  get root() {
+    let primary = this;
+    while (true) {
+      if (primary.parent !== undefined) {
+          primary = primary.parent;
+      } else {
+          return primary;
+      }
+    }
+  }
+};
+      "#,
+    );
   }
 
   #[test]

--- a/src/rules/getter_return.rs
+++ b/src/rules/getter_return.rs
@@ -1,14 +1,13 @@
 // Copyright 2020 the Deno authors. All rights reserved. MIT license.
 use super::Context;
 use super::LintRule;
-use swc_ecmascript::ast::BlockStmt;
-use swc_ecmascript::ast::Class;
-use swc_ecmascript::ast::ClassMember;
-use swc_ecmascript::ast::Expr;
-use swc_ecmascript::ast::ExprOrSuper;
-use swc_ecmascript::ast::GetterProp;
-use swc_ecmascript::ast::MethodKind;
-use swc_ecmascript::ast::Stmt;
+use crate::swc_util::Key;
+use std::mem;
+use swc_common::Span;
+use swc_ecmascript::ast::{
+  BlockStmtOrExpr, CallExpr, ClassMethod, Expr, ExprOrSuper, GetterProp,
+  MethodKind, PrivateMethod, Prop, PropName, PropOrSpread, ReturnStmt,
+};
 use swc_ecmascript::visit::noop_visit_type;
 use swc_ecmascript::visit::Node;
 use swc_ecmascript::visit::Visit;
@@ -41,139 +40,133 @@ impl LintRule for GetterReturn {
 
 struct GetterReturnVisitor<'c> {
   context: &'c mut Context,
+  /// If this visitor is currently in a getter, its name is stored.
+  getter_name: Option<String>,
+  // `true` if a getter contains as least one return statement.
+  has_return: bool,
 }
 
 impl<'c> GetterReturnVisitor<'c> {
   fn new(context: &'c mut Context) -> Self {
-    Self { context }
+    Self {
+      context,
+      getter_name: None,
+      has_return: false,
+    }
   }
 
-  fn return_has_arg(
-    &self,
-    return_stmt: &swc_ecmascript::ast::ReturnStmt,
-  ) -> bool {
-    return_stmt.arg.is_some()
+  fn report(&mut self, span: Span, msg: impl AsRef<str>) {
+    self
+      .context
+      .add_diagnostic(span, "getter-return", msg.as_ref());
   }
 
-  fn stmts_have_return(&self, stmts: &[Stmt]) -> bool {
-    for stmt in stmts {
-      if let Stmt::Return(return_stmt) = stmt {
-        return self.return_has_arg(return_stmt);
+  fn report_expected(&mut self, span: Span) {
+    self.report(
+      span,
+      format!(
+        "Expected to return a value in {}.",
+        self
+          .getter_name
+          .clone()
+          .expect("the name of getter is not set")
+      ),
+    );
+  }
+
+  fn report_always_expected(&mut self, span: Span) {
+    self.report(
+      span,
+      format!(
+        "Expected {} to always return a value.",
+        self
+          .getter_name
+          .clone()
+          .expect("the name of getter is not set")
+      ),
+    );
+  }
+
+  fn check_getter(&mut self, getter_body_span: Span) {
+    if self
+      .context
+      .control_flow
+      .meta(getter_body_span.lo)
+      .unwrap()
+      .continues_execution()
+    {
+      if self.has_return {
+        self.report_always_expected(getter_body_span);
+      } else {
+        self.report_expected(getter_body_span);
       }
     }
-    false
   }
 
-  fn check_if_stmt(&self, if_stmt: &swc_ecmascript::ast::IfStmt) -> bool {
-    if if_stmt.alt.is_none() {
-      return false;
-    }
-    if let Stmt::Block(if_block) = &*if_stmt.cons {
-      if !self.stmts_have_return(&if_block.stmts) {
-        return false;
-      }
-      let mut alt_stmt = &if_stmt.alt;
-      loop {
-        if let Some(if_alt_block) = alt_stmt {
-          if let Stmt::If(else_if) = &**if_alt_block {
-            if else_if.alt.is_none() {
-              return false;
-            } else {
-              alt_stmt = &else_if.alt;
-            }
-            if let Stmt::Block(else_if_block) = &*else_if.cons {
-              if !self.stmts_have_return(&else_if_block.stmts) {
-                return false;
-              }
-            }
-          } else if let Stmt::Block(else_block) = &**if_alt_block {
-            if self.stmts_have_return(&else_block.stmts) {
-              break;
-            } else {
-              return false;
-            }
-          }
-        }
-      }
-    }
-    true
+  fn set_getter_name<T: Key>(&mut self, name: &T) {
+    self.getter_name =
+      Some(name.get_key().unwrap_or_else(|| "[GETTER]".to_string()));
   }
 
-  fn check_switch_stmt(
-    &self,
-    switch_stmt: &swc_ecmascript::ast::SwitchStmt,
-  ) -> bool {
-    for case in &switch_stmt.cases {
-      if !case.cons.is_empty() && !self.stmts_have_return(&case.cons) {
-        return false;
-      }
-    }
-    true
-  }
-
-  fn check_block_stmt(
-    &mut self,
-    block_stmt: &BlockStmt,
-    span: swc_common::Span,
-  ) {
-    if !block_stmt.stmts.iter().any(|s| match s {
-      Stmt::If(if_stmt) => self.check_if_stmt(if_stmt),
-      Stmt::Switch(switch_stmt) => self.check_switch_stmt(switch_stmt),
-      Stmt::Return(return_stmt) => self.return_has_arg(return_stmt),
-      _ => false,
-    }) {
-      self.context.add_diagnostic(
-        span,
-        "getter-return",
-        "Getter requires a return",
-      );
-    }
+  fn visit_getter<F>(&mut self, op: F)
+  where
+    F: FnOnce(&mut Self),
+  {
+    let prev_name = mem::take(&mut self.getter_name);
+    let prev_has_return = self.has_return;
+    op(self);
+    self.getter_name = prev_name;
+    self.has_return = prev_has_return;
   }
 }
 
 impl<'c> Visit for GetterReturnVisitor<'c> {
   noop_visit_type!();
 
-  fn visit_class(&mut self, class: &Class, _parent: &dyn Node) {
-    class.visit_children_with(self);
-    for member in &class.body {
-      match member {
-        ClassMember::Method(class_method) => {
-          if class_method.kind == MethodKind::Getter {
-            if let Some(block_stmt) = &class_method.function.body {
-              self.check_block_stmt(block_stmt, class_method.span);
-            }
-          }
-        }
-        ClassMember::PrivateMethod(private_method) => {
-          if private_method.kind == MethodKind::Getter {
-            if let Some(block_stmt) = &private_method.function.body {
-              self.check_block_stmt(block_stmt, private_method.span);
-            }
-          }
-        }
-        _ => {}
+  fn visit_class_method(&mut self, class_method: &ClassMethod, _: &dyn Node) {
+    self.visit_getter(|a| {
+      if class_method.kind == MethodKind::Getter {
+        a.set_getter_name(&class_method.key);
       }
-    }
+      class_method.visit_children_with(a);
+
+      if let Some(body) = &class_method.function.body {
+        a.check_getter(body.span);
+      }
+    });
   }
 
-  fn visit_getter_prop(
+  fn visit_private_method(
     &mut self,
-    getter_prop: &GetterProp,
-    _parent: &dyn Node,
+    private_method: &PrivateMethod,
+    _: &dyn Node,
   ) {
-    getter_prop.visit_children_with(self);
-    if let Some(block_stmt) = &getter_prop.body {
-      self.check_block_stmt(block_stmt, getter_prop.span);
-    }
+    self.visit_getter(|a| {
+      if private_method.kind == MethodKind::Getter {
+        a.set_getter_name(&private_method.key);
+      }
+      private_method.visit_children_with(a);
+
+      if let Some(body) = &private_method.function.body {
+        a.check_getter(body.span);
+      }
+    });
   }
 
-  fn visit_call_expr(
-    &mut self,
-    call_expr: &swc_ecmascript::ast::CallExpr,
-    _parent: &dyn Node,
-  ) {
+  fn visit_getter_prop(&mut self, getter_prop: &GetterProp, _: &dyn Node) {
+    self.visit_getter(|a| {
+      a.set_getter_name(&getter_prop.key);
+      getter_prop.visit_children_with(a);
+
+      if let Some(body) = &getter_prop.body {
+        a.check_getter(body.span);
+      }
+    });
+  }
+
+  fn visit_call_expr(&mut self, call_expr: &CallExpr, _parent: &dyn Node) {
     call_expr.visit_children_with(self);
+
     if call_expr.args.len() != 3 {
       return;
     }
@@ -195,40 +188,57 @@ impl<'c> Visit for GetterReturnVisitor<'c> {
     }
     if let Expr::Object(obj_expr) = &*call_expr.args[2].expr {
       for prop in obj_expr.props.iter() {
-        if let swc_ecmascript::ast::PropOrSpread::Prop(prop_expr) = prop {
-          if let swc_ecmascript::ast::Prop::KeyValue(kv_prop) = &**prop_expr {
-            if let swc_ecmascript::ast::PropName::Ident(ident) = &kv_prop.key {
+        if let PropOrSpread::Prop(prop_expr) = prop {
+          if let Prop::KeyValue(kv_prop) = &**prop_expr {
+            if let PropName::Ident(ident) = &kv_prop.key {
               if ident.sym != *"get" {
                 return;
               }
-              if let Expr::Fn(fn_expr) = &*kv_prop.value {
-                if let Some(body) = &fn_expr.function.body {
-                  self.check_block_stmt(&body, ident.span);
+
+              self.visit_getter(|a| {
+                a.set_getter_name(&kv_prop.key);
+
+                if let Expr::Fn(fn_expr) = &*kv_prop.value {
+                  if let Some(body) = &fn_expr.function.body {
+                    body.visit_children_with(a);
+                    a.check_getter(body.span);
+                  }
+                } else if let Expr::Arrow(arrow_expr) = &*kv_prop.value {
+                  if let BlockStmtOrExpr::BlockStmt(block_stmt) =
+                    &arrow_expr.body
+                  {
+                    block_stmt.visit_children_with(a);
+                    a.check_getter(block_stmt.span);
+                  }
                 }
-              } else if let Expr::Arrow(arrow_expr) = &*kv_prop.value {
-                if let swc_ecmascript::ast::BlockStmtOrExpr::BlockStmt(
-                  block_stmt,
-                ) = &arrow_expr.body
-                {
-                  self.check_block_stmt(&block_stmt, ident.span);
-                }
-              }
+              });
             }
-          } else if let swc_ecmascript::ast::Prop::Method(method_prop) =
-            &**prop_expr
-          {
-            if let swc_ecmascript::ast::PropName::Ident(ident) =
-              &method_prop.key
-            {
+          } else if let Prop::Method(method_prop) = &**prop_expr {
+            if let PropName::Ident(ident) = &method_prop.key {
               if ident.sym != *"get" {
                 return;
               }
-              if let Some(body) = &method_prop.function.body {
-                self.check_block_stmt(&body, ident.span);
-              }
+
+              self.visit_getter(|a| {
+                a.set_getter_name(&method_prop.key);
+
+                if let Some(body) = &method_prop.function.body {
+                  body.visit_children_with(a);
+                  a.check_getter(body.span);
+                }
+              });
             }
           }
         }
+      }
+    }
+  }
+
+  fn visit_return_stmt(&mut self, return_stmt: &ReturnStmt, _: &dyn Node) {
+    if self.getter_name.is_some() {
+      self.has_return = true;
+      if return_stmt.arg.is_none() {
+        self.report_expected(return_stmt.span);
       }
     }
   }

--- a/src/rules/getter_return.rs
+++ b/src/rules/getter_return.rs
@@ -92,6 +92,10 @@ impl<'c> GetterReturnVisitor<'c> {
   }
 
   fn check_getter(&mut self, getter_body_span: Span, getter_span: Span) {
+    if self.getter_name.is_none() {
+      return;
+    }
+
     if self
       .context
       .control_flow
@@ -261,6 +265,7 @@ mod tests {
   fn getter_return_valid() {
     assert_lint_ok::<GetterReturn>("let foo = { get bar() { return true; } };");
     assert_lint_ok::<GetterReturn>("class Foo { get bar() { return true; } }");
+    assert_lint_ok::<GetterReturn>("class Foo { bar() {} }");
     assert_lint_ok::<GetterReturn>(
       "class Foo { get bar() { if (baz) { return true; } else { return false; } } }",
     );

--- a/src/rules/no_unreachable.rs
+++ b/src/rules/no_unreachable.rs
@@ -643,4 +643,28 @@ console.log("unreachable???");
       "#,
     );
   }
+
+  // https://github.com/denoland/deno_lint/issues/348
+  #[test]
+  fn issue_348() {
+    assert_lint_err_on_line::<NoUnreachable>(
+      r#"
+const obj = {
+  get root() {
+    let primary = this;
+    while (true) {
+      if (primary.parent !== undefined) {
+          primary = primary.parent;
+      } else {
+          return primary;
+      }
+    }
+    return 1;
+  }
+};
+      "#,
+      12,
+      4,
+    );
+  }
 }

--- a/src/rules/no_unreachable.rs
+++ b/src/rules/no_unreachable.rs
@@ -162,15 +162,18 @@ mod tests {
     );
 
     assert_lint_ok::<NoUnreachable>(
-      "function foo() {
-      var x = 1;
-      switch (x) {
-        case 0:
-          break;
-        default:
-          return;
-      }
-      x = 2; }",
+      r#"
+function foo() {
+  var x = 1;
+  switch (x) {
+    case 0:
+      break;
+    default:
+      return;
+  }
+  x = 2; 
+}
+"#,
     );
   }
 

--- a/src/rules/no_unreachable.rs
+++ b/src/rules/no_unreachable.rs
@@ -183,6 +183,10 @@ mod tests {
     );
 
     assert_lint_ok::<NoUnreachable>(
+      "function foo() { var x = 1; for (x of []) { return; } x = 2; }",
+    );
+
+    assert_lint_ok::<NoUnreachable>(
       "function foo() { var x = 1; try { return; } finally { x = 2; } }",
     );
   }

--- a/src/swc_util.rs
+++ b/src/swc_util.rs
@@ -18,7 +18,7 @@ use swc_common::DUMMY_SP;
 use swc_common::{Mark, GLOBALS};
 use swc_ecmascript::ast::{
   ComputedPropName, Expr, ExprOrSpread, Ident, Lit, MemberExpr, PatOrExpr,
-  Prop, PropName, PropOrSpread, Str, Tpl,
+  PrivateName, Prop, PropName, PropOrSpread, Str, Tpl,
 };
 use swc_ecmascript::parser::lexer::Lexer;
 use swc_ecmascript::parser::EsConfig;
@@ -352,6 +352,12 @@ impl Key for PropName {
         _ => None,
       },
     }
+  }
+}
+
+impl Key for PrivateName {
+  fn get_key(&self) -> Option<String> {
+    Some(self.id.sym.to_string())
   }
 }
 


### PR DESCRIPTION
Currently, `getter-return` rule only checks `if` and `switch` statements, so it doesn't handle more complicated cases such as including `while` loops.
This PR allows `getter-return` to use `ControlFlow` to check if getters return something, which will make it possible to handle complicated cases.

Fixes #348 