### PR TITLE
refactor: remove Arc/Rc

### DIFF
--- a/src/linter.rs
+++ b/src/linter.rs
@@ -23,17 +23,15 @@ lazy_static! {
     regex::Regex::new(r",\s*|\s").unwrap();
 }
 
-#[derive(Clone)]
 pub struct Context {
   pub file_name: String,
   pub diagnostics: Vec<LintDiagnostic>,
   pub source_map: Arc<SourceMap>,
-  pub(crate) leading_comments: Rc<HashMap<BytePos, Vec<Comment>>>,
-  pub(crate) trailing_comments: Rc<HashMap<BytePos, Vec<Comment>>>,
-  pub ignore_directives: Rc<RefCell<Vec<IgnoreDirective>>>,
-  /// Arc as it's not modified
-  pub(crate) scope: Arc<Scope>,
-  pub(crate) control_flow: Arc<ControlFlow>,
+  pub(crate) leading_comments: HashMap<BytePos, Vec<Comment>>,
+  pub(crate) trailing_comments: HashMap<BytePos, Vec<Comment>>,
+  pub ignore_directives: RefCell<Vec<IgnoreDirective>>,
+  pub(crate) scope: Scope,
+  pub(crate) control_flow: ControlFlow,
   pub(crate) top_level_ctxt: SyntaxContext,
 }
 
@@ -363,16 +361,16 @@ impl Linter {
       ignore_directives.insert(0, ignore_directive);
     }
 
-    let scope = Arc::new(analyze(&module));
-    let control_flow = Arc::new(ControlFlow::analyze(&module));
+    let scope = analyze(&module);
+    let control_flow = ControlFlow::analyze(&module);
 
     let mut context = Context {
       file_name,
       diagnostics: vec![],
       source_map: self.ast_parser.source_map.clone(),
-      leading_comments: Rc::new(leading),
-      trailing_comments: Rc::new(trailing),
-      ignore_directives: Rc::new(RefCell::new(ignore_directives)),
+      leading_comments: leading,
+      trailing_comments: trailing,
+      ignore_directives: RefCell::new(ignore_directives),
       scope,
       control_flow,
       top_level_ctxt: swc_common::GLOBALS.set(&self.ast_parser.globals, || {

--- a/src/rules/ban_ts_ignore.rs
+++ b/src/rules/ban_ts_ignore.rs
@@ -4,24 +4,13 @@ use super::LintRule;
 
 use swc_common::comments::Comment;
 use swc_common::comments::CommentKind;
+use swc_common::Span;
 
 pub struct BanTsIgnore;
 
 impl BanTsIgnore {
-  fn lint_comment(&self, context: &mut Context, comment: &Comment) {
-    if comment.kind != CommentKind::Line {
-      return;
-    }
-
-    if !comment.text.contains("@ts-ignore") {
-      return;
-    }
-
-    context.add_diagnostic(
-      comment.span,
-      "ban-ts-ignore",
-      "@ts-ignore is not allowed",
-    );
+  fn report(&self, context: &mut Context, span: Span) {
+    context.add_diagnostic(span, "ban-ts-ignore", "@ts-ignore is not allowed");
   }
 }
 
@@ -39,16 +28,42 @@ impl LintRule for BanTsIgnore {
     context: &mut Context,
     _module: &swc_ecmascript::ast::Module,
   ) {
-    let leading = context.leading_comments.clone();
-    let trailing = context.trailing_comments.clone();
+    let mut violated_comment_spans = Vec::new();
 
-    for comment in leading.values().flatten() {
-      self.lint_comment(context, comment);
-    }
-    for comment in trailing.values().flatten() {
-      self.lint_comment(context, comment);
+    violated_comment_spans.extend(
+      context.leading_comments.values().flatten().filter_map(|c| {
+        if check_comment(c) {
+          Some(c.span)
+        } else {
+          None
+        }
+      }),
+    );
+    violated_comment_spans.extend(
+      context
+        .trailing_comments
+        .values()
+        .flatten()
+        .filter_map(|c| if check_comment(c) { Some(c.span) } else { None }),
+    );
+
+    for span in violated_comment_spans {
+      self.report(context, span);
     }
   }
+}
+
+/// Returns `true` if the comment should be reported.
+fn check_comment(comment: &Comment) -> bool {
+  if comment.kind != CommentKind::Line {
+    return false;
+  }
+
+  if !comment.text.contains("@ts-ignore") {
+    return false;
+  }
+
+  true
 }
 
 #[cfg(test)]


### PR DESCRIPTION
- `leading_comments`
- `trailing_comments`
- `ignore_directives`
- `scope`
- `control_flow`

The above fields of `Context` struct are declared with `Arc` or `Rc` now, but it seems unnecessary so I removed them.
If `Arc` and `Rc` are removed, it will cost us a lot to call `.clone`. To address it, I refactored some implementations so that unnecessary cloning won't happen.