### PR TITLE
refactor: use matches!

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Install rust
         uses: hecrj/setup-rust-action@v1.3.3
         with:
-          rust-version: "1.46.0"
+          rust-version: "1.47.0"
 
       - name: Install clippy and rustfmt
         run: |

--- a/README.md
+++ b/README.md
@@ -251,12 +251,12 @@ For more concrete implementation visit [`deno`](https://github.com/denoland/deno
 
 ## Developing
 
-Make sure to have latest stable version of Rust installed (1.44.0).
+Make sure to have latest stable version of Rust installed (1.47.0).
 
 ```shell
 // check version
 $ rustc --version
-rustc 1.44.0 (49cae5576 2020-06-01)
+rustc 1.47.0 (18bf6b4f0 2020-10-07)
 
 // build all targets
 $ cargo build --all-targets

--- a/src/control_flow/mod.rs
+++ b/src/control_flow/mod.rs
@@ -186,10 +186,7 @@ impl Analyzer<'_> {
   }
 
   fn is_forced_done(&self, lo: BytePos) -> bool {
-    match self.get_done_reason(lo) {
-      Some(Done::Forced) => true,
-      _ => false,
-    }
+    matches!(self.get_done_reason(lo), Some(Done::Forced))
   }
 
   fn get_done_reason(&self, lo: BytePos) -> Option<Done> {

--- a/src/rules/no_compare_neg_zero.rs
+++ b/src/rules/no_compare_neg_zero.rs
@@ -85,10 +85,10 @@ trait Comparator {
 
 impl Comparator for BinaryOp {
   fn is_comparator(&self) -> bool {
-    match self {
-      EqEq | NotEq | EqEqEq | NotEqEq | Lt | LtEq | Gt | GtEq => true,
-      _ => false,
-    }
+    matches!(
+      self,
+      EqEq | NotEq | EqEqEq | NotEqEq | Lt | LtEq | Gt | GtEq
+    )
   }
 }
 

--- a/src/rules/no_dupe_class_members.rs
+++ b/src/rules/no_dupe_class_members.rs
@@ -176,11 +176,11 @@ impl PartialEq for MethodToCheck {
       return false;
     }
 
-    match (self.kind, other.kind) {
+    !matches!(
+      (self.kind, other.kind),
       (MethodKind::Getter, MethodKind::Setter)
-      | (MethodKind::Setter, MethodKind::Getter) => false,
-      _ => true,
-    }
+        | (MethodKind::Setter, MethodKind::Getter)
+    )
   }
 }
 

--- a/src/rules/no_extra_boolean_cast.rs
+++ b/src/rules/no_extra_boolean_cast.rs
@@ -184,10 +184,7 @@ fn expr_or_super_callee_is_boolean(expr_or_super: &ExprOrSuper) -> bool {
 }
 
 fn expr_callee_is_boolean(expr: &Expr) -> bool {
-  match expr {
-    Expr::Ident(Ident { ref sym, .. }) if sym == "Boolean" => true,
-    _ => false,
-  }
+  matches!(expr, Expr::Ident(Ident { ref sym, .. }) if sym == "Boolean")
 }
 
 /// Checks if `expr` has `n` continuous bang operators at the beginning, ignoring parentheses.

--- a/src/rules/no_shadow_restricted_names.rs
+++ b/src/rules/no_shadow_restricted_names.rs
@@ -41,10 +41,10 @@ impl<'c> NoShadowRestrictedNamesVisitor<'c> {
   }
 
   fn is_restricted_names(&self, ident: &Ident) -> bool {
-    match ident.sym.as_ref() {
-      "undefined" | "NaN" | "Infinity" | "arguments" | "eval" => true,
-      _ => false,
-    }
+    matches!(
+      ident.sym.as_ref(),
+      "undefined" | "NaN" | "Infinity" | "arguments" | "eval"
+    )
   }
 
   fn check_pat(&mut self, pat: &Pat, check_scope: bool) {

--- a/src/rules/valid_typeof.rs
+++ b/src/rules/valid_typeof.rs
@@ -133,11 +133,17 @@ impl<'c> Visit for ValidTypeofVisitor<'c> {
 }
 
 fn is_valid_typeof_string(str: &str) -> bool {
-  match str {
-    "undefined" | "object" | "boolean" | "number" | "string" | "function"
-    | "symbol" | "bigint" => true,
-    _ => false,
-  }
+  matches!(
+    str,
+    "undefined"
+      | "object"
+      | "boolean"
+      | "number"
+      | "string"
+      | "function"
+      | "symbol"
+      | "bigint"
+  )
 }
 
 trait EqExpr {
@@ -146,10 +152,7 @@ trait EqExpr {
 
 impl EqExpr for BinExpr {
   fn is_eq_expr(&self) -> bool {
-    match self.op {
-      EqEq | NotEq | EqEqEq | NotEqEq => true,
-      _ => false,
-    }
+    matches!(self.op, EqEq | NotEq | EqEqEq | NotEqEq)
   }
 }
 


### PR DESCRIPTION
clippy has started to complain about not using `matches!`. I refactored the code according to clippy.