### PR TITLE
example(dlint): use annotate-snippets for diagnostic formatting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20,6 +20,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "annotate-snippets"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c96c3d1062ea7101741480185a6a1275eab01cbe8b20e378d1311bc056d2e08"
+dependencies = [
+ "unicode-width",
+]
+
+[[package]]
 name = "ansi_term"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -184,6 +193,7 @@ dependencies = [
 name = "deno_lint"
 version = "0.2.3"
 dependencies = [
+ "annotate-snippets",
  "clap",
  "env_logger",
  "lazy_static",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -26,6 +26,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c96c3d1062ea7101741480185a6a1275eab01cbe8b20e378d1311bc056d2e08"
 dependencies = [
  "unicode-width",
+ "yansi-term",
 ]
 
 [[package]]
@@ -205,7 +206,6 @@ dependencies = [
  "swc_atoms",
  "swc_common",
  "swc_ecmascript",
- "termcolor",
 ]
 
 [[package]]
@@ -1105,3 +1105,12 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "yansi-term"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe5c30ade05e61656247b2e334a031dfd0cc466fadef865bdcdea8d537951bf1"
+dependencies = [
+ "winapi",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ swc_ecmascript = { version = "=0.9.1", features = ["parser", "transforms", "util
 regex = "1.3.9"
 
 [dev-dependencies]
+annotate-snippets = "0.9.0"
 clap = "2.33.1"
 env_logger = "0.7.1"
 rayon = "1.4.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,8 +26,7 @@ swc_ecmascript = { version = "=0.9.1", features = ["parser", "transforms", "util
 regex = "1.3.9"
 
 [dev-dependencies]
-annotate-snippets = "0.9.0"
+annotate-snippets = { version = "0.9.0", features = ["color"] }
 clap = "2.33.1"
 env_logger = "0.7.1"
 rayon = "1.4.0"
-termcolor = "1.1.0"

--- a/examples/dlint/main.rs
+++ b/examples/dlint/main.rs
@@ -201,9 +201,6 @@ fn print_rule_info(maybe_rule_name: Option<&str>) {
 }
 
 fn main() {
-  #[cfg(windows)]
-  enable_ansi();
-
   env_logger::init();
 
   let cli_app = create_cli_app();

--- a/examples/dlint/main.rs
+++ b/examples/dlint/main.rs
@@ -47,21 +47,21 @@ fn get_slice_source_and_range<'a>(
 
   let is_same_line = range.start.line == range.end.line;
 
-  let (first_line_start, last_line_start, last_line_end) = if is_same_line {
+  let (first_line_start, last_line_end) = if is_same_line {
     let (line_no, first_line_start) = line_start_indexes[range.start.line - 1];
     let last_line_end = line_start_indexes[line_no + 1].1 - 1;
-    (first_line_start, first_line_start, last_line_end)
+    (first_line_start, last_line_end)
   } else {
     let (_first_line_no, first_line_start) =
       line_start_indexes[range.start.line - 1];
-    let (last_line_no, last_line_start) =
+    let (last_line_no, _last_line_start) =
       line_start_indexes[range.end.line - 1];
-    let last_line_end = line_start_indexes[last_line_no].1 - 1;
-    (first_line_start, last_line_start, last_line_end)
+    let last_line_end = line_start_indexes[last_line_no + 1].1 - 1;
+    (first_line_start, last_line_end)
   };
 
   let adjusted_start = range.start.byte_pos - first_line_start;
-  let adjusted_end = range.end.byte_pos - last_line_start;
+  let adjusted_end = range.end.byte_pos - first_line_start;
   let adjusted_range = (adjusted_start, adjusted_end);
   let slice_str = &source[first_line_start..last_line_end];
   (slice_str, adjusted_range)

--- a/src/diagnostic.rs
+++ b/src/diagnostic.rs
@@ -1,23 +1,26 @@
 // Copyright 2020 the Deno authors. All rights reserved. MIT license.
 #[cfg(feature = "json")]
 use serde::Serialize;
+use std::convert::TryInto;
 
 #[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "json", derive(Serialize))]
 pub struct Position {
   pub line: usize,
   pub col: usize,
+  pub byte_pos: usize,
 }
 
-impl Into<Position> for swc_common::Loc {
-  fn into(self) -> Position {
+impl Position {
+  pub fn new(byte_pos: swc_common::BytePos, loc: swc_common::Loc) -> Self {
     Position {
-      line: self.line,
-      // Using self.col instead of self.col_display
+      line: loc.line,
+      // Using loc.col instead of loc.col_display
       // because it leads to out-of-bounds columns if file
       // contains non-narrow chars (like tabs).
       // See: https://github.com/denoland/deno_lint/issues/139
-      col: self.col.0,
+      col: loc.col.0,
+      byte_pos: byte_pos.0.try_into().expect("Failed to convert byte_pos"),
     }
   }
 }

--- a/src/linter.rs
+++ b/src/linter.rs
@@ -53,14 +53,10 @@ impl Context {
     message: &str,
   ) -> LintDiagnostic {
     let time_start = Instant::now();
-    let start = Position::new(
-      span.lo(),
-      self.source_map.lookup_char_pos(span.lo())
-    );
-    let end = Position::new(
-      span.hi(),
-      self.source_map.lookup_char_pos(span.hi())
-    );
+    let start =
+      Position::new(span.lo(), self.source_map.lookup_char_pos(span.lo()));
+    let end =
+      Position::new(span.hi(), self.source_map.lookup_char_pos(span.hi()));
 
     let diagnostic = LintDiagnostic {
       range: Range { start, end },
@@ -531,16 +527,44 @@ object | undefined {}
 
     assert_eq!(directives.len(), 4);
     let d = &directives[0];
-    assert_eq!(d.position, Position { line: 2, col: 0 });
+    assert_eq!(
+      d.position,
+      Position {
+        line: 2,
+        col: 0,
+        byte_pos: 1
+      }
+    );
     assert_eq!(d.codes, vec!["no-explicit-any", "no-empty", "no-debugger"]);
     let d = &directives[1];
-    assert_eq!(d.position, Position { line: 8, col: 0 });
+    assert_eq!(
+      d.position,
+      Position {
+        line: 8,
+        col: 0,
+        byte_pos: 146
+      }
+    );
     assert_eq!(d.codes, vec!["no-explicit-any", "no-empty", "no-debugger"]);
     let d = &directives[2];
-    assert_eq!(d.position, Position { line: 11, col: 0 });
+    assert_eq!(
+      d.position,
+      Position {
+        line: 11,
+        col: 0,
+        byte_pos: 229
+      }
+    );
     assert_eq!(d.codes, vec!["no-explicit-any", "no-empty", "no-debugger"]);
     let d = &directives[3];
-    assert_eq!(d.position, Position { line: 17, col: 3 });
+    assert_eq!(
+      d.position,
+      Position {
+        line: 17,
+        col: 3,
+        byte_pos: 392
+      }
+    );
     assert_eq!(d.codes, vec!["ban-types"]);
   }
 }

--- a/src/linter.rs
+++ b/src/linter.rs
@@ -53,8 +53,14 @@ impl Context {
     message: &str,
   ) -> LintDiagnostic {
     let time_start = Instant::now();
-    let start: Position = self.source_map.lookup_char_pos(span.lo()).into();
-    let end: Position = self.source_map.lookup_char_pos(span.hi()).into();
+    let start = Position::new(
+      span.lo(),
+      self.source_map.lookup_char_pos(span.lo())
+    );
+    let end = Position::new(
+      span.hi(),
+      self.source_map.lookup_char_pos(span.hi())
+    );
 
     let diagnostic = LintDiagnostic {
       range: Range { start, end },
@@ -454,14 +460,14 @@ fn parse_ignore_comment(
           .collect::<Vec<String>>();
 
         let location = source_map.lookup_char_pos(comment.span.lo());
-
+        let position = Position::new(comment.span.lo(), location);
         let mut used_codes = HashMap::new();
         codes.iter().for_each(|code| {
           used_codes.insert(code.to_string(), false);
         });
 
         return Some(IgnoreDirective {
-          position: location.into(),
+          position,
           span: comment.span,
           codes,
           used_codes,


### PR DESCRIPTION
This commit updates "dlint" example to use "annotate-snippets" crate
for diagnostic formatting. It allows to remove custom formatting implementation
(which was supposed to look the same) as well as colors implementation.

Closes https://github.com/denoland/deno_lint/issues/386

```
error[no-explicit-any]: `any` type is not allowed
   --> ./benchmarks/oak/router.ts:6:27
    |
  1 | /**
  2 |  * Adapted directly from @koa/router at
  3 |  * https://github.com/koajs/router/ which is licensed as:
  4 |  *
...
899 |
900 |     return this as Router<any, any>;
    |                           ^^^
    |
error[no-explicit-any]: `any` type is not allowed
   --> ./benchmarks/oak/router.ts:6:32
    |
  1 | /**
  2 |  * Adapted directly from @koa/router at
  3 |  * https://github.com/koajs/router/ which is licensed as:
  4 |  *
...
899 |
900 |     return this as Router<any, any>;
    |                                ^^^
    |
Found 36 problems
```

![Screenshot 2020-10-13 at 20 30 17](https://user-images.githubusercontent.com/13602871/95900961-ed25dd00-0d92-11eb-9323-7e64debeed07.png)


Current problems:
- first 4 lines of source file are displayed for each error
- line number next to file is wrong - not sure what's the problem here - it's computed from `SourceAnnotation` which properly underlines offending token

Given that a lot of lines have been removed I think we should pursue this solution.