### PR TITLE
refactor: switch to `impl Into<String>` to avoid unnecessary allocation

### DIFF
--- a/src/linter.rs
+++ b/src/linter.rs
@@ -39,8 +39,8 @@ impl Context {
   pub(crate) fn add_diagnostic(
     &mut self,
     span: Span,
-    code: &str,
-    message: &str,
+    code: impl Into<String>,
+    message: impl Into<String>,
   ) {
     let diagnostic = self.create_diagnostic(span, code, message);
     self.diagnostics.push(diagnostic);
@@ -49,8 +49,8 @@ impl Context {
   fn create_diagnostic(
     &self,
     span: Span,
-    code: &str,
-    message: &str,
+    code: impl Into<String>,
+    message: impl Into<String>,
   ) -> LintDiagnostic {
     let time_start = Instant::now();
     let start: Position = self.source_map.lookup_char_pos(span.lo()).into();
@@ -59,8 +59,8 @@ impl Context {
     let diagnostic = LintDiagnostic {
       range: Range { start, end },
       filename: self.file_name.clone(),
-      message: message.to_string(),
-      code: code.to_string(),
+      message: message.into(),
+      code: code.into(),
       hint: None,
     };
 

--- a/src/linter.rs
+++ b/src/linter.rs
@@ -280,7 +280,7 @@ impl Linter {
             let diagnostic = context.create_diagnostic(
               ignore_directive.span,
               "ban-unused-ignore",
-              &format!("Ignore for code \"{}\" was not used.", code),
+              format!("Ignore for code \"{}\" was not used.", code),
             );
             filtered_diagnostics.push(diagnostic);
           }
@@ -289,7 +289,7 @@ impl Linter {
             filtered_diagnostics.push(context.create_diagnostic(
               ignore_directive.span,
               "ban-unknown-rule-code",
-              &format!("Unknown rule for code \"{}\"", code),
+              format!("Unknown rule for code \"{}\"", code),
             ))
           }
         }

--- a/src/rules/adjacent_overload_signatures.rs
+++ b/src/rules/adjacent_overload_signatures.rs
@@ -46,7 +46,7 @@ impl<'c> AdjacentOverloadSignaturesVisitor<'c> {
     self.context.add_diagnostic(
       span,
       "adjacent-overload-signatures",
-      &format!("All '{}' signatures should be adjacent", fn_name),
+      format!("All '{}' signatures should be adjacent", fn_name),
     );
   }
 

--- a/src/rules/no_control_regex.rs
+++ b/src/rules/no_control_regex.rs
@@ -48,7 +48,7 @@ impl<'c> NoControlRegexVisitor<'c> {
     self.context.add_diagnostic(
       span,
       "no-control-regex",
-      &format!(
+      format!(
         "Unexpected control character(s) in regular expression: \\x{:x}.",
         cp
       ),

--- a/src/rules/no_dupe_class_members.rs
+++ b/src/rules/no_dupe_class_members.rs
@@ -50,7 +50,7 @@ impl<'c> NoDupeClassMembersVisitor<'c> {
     self.context.add_diagnostic(
       span,
       "no-dupe-class-members",
-      &format!("Duplicate name '{}'", name),
+      format!("Duplicate name '{}'", name),
     );
   }
 }

--- a/src/rules/no_dupe_keys.rs
+++ b/src/rules/no_dupe_keys.rs
@@ -91,7 +91,7 @@ impl<'c> Visit for NoDupeKeysVisitor<'c> {
       self.context.add_diagnostic(
         obj_lit.span,
         "no-dupe-keys",
-        format!("Duplicate key '{}'", key).as_str(),
+        format!("Duplicate key '{}'", key),
       );
     }
   }

--- a/src/rules/no_inner_declarations.rs
+++ b/src/rules/no_inner_declarations.rs
@@ -162,7 +162,7 @@ impl<'c> NoInnerDeclarationsVisitor<'c> {
     self.context.add_diagnostic(
       span,
       "no-inner-declarations",
-      &format!("Move {} declaration to {} root", kind, root),
+      format!("Move {} declaration to {} root", kind, root),
     );
   }
 }

--- a/src/rules/no_obj_calls.rs
+++ b/src/rules/no_obj_calls.rs
@@ -51,7 +51,7 @@ impl<'c> NoObjCallsVisitor<'c> {
         self.context.add_diagnostic(
           span,
           "no-obj-calls",
-          format!("`{}` call as function is not allowed", callee_name).as_ref(),
+          format!("`{}` call as function is not allowed", callee_name),
         );
       }
       _ => {}

--- a/src/rules/no_prototype_builtins.rs
+++ b/src/rules/no_prototype_builtins.rs
@@ -70,7 +70,7 @@ impl<'c> Visit for NoPrototypeBuiltinsVisitor<'c> {
         self.context.add_diagnostic(
           call_expr.span,
           "no-prototype-builtins",
-          &format!(
+          format!(
             "Access to Object.prototype.{} is not allowed from target object",
             prop_name
           ),

--- a/src/rules/no_self_assign.rs
+++ b/src/rules/no_self_assign.rs
@@ -54,11 +54,11 @@ impl<'c> NoSelfAssignVisitor<'c> {
     Self { context }
   }
 
-  fn add_diagnostic(&mut self, span: Span, name: &str) {
+  fn add_diagnostic(&mut self, span: Span, name: impl AsRef<str>) {
     self.context.add_diagnostic(
       span,
       "no-self-assign",
-      &format!("\"{}\" is assigned to itself", name),
+      format!("\"{}\" is assigned to itself", name.as_ref()),
     );
   }
 
@@ -129,7 +129,7 @@ impl<'c> NoSelfAssignVisitor<'c> {
   fn check_same_member(&mut self, left: &MemberExpr, right: &MemberExpr) {
     if self.is_same_member(left, right) {
       let name = (&*right.prop).get_key().expect("Should be identifier");
-      self.add_diagnostic(right.span, &name);
+      self.add_diagnostic(right.span, name);
     }
   }
 

--- a/src/rules/no_shadow_restricted_names.rs
+++ b/src/rules/no_shadow_restricted_names.rs
@@ -103,7 +103,7 @@ impl<'c> NoShadowRestrictedNamesVisitor<'c> {
     self.context.add_diagnostic(
       ident.span,
       "no-shadow-restricted-names",
-      &format!("Shadowing of global property {}", &ident.sym),
+      format!("Shadowing of global property {}", &ident.sym),
     );
   }
 }

--- a/src/rules/no_undef.rs
+++ b/src/rules/no_undef.rs
@@ -181,7 +181,7 @@ impl<'c> NoUndefVisitor<'c> {
     self.context.add_diagnostic(
       ident.span,
       "no-undef",
-      &format!("{} is not defined", ident.sym),
+      format!("{} is not defined", ident.sym),
     )
   }
 }

--- a/src/rules/no_unsafe_finally.rs
+++ b/src/rules/no_unsafe_finally.rs
@@ -82,7 +82,7 @@ impl<'c> NoUnsafeFinallyVisitor<'c> {
     self.context.add_diagnostic(
       span,
       "no-unsafe-finally",
-      format!("Unsafe usage of {}Statement", stmt_type).as_str(),
+      format!("Unsafe usage of {}Statement", stmt_type),
     );
   }
 }

--- a/src/rules/no_unused_labels.rs
+++ b/src/rules/no_unused_labels.rs
@@ -86,7 +86,7 @@ impl<'c> Visit for NoUnusedLabelsVisitor<'c> {
       self.context.add_diagnostic(
         labeled_stmt.span,
         "no-unused-labels",
-        &format!("\"{}\" label is never used", name),
+        format!("\"{}\" label is never used", name),
       );
     }
   }

--- a/src/rules/no_unused_vars.rs
+++ b/src/rules/no_unused_vars.rs
@@ -269,7 +269,7 @@ impl<'c> NoUnusedVarVisitor<'c> {
       self.context.add_diagnostic(
         ident.span,
         "no-unused-vars",
-        &format!("\"{}\" is never used", ident.sym),
+        format!("\"{}\" is never used", ident.sym),
       );
     }
   }

--- a/src/rules/prefer_const.rs
+++ b/src/rules/prefer_const.rs
@@ -496,9 +496,9 @@ impl<'c> PreferConstVisitor<'c> {
     self.context.add_diagnostic(
       span,
       "prefer-const",
-      &format!(
+      format!(
         "'{}' is never reassigned. Use 'const' instead",
-        sym.to_string()
+        sym.as_ref()
       ),
     );
   }


### PR DESCRIPTION
Currently `Context::add_diagnostic` method receives code and message with `&str`.
It results in unnecessary allocation because the callers of `add_diagnostic` often pass a message like `&format!("foo {}", bar)`. 
It'd be better to pass the built `String` value (not reference) to`add_diagnostic` for efficiency.

So, I switched their types to `impl Into<String>`, which will allow us to build and allocate new `String` only if that's required.