### PR TITLE
doc: Add markup docs for rules

### DIFF
--- a/src/rules/adjacent_overload_signatures.rs
+++ b/src/rules/adjacent_overload_signatures.rs
@@ -31,6 +31,78 @@ impl LintRule for AdjacentOverloadSignatures {
     let mut visitor = AdjacentOverloadSignaturesVisitor::new(context);
     visitor.visit_module(module, module);
   }
+
+  fn docs(&self) -> &'static str {
+    r#"Requires overload signatures to be adjacent to each other.
+
+Overloaded signatures which are not next to each other can lead to code which is hard to read and maintain.
+
+### Valid:
+(bar is declared after foo)
+```typescript
+type FooType = {
+  foo(s: string): void;
+  foo(n: number): void;
+  foo(sn: string | number): void;
+  bar(): void;
+};
+```
+```typescript
+interface FooInterface {
+  foo(s: string): void;
+  foo(n: number): void;
+  foo(sn: string | number): void;
+  bar(): void;
+}
+```
+```typescript
+class FooClass {
+  foo(s: string): void;
+  foo(n: number): void;
+  foo(sn: string | number): void {}
+  bar(): void {}
+}
+```
+```typescript
+export function foo(s: string): void;
+export function foo(n: number): void;
+export function foo(sn: string | number): void {}
+export function bar(): void {}
+```
+
+### Invalid:
+(bar is declared in-between foo overloads)
+```typescript
+type FooType = {
+  foo(s: string): void;
+  foo(n: number): void;
+  bar(): void;
+  foo(sn: string | number): void;
+};
+```
+```typescript
+interface FooInterface {
+  foo(s: string): void;
+  foo(n: number): void;
+  bar(): void;
+  foo(sn: string | number): void;
+}
+```
+```typescript
+class FooClass {
+  foo(s: string): void;
+  foo(n: number): void;
+  bar(): void {}
+  foo(sn: string | number): void {}
+}
+```
+```typescript
+export function foo(s: string): void;
+export function foo(n: number): void;
+export function bar(): void {}
+export function foo(sn: string | number): void {}
+```"#
+  }
 }
 
 struct AdjacentOverloadSignaturesVisitor<'c> {

--- a/src/rules/ban_ts_comment.rs
+++ b/src/rules/ban_ts_comment.rs
@@ -13,7 +13,7 @@ impl BanTsComment {
     context.add_diagnostic(
       span,
       "ban-ts-comment",
-      "ts directives are not allowed",
+      "ts directives are not allowed without comment",
     );
   }
 }
@@ -58,6 +58,40 @@ impl LintRule for BanTsComment {
     for span in violated_comment_spans {
       self.report(context, span);
     }
+  }
+
+  fn docs(&self) -> &'static str {
+    r#"Disallows the use of Typescript directives without a comment.
+
+Typescript directives reduce the effectiveness of the compiler, something which should only be done in exceptional circumstances.  The reason why should be documented in a comment alongside the directive.
+
+### Valid:
+```typescript
+// @ts-expect-error: Temporary workaround (see ticket #422)
+let a: number = "I am a string";
+```
+```typescript
+// @ts-ignore: Temporary workaround (see ticket #422)
+let a: number = "I am a string";
+```
+```typescript
+// @ts-nocheck: Temporary workaround (see ticket #422)
+let a: number = "I am a string";
+```
+
+### Invalid:
+```typescript
+// @ts-expect-error
+let a: number = "I am a string";
+```
+```typescript
+// @ts-ignore
+let a: number = "I am a string";
+```
+```typescript
+// @ts-nocheck
+let a: number = "I am a string";
+```"#
   }
 }
 


### PR DESCRIPTION
Dipping my toe into #159, this add docs for `adjacent-overload-signatures` and `ban-ts-comment`.  

As an aside, `ban-ts-comment` as a name is confusing.  This lint rule does not ban any TS directives (as is the default intent of the eslint equivalent), but instead only allows them with comments/descriptions (which is confusing considering the name).  I've updated the rule diagnostic text to reflect this, but if we aren't tied to eslint's names something like `no-ts-directive-without-comment` or some such might be more descriptive.