### PR TITLE
doc: Additional docs for a few rules

### DIFF
--- a/src/rules/adjacent_overload_signatures.rs
+++ b/src/rules/adjacent_overload_signatures.rs
@@ -31,6 +31,78 @@ impl LintRule for AdjacentOverloadSignatures {
     let mut visitor = AdjacentOverloadSignaturesVisitor::new(context);
     visitor.visit_module(module, module);
   }
+
+  fn docs(&self) -> &'static str {
+    r#"Requires overload signatures to be adjacent to each other.
+
+Overloaded signatures which are not next to each other can lead to code which is hard to read and maintain.
+
+### Valid:
+(bar is declared after foo)
+```typescript
+type FooType = {
+  foo(s: string): void;
+  foo(n: number): void;
+  foo(sn: string | number): void;
+  bar(): void;
+};
+```
+```typescript
+interface FooInterface {
+  foo(s: string): void;
+  foo(n: number): void;
+  foo(sn: string | number): void;
+  bar(): void;
+}
+```
+```typescript
+class FooClass {
+  foo(s: string): void;
+  foo(n: number): void;
+  foo(sn: string | number): void {}
+  bar(): void {}
+}
+```
+```typescript
+export function foo(s: string): void;
+export function foo(n: number): void;
+export function foo(sn: string | number): void {}
+export function bar(): void {}
+```
+
+### Invalid:
+(bar is declared in-between foo overloads)
+```typescript
+type FooType = {
+  foo(s: string): void;
+  foo(n: number): void;
+  bar(): void;
+  foo(sn: string | number): void;
+};
+```
+```typescript
+interface FooInterface {
+  foo(s: string): void;
+  foo(n: number): void;
+  bar(): void;
+  foo(sn: string | number): void;
+}
+```
+```typescript
+class FooClass {
+  foo(s: string): void;
+  foo(n: number): void;
+  bar(): void {}
+  foo(sn: string | number): void {}
+}
+```
+```typescript
+export function foo(s: string): void;
+export function foo(n: number): void;
+export function bar(): void {}
+export function foo(sn: string | number): void {}
+```"#
+  }
 }
 
 struct AdjacentOverloadSignaturesVisitor<'c> {

--- a/src/rules/adjacent_overload_signatures.rs
+++ b/src/rules/adjacent_overload_signatures.rs
@@ -115,10 +115,11 @@ impl<'c> AdjacentOverloadSignaturesVisitor<'c> {
   }
 
   fn add_diagnostic(&mut self, span: Span, fn_name: &str) {
-    self.context.add_diagnostic(
+    self.context.add_diagnostic_with_hint(
       span,
       "adjacent-overload-signatures",
       format!("All '{}' signatures should be adjacent", fn_name),
+      "Make sure all overloaded signatures are grouped together",
     );
   }
 

--- a/src/rules/ban_ts_comment.rs
+++ b/src/rules/ban_ts_comment.rs
@@ -8,6 +8,18 @@ use swc_common::Span;
 
 pub struct BanTsComment;
 
+/*
+ * This rule differs from typescript-eslint.  In typescript-eslint the following
+ * defaults apply:
+ * ts-expect-error: allowed with comment
+ * ts-ignore: not allowed
+ * ts-nocheck: not allowed
+ *
+ * This rules defaults:
+ * ts-expect-error: allowed with comment
+ * ts-ignore: allowed with comment
+ * ts-nocheck: allowed with comment
+ */
 impl BanTsComment {
   fn report(&self, context: &mut Context, span: Span) {
     context.add_diagnostic_with_hint(

--- a/src/rules/ban_ts_comment.rs
+++ b/src/rules/ban_ts_comment.rs
@@ -13,7 +13,7 @@ impl BanTsComment {
     context.add_diagnostic(
       span,
       "ban-ts-comment",
-      "ts directives are not allowed",
+      "ts directives are not allowed without comment",
     );
   }
 }
@@ -58,6 +58,40 @@ impl LintRule for BanTsComment {
     for span in violated_comment_spans {
       self.report(context, span);
     }
+  }
+
+  fn docs(&self) -> &'static str {
+    r#"Disallows the use of Typescript directives without a comment.
+
+Typescript directives reduce the effectiveness of the compiler, something which should only be done in exceptional circumstances.  The reason why should be documented in a comment alongside the directive.
+
+### Valid:
+```typescript
+// @ts-expect-error: Temporary workaround (see ticket #422)
+let a: number = "I am a string";
+```
+```typescript
+// @ts-ignore: Temporary workaround (see ticket #422)
+let a: number = "I am a string";
+```
+```typescript
+// @ts-nocheck: Temporary workaround (see ticket #422)
+let a: number = "I am a string";
+```
+
+### Invalid:
+```typescript
+// @ts-expect-error
+let a: number = "I am a string";
+```
+```typescript
+// @ts-ignore
+let a: number = "I am a string";
+```
+```typescript
+// @ts-nocheck
+let a: number = "I am a string";
+```"#
   }
 }
 

--- a/src/rules/ban_ts_comment.rs
+++ b/src/rules/ban_ts_comment.rs
@@ -10,10 +10,11 @@ pub struct BanTsComment;
 
 impl BanTsComment {
   fn report(&self, context: &mut Context, span: Span) {
-    context.add_diagnostic(
+    context.add_diagnostic_with_hint(
       span,
       "ban-ts-comment",
       "ts directives are not allowed without comment",
+      "Add an in-line comment explaining the reason for using this directive",
     );
   }
 }

--- a/src/rules/ban_ts_comment.rs
+++ b/src/rules/ban_ts_comment.rs
@@ -6,20 +6,18 @@ use swc_common::comments::Comment;
 use swc_common::comments::CommentKind;
 use swc_common::Span;
 
+/// This rule differs from typescript-eslint. In typescript-eslint the following
+/// defaults apply:
+/// - ts-expect-error: allowed with comment
+/// - ts-ignore: not allowed
+/// - ts-nocheck: not allowed
+///
+/// This rules defaults:
+/// - ts-expect-error: allowed with comment
+/// - ts-ignore: allowed with comment
+/// - ts-nocheck: allowed with comment
 pub struct BanTsComment;
 
-/*
- * This rule differs from typescript-eslint.  In typescript-eslint the following
- * defaults apply:
- * ts-expect-error: allowed with comment
- * ts-ignore: not allowed
- * ts-nocheck: not allowed
- *
- * This rules defaults:
- * ts-expect-error: allowed with comment
- * ts-ignore: allowed with comment
- * ts-nocheck: allowed with comment
- */
 impl BanTsComment {
   fn report(&self, context: &mut Context, span: Span) {
     context.add_diagnostic_with_hint(

--- a/src/rules/ban_types.rs
+++ b/src/rules/ban_types.rs
@@ -34,8 +34,8 @@ impl LintRule for BanTypes {
 
   fn docs(&self) -> &'static str {
     r#"Bans the use of primitive wrapper objects (e.g. `String` the object is a 
-      wrapper of `string` the primitive) in addition to the non-explicit `Function`
-      type and the misunderstood `Object` type. 
+wrapper of `string` the primitive) in addition to the non-explicit `Function`
+type and the misunderstood `Object` type. 
 
 There are very few situations where primitive wrapper objects are desired and
 far more often a mistake was made with the case of the primitive type.  You also 

--- a/src/rules/ban_types.rs
+++ b/src/rules/ban_types.rs
@@ -31,6 +31,44 @@ impl LintRule for BanTypes {
     let mut visitor = BanTypesVisitor::new(context);
     visitor.visit_module(module, module);
   }
+
+  fn docs(&self) -> &'static str {
+    r#"Bans the use of primitive wrapper objects (e.g. `String` the object is a 
+      wrapper of `string` the primitive) in addition to the non-explicit `Function`
+      type and the misunderstood `Object` type. 
+
+There are very few situations where primitive wrapper objects are desired and
+far more often a mistake was made with the case of the primitive type.  You also 
+cannot assign a primitive wrapper object to a primitive leading to type issues
+down the line.  
+
+With `Function`, it is better to explicitly define the entire function
+signature rather than use the non-specific `Function` type which won't give you
+type safety with the function.
+
+Finally, `Object` means "any non-nullish value" rather than "any object type".
+`Record<string, unknown>` is a good choice for a meaning of "any object type".
+
+### Valid:
+```typescript
+let a: boolean;
+let b: string;
+let c: number;
+let d: symbol;
+let e: () => number;
+let f: Record<string, unknown>;
+```
+
+### Invalid:
+```typescript
+let a: Boolean;
+let b: String;
+let c: Number;
+let d: Symbol;
+let e: Function;
+let f: Object;
+```"#
+  }
 }
 
 struct BanTypesVisitor<'c> {

--- a/src/rules/ban_untagged_ignore.rs
+++ b/src/rules/ban_untagged_ignore.rs
@@ -49,7 +49,7 @@ impl LintRule for BanUntaggedIgnore {
   fn docs(&self) -> &'static str {
     r#"Requires `deno-lint-ignore` to be annotated with one or more rule names.
 
-Ignoring all rules can mask unexpected or future problems.  Therefore you need to explicitly specify which rule(s) are to be ignored.
+Ignoring all rules can mask unexpected or future problems. Therefore you need to explicitly specify which rule(s) are to be ignored.
 
 ### Valid:
 ```typescript

--- a/src/rules/ban_untagged_ignore.rs
+++ b/src/rules/ban_untagged_ignore.rs
@@ -54,13 +54,13 @@ Ignoring all rules can mask unexpected or future problems.  Therefore you need t
 ### Valid:
 ```typescript
 // deno-lint-ignore no-dupe-args
-export function dupeArgs1(a, b, a) { }
+export function duplicateArgumentsFn(a, b, a) { }
 ```
 
 ### Invalid:
 ```typescript
 // deno-lint-ignore
-export function dupeArgs1(a, b, a) { }
+export function duplicateArgumentsFn(a, b, a) { }
 ```"#
   }
 }

--- a/src/rules/ban_untagged_ignore.rs
+++ b/src/rules/ban_untagged_ignore.rs
@@ -37,12 +37,31 @@ impl LintRule for BanUntaggedIgnore {
       .collect();
 
     for span in violated_spans {
-      context.add_diagnostic(
+      context.add_diagnostic_with_hint(
         span,
         "ban-untagged-ignore",
-        "Ignore directive requires lint rule code",
+        "Ignore directive requires lint rule name(s)",
+        "Add one or more lint rule names.  E.g. // deno-lint-ignore adjacent-overload-signatures",
       )
     }
+  }
+
+  fn docs(&self) -> &'static str {
+    r#"Requires `deno-lint-ignore` to be annotated with one or more rule names.
+
+Ignoring all rules can mask unexpected or future problems.  Therefore you need to explicitly specify which rule(s) are to be ignored.
+
+### Valid:
+```typescript
+// deno-lint-ignore no-dupe-args
+export function dupeArgs1(a, b, a) { }
+```
+
+### Invalid:
+```typescript
+// deno-lint-ignore
+export function dupeArgs1(a, b, a) { }
+```"#
   }
 }
 

--- a/src/rules/ban_untagged_todo.rs
+++ b/src/rules/ban_untagged_todo.rs
@@ -10,10 +10,11 @@ pub struct BanUntaggedTodo;
 
 impl BanUntaggedTodo {
   fn report(&self, context: &mut Context, span: Span) {
-    context.add_diagnostic(
+    context.add_diagnostic_with_hint(
       span,
       "ban-untagged-todo",
       "TODO should be tagged with (@username) or (#issue)",
+      "Add a user tag, e.g. @djones, or issue reference, e.g. #123, to the TODO comment"
     );
   }
 }
@@ -54,6 +55,28 @@ impl LintRule for BanUntaggedTodo {
     for span in violated_comment_spans {
       self.report(context, span);
     }
+  }
+
+  fn docs(&self) -> &'static str {
+    r#"Requires TODOs to be annotated with either a user tag (@user) or an issue reference (#issue).
+
+TODOs without reference to a user or an issue become stale with no easy way to get more information
+
+### Valid:
+```typescript
+// TODO Improve calc engine (@djones)
+export function calcValue(): number { }
+```
+```typescript
+// TODO Improve calc engine (#332)
+export function calcValue(): number { }
+```
+
+### Invalid:
+```typescript
+// TODO Improve calc engine
+export function calcValue(): number { }
+```"#
   }
 }
 

--- a/src/rules/ban_untagged_todo.rs
+++ b/src/rules/ban_untagged_todo.rs
@@ -60,7 +60,7 @@ impl LintRule for BanUntaggedTodo {
   fn docs(&self) -> &'static str {
     r#"Requires TODOs to be annotated with either a user tag (@user) or an issue reference (#issue).
 
-TODOs without reference to a user or an issue become stale with no easy way to get more information
+TODOs without reference to a user or an issue become stale with no easy way to get more information.
 
 ### Valid:
 ```typescript


### PR DESCRIPTION
This PR:
* Adds clarity in comments to the differences in `ban-ts-comment` between typescript-eslint and deno lint
* Adds documentation to `ban-types`, `ban-untagged-ignore` and `ban-untagged-todo`