### PR TITLE
fix(no-dupe-keys): handle nested objects & getter and setter with the same name

### DIFF
--- a/src/rules/no_dupe_keys.rs
+++ b/src/rules/no_dupe_keys.rs
@@ -153,29 +153,33 @@ mod tests {
       r#"var foo = { bar: "baz", set bar() {} };"#,
       10,
     );
-    assert_lint_err::<NoDupeKeys>(r#"var x = { a: b, ['a']: b };"#, 0);
-    assert_lint_err::<NoDupeKeys>(r#"var x = { '': 1, '': 2 };"#, 0);
-    assert_lint_err::<NoDupeKeys>(r#"var x = { '': 1, [``]: 2 };"#, 0);
-    assert_lint_err::<NoDupeKeys>(r#"var x = { 012: 1, 10: 2 };"#, 0);
-    assert_lint_err::<NoDupeKeys>(r#"var x = { 0b1: 1, 1: 2 };"#, 0);
-    assert_lint_err::<NoDupeKeys>(r#"var x = { 0o1: 1, 1: 2 };"#, 0);
-    assert_lint_err::<NoDupeKeys>(r#"var x = { 1n: 1, 1: 2 };"#, 0);
-    assert_lint_err::<NoDupeKeys>(r#"var x = { 1_0: 1, 10: 2 };"#, 0);
-    assert_lint_err::<NoDupeKeys>(r#"var x = { "z": 1, z: 2 };"#, 0);
-    assert_lint_err::<NoDupeKeys>(
-      r#"var foo = {
+    assert_lint_err::<NoDupeKeys>(r#"var x = { a: b, ['a']: b };"#, 8);
+    assert_lint_err::<NoDupeKeys>(r#"var x = { '': 1, '': 2 };"#, 8);
+    assert_lint_err::<NoDupeKeys>(r#"var x = { '': 1, [``]: 2 };"#, 8);
+    assert_lint_err::<NoDupeKeys>(r#"var x = { 012: 1, 10: 2 };"#, 8);
+    assert_lint_err::<NoDupeKeys>(r#"var x = { 0b1: 1, 1: 2 };"#, 8);
+    assert_lint_err::<NoDupeKeys>(r#"var x = { 0o1: 1, 1: 2 };"#, 8);
+    // TODO(magurotuna): this leads to panic due to swc error
+    // assert_lint_err::<NoDupeKeys>(r#"var x = { 1n: 1, 1: 2 };"#, 8);
+    assert_lint_err::<NoDupeKeys>(r#"var x = { 1_0: 1, 10: 2 };"#, 8);
+    assert_lint_err::<NoDupeKeys>(r#"var x = { "z": 1, z: 2 };"#, 8);
+    assert_lint_err_on_line::<NoDupeKeys>(
+      r#"
+var foo = {
   bar: 1,
   bar: 1,
-}"#,
-      0,
+}
+"#,
+      2,
+      10,
     );
     assert_lint_err::<NoDupeKeys>(
       r#"var x = { a: 1, b: { a: 2 }, get b() {} };"#,
-      0,
+      8,
     );
     assert_lint_err::<NoDupeKeys>(
       r#"var x = ({ '/(?<zero>0)/': 1, [/(?<zero>0)/]: 2 })"#,
-      0,
+      9,
     );
   }
 }

--- a/src/rules/no_dupe_keys.rs
+++ b/src/rules/no_dupe_keys.rs
@@ -281,6 +281,8 @@ let x = {
     assert_lint_err::<NoDupeKeys>(r#"var x = { 0b1: 1, 1: 2 };"#, 8);
     assert_lint_err::<NoDupeKeys>(r#"var x = { 0o1: 1, 1: 2 };"#, 8);
     // TODO(magurotuna): this leads to panic due to swc error
+    // It seems like tsc v4.0.2 cannot handle this either
+    // playground: https://www.typescriptlang.org/play?target=99&ts=4.0.2#code/MYewdgzgLgBCBGArGBeGBvAUDGBGMAXDACwBMANJgL4DcQA
     // assert_lint_err::<NoDupeKeys>(r#"var x = { 1n: 1, 1: 2 };"#, 8);
     assert_lint_err::<NoDupeKeys>(r#"var x = { 1_0: 1, 10: 2 };"#, 8);
     assert_lint_err::<NoDupeKeys>(r#"var x = { "z": 1, z: 2 };"#, 8);

--- a/src/rules/no_dupe_keys.rs
+++ b/src/rules/no_dupe_keys.rs
@@ -102,60 +102,80 @@ mod tests {
   use super::*;
   use crate::test_util::*;
 
-  #[test]
-  fn it_passes_when_there_are_no_duplicate_keys() {
-    assert_lint_ok::<NoDupeKeys>(r#"var foo = { bar: "baz", boo: "bang" }"#);
-  }
+  // Some tests are derived from
+  // https://github.com/eslint/eslint/blob/v7.11.0/tests/lib/rules/no-dupe-keys.js
+  // MIT Licensed.
 
   #[test]
-  fn it_passes_when_there_are_duplicate_nested_keys() {
+  fn no_dupe_keys_valid() {
+    assert_lint_ok::<NoDupeKeys>(r#"var foo = { bar: "baz", boo: "bang" }"#);
     assert_lint_ok::<NoDupeKeys>(
       r#"var foo = { bar: "baz", boo: { bar: "bang", }, }"#,
     );
+    assert_lint_ok::<NoDupeKeys>(r#"var foo = { __proto__: 1, two: 2};"#);
+    assert_lint_ok::<NoDupeKeys>(r#"var x = { '': 1, bar: 2 };"#);
+    assert_lint_ok::<NoDupeKeys>(r#"var x = { '': 1, ' ': 2 };"#);
+    assert_lint_ok::<NoDupeKeys>(r#"var x = { '': 1, [null]: 2 };"#);
+    assert_lint_ok::<NoDupeKeys>(r#"var x = { '': 1, [a]: 2 };"#);
+    assert_lint_ok::<NoDupeKeys>(r#"var x = { [a]: 1, [a]: 2 };"#);
+    assert_lint_ok::<NoDupeKeys>(r#"+{ get a() { }, set a(b) { } };"#);
+    assert_lint_ok::<NoDupeKeys>(r#"var x = { a: b, [a]: b };"#);
+    assert_lint_ok::<NoDupeKeys>(r#"var x = { a: b, ...c }"#);
+    assert_lint_ok::<NoDupeKeys>(
+      r#"var x = { get a() {}, set a (value) {} };"#,
+    );
+    assert_lint_ok::<NoDupeKeys>(r#"var x = ({ null: 1, [/(?<zero>0)/]: 2 })"#);
+    assert_lint_ok::<NoDupeKeys>(r#"var {a, a} = obj"#);
+    assert_lint_ok::<NoDupeKeys>(r#"var x = { 012: 1, 12: 2 };"#);
+    assert_lint_ok::<NoDupeKeys>(r#"var x = { 1_0: 1, 1: 2 };"#);
   }
 
   #[test]
-  fn it_fails_when_there_are_duplicate_keys() {
+  fn no_dupe_keys_invalid() {
     assert_lint_err::<NoDupeKeys>(
       r#"var foo = { bar: "baz", bar: "qux" };"#,
       10,
     );
-  }
-
-  #[test]
-  fn it_fails_when_there_are_multiple_duplicate_keys() {
     assert_lint_err_n::<NoDupeKeys>(
       r#"var foo = { bar: "baz", bar: "qux", quux: "boom", quux: "bang" };"#,
       vec![10, 10],
     );
-  }
-
-  #[test]
-  fn it_fails_when_there_are_duplicate_string_keys() {
     assert_lint_err::<NoDupeKeys>(
       r#"var foo = { bar: "baz", "bar": "qux" };"#,
       10,
     );
-  }
-
-  #[test]
-  fn it_fails_when_there_are_duplicate_numeric_keys() {
     assert_lint_err::<NoDupeKeys>(r#"var foo = { 1: "baz", 0x1: "qux" };"#, 10);
-  }
-
-  #[test]
-  fn it_fails_when_there_are_duplicate_getter_keys() {
     assert_lint_err::<NoDupeKeys>(
       r#"var foo = { bar: "baz", get bar() {} };"#,
       10,
     );
-  }
-
-  #[test]
-  fn it_fails_when_there_are_duplicate_setter_keys() {
     assert_lint_err::<NoDupeKeys>(
       r#"var foo = { bar: "baz", set bar() {} };"#,
       10,
+    );
+    assert_lint_err::<NoDupeKeys>(r#"var x = { a: b, ['a']: b };"#, 0);
+    assert_lint_err::<NoDupeKeys>(r#"var x = { '': 1, '': 2 };"#, 0);
+    assert_lint_err::<NoDupeKeys>(r#"var x = { '': 1, [``]: 2 };"#, 0);
+    assert_lint_err::<NoDupeKeys>(r#"var x = { 012: 1, 10: 2 };"#, 0);
+    assert_lint_err::<NoDupeKeys>(r#"var x = { 0b1: 1, 1: 2 };"#, 0);
+    assert_lint_err::<NoDupeKeys>(r#"var x = { 0o1: 1, 1: 2 };"#, 0);
+    assert_lint_err::<NoDupeKeys>(r#"var x = { 1n: 1, 1: 2 };"#, 0);
+    assert_lint_err::<NoDupeKeys>(r#"var x = { 1_0: 1, 10: 2 };"#, 0);
+    assert_lint_err::<NoDupeKeys>(r#"var x = { "z": 1, z: 2 };"#, 0);
+    assert_lint_err::<NoDupeKeys>(
+      r#"var foo = {
+  bar: 1,
+  bar: 1,
+}"#,
+      0,
+    );
+    assert_lint_err::<NoDupeKeys>(
+      r#"var x = { a: 1, b: { a: 2 }, get b() {} };"#,
+      0,
+    );
+    assert_lint_err::<NoDupeKeys>(
+      r#"var x = ({ '/(?<zero>0)/': 1, [/(?<zero>0)/]: 2 })"#,
+      0,
     );
   }
 }


### PR DESCRIPTION
This is a part of #330 

What I did In this PR:

- adding more tests (mostly from ESLint)
- allowing it to handle nested objects e.g. `const obj = { a: { b: 1, b: 2 } };`
- adding proper handling for getter and setter with the same name e.g. `const obj = { get a() {}, set a() {} };`