### PR TITLE
doc: add lint docs

### DIFF
--- a/src/rules/explicit_function_return_type.rs
+++ b/src/rules/explicit_function_return_type.rs
@@ -24,6 +24,26 @@ impl LintRule for ExplicitFunctionReturnType {
     let mut visitor = ExplicitFunctionReturnTypeVisitor::new(context);
     visitor.visit_module(module, module);
   }
+
+  fn docs(&self) -> &'static str {
+    r#"Requires all functions to have explicit return types.
+
+Explicit return types have a number of advantages including easier to understand
+code and better type safety.  It is clear from the signature what the return 
+type of the function (if any) will be.
+    
+### Valid:
+```typescript
+function someCalc(): number { return 2*2; }
+function anotherCalc(): void { return; }
+```
+
+### Invalid:
+```typescript
+function someCalc() { return 2*2; }
+function anotherCalc() { return; }
+```"#
+  }
 }
 
 struct ExplicitFunctionReturnTypeVisitor<'c> {
@@ -45,10 +65,11 @@ impl<'c> Visit for ExplicitFunctionReturnTypeVisitor<'c> {
     _parent: &dyn Node,
   ) {
     if function.return_type.is_none() {
-      self.context.add_diagnostic(
+      self.context.add_diagnostic_with_hint(
         function.span,
         "explicit-function-return-type",
         "Missing return type on function",
+        "Add a return type to the function signature",
       );
     }
     for stmt in &function.body {

--- a/src/rules/for_direction.rs
+++ b/src/rules/for_direction.rs
@@ -39,6 +39,25 @@ impl LintRule for ForDirection {
     let mut visitor = ForDirectionVisitor::new(context);
     visitor.visit_module(module, module);
   }
+
+  fn docs(&self) -> &'static str {
+    r#"Requires `for` loop control variables to increment in the correct direction
+
+Incrementing `for` loop control variables in the wrong direction leads to infinite
+loops.  This can occur through incorrect initialization, bad continuation step logic
+or wrong direction incrementing of the loop control variable.  
+    
+### Valid:
+```typescript
+for(let i = 0; i < 2; i++) {}
+```
+
+### Invalid:
+```typescript
+// Infinite loop
+for(let i = 0; i < 2; i--) {}
+```"#
+  }
 }
 
 struct ForDirectionVisitor<'c> {
@@ -159,10 +178,11 @@ impl<'c> Visit for ForDirectionVisitor<'c> {
         };
 
         if update_direction == wrong_direction {
-          self.context.add_diagnostic(
+          self.context.add_diagnostic_with_hint(
             for_stmt.span,
             "for-direction",
             "Update clause moves variable in the wrong direction",
+            "Flip the update clause logic or change the continuation step condition"
           );
         }
       }

--- a/src/rules/getter_return.rs
+++ b/src/rules/getter_return.rs
@@ -38,6 +38,39 @@ impl LintRule for GetterReturn {
     visitor.visit_module(module, module);
     visitor.report();
   }
+
+  fn docs(&self) -> &'static str {
+    r#"Requires all property getter functions to return a value
+
+Getter functions return the value of a property.  If the function returns no
+value then this contract is broken.
+    
+### Valid:
+```typescript
+let foo = { 
+  get bar() { 
+    return true; 
+  }
+};
+
+class Person { 
+  get name() { 
+    return "alice"; 
+  }
+}
+```
+
+### Invalid:
+```typescript
+let foo = { 
+  get bar() {}
+};
+
+class Person { 
+  get name() {}
+}
+```"#
+  }
 }
 
 struct GetterReturnVisitor<'c> {
@@ -61,7 +94,12 @@ impl<'c> GetterReturnVisitor<'c> {
 
   fn report(&mut self) {
     for (span, msg) in &self.errors {
-      self.context.add_diagnostic(*span, "getter-return", msg);
+      self.context.add_diagnostic_with_hint(
+        *span,
+        "getter-return",
+        msg,
+        "Return a value from the getter function",
+      );
     }
   }
 


### PR DESCRIPTION
This PR contributes to #159, with docs on the following rules:
* explicit-function-return-types
* explicit-module-boundary-types
* for-direction
* getter-return