### PR TITLE
test(no-constant-condition): add tests to make sure else-if is handled

### DIFF
--- a/src/rules/no_constant_condition.rs
+++ b/src/rules/no_constant_condition.rs
@@ -399,6 +399,18 @@ mod tests {
 
     // nested
     assert_lint_err::<NoConstantCondition>(r#"if (foo) { if (true) {} }"#, 15);
+    assert_lint_err::<NoConstantCondition>(
+      r#"if (foo) {} else if (true) {}"#,
+      21,
+    );
+    assert_lint_err::<NoConstantCondition>(
+      r#"if (foo) {} else if (bar) {} else if (true) {}"#,
+      38,
+    );
+    assert_lint_err::<NoConstantCondition>(
+      r#"if (foo) {} else { if (true) {} }"#,
+      23,
+    );
     assert_lint_err::<NoConstantCondition>(r#"foo ? true ? 1 : 2 : 3"#, 6);
   }
 


### PR DESCRIPTION
I was going to fix the false negative that described in #417, but in fact, I fixed it already in #404.
So in this PR, I just added some more tests to make sure `else-if` is handled correctly.

Closes #417 