### PR TITLE
doc: put invalid examples first and add new docs

### DIFF
--- a/src/rules/adjacent_overload_signatures.rs
+++ b/src/rules/adjacent_overload_signatures.rs
@@ -38,39 +38,6 @@ impl LintRule for AdjacentOverloadSignatures {
 
 Overloaded signatures which are not next to each other can lead to code which is hard to read and maintain.
 
-### Valid:
-(bar is declared after foo)
-```typescript
-type FooType = {
-  foo(s: string): void;
-  foo(n: number): void;
-  foo(sn: string | number): void;
-  bar(): void;
-};
-```
-```typescript
-interface FooInterface {
-  foo(s: string): void;
-  foo(n: number): void;
-  foo(sn: string | number): void;
-  bar(): void;
-}
-```
-```typescript
-class FooClass {
-  foo(s: string): void;
-  foo(n: number): void;
-  foo(sn: string | number): void {}
-  bar(): void {}
-}
-```
-```typescript
-export function foo(s: string): void;
-export function foo(n: number): void;
-export function foo(sn: string | number): void {}
-export function bar(): void {}
-```
-
 ### Invalid:
 (bar is declared in-between foo overloads)
 ```typescript
@@ -102,6 +69,38 @@ export function foo(s: string): void;
 export function foo(n: number): void;
 export function bar(): void {}
 export function foo(sn: string | number): void {}
+```
+### Valid:
+(bar is declared after foo)
+```typescript
+type FooType = {
+  foo(s: string): void;
+  foo(n: number): void;
+  foo(sn: string | number): void;
+  bar(): void;
+};
+```
+```typescript
+interface FooInterface {
+  foo(s: string): void;
+  foo(n: number): void;
+  foo(sn: string | number): void;
+  bar(): void;
+}
+```
+```typescript
+class FooClass {
+  foo(s: string): void;
+  foo(n: number): void;
+  foo(sn: string | number): void {}
+  bar(): void {}
+}
+```
+```typescript
+export function foo(s: string): void;
+export function foo(n: number): void;
+export function foo(sn: string | number): void {}
+export function bar(): void {}
 ```"#
   }
 }

--- a/src/rules/ban_ts_comment.rs
+++ b/src/rules/ban_ts_comment.rs
@@ -76,6 +76,20 @@ impl LintRule for BanTsComment {
 
 Typescript directives reduce the effectiveness of the compiler, something which should only be done in exceptional circumstances.  The reason why should be documented in a comment alongside the directive.
 
+### Invalid:
+```typescript
+// @ts-expect-error
+let a: number = "I am a string";
+```
+```typescript
+// @ts-ignore
+let a: number = "I am a string";
+```
+```typescript
+// @ts-nocheck
+let a: number = "I am a string";
+```
+
 ### Valid:
 ```typescript
 // @ts-expect-error: Temporary workaround (see ticket #422)
@@ -89,20 +103,7 @@ let a: number = "I am a string";
 // @ts-nocheck: Temporary workaround (see ticket #422)
 let a: number = "I am a string";
 ```
-
-### Invalid:
-```typescript
-// @ts-expect-error
-let a: number = "I am a string";
-```
-```typescript
-// @ts-ignore
-let a: number = "I am a string";
-```
-```typescript
-// @ts-nocheck
-let a: number = "I am a string";
-```"#
+"#
   }
 }
 

--- a/src/rules/ban_types.rs
+++ b/src/rules/ban_types.rs
@@ -49,6 +49,16 @@ type safety with the function.
 Finally, `Object` means "any non-nullish value" rather than "any object type".
 `Record<string, unknown>` is a good choice for a meaning of "any object type".
 
+### Invalid:
+```typescript
+let a: Boolean;
+let b: String;
+let c: Number;
+let d: Symbol;
+let e: Function;
+let f: Object;
+```
+
 ### Valid:
 ```typescript
 let a: boolean;
@@ -58,16 +68,7 @@ let d: symbol;
 let e: () => number;
 let f: Record<string, unknown>;
 ```
-
-### Invalid:
-```typescript
-let a: Boolean;
-let b: String;
-let c: Number;
-let d: Symbol;
-let e: Function;
-let f: Object;
-```"#
+"#
   }
 }
 

--- a/src/rules/ban_untagged_ignore.rs
+++ b/src/rules/ban_untagged_ignore.rs
@@ -51,17 +51,18 @@ impl LintRule for BanUntaggedIgnore {
 
 Ignoring all rules can mask unexpected or future problems. Therefore you need to explicitly specify which rule(s) are to be ignored.
 
+### Invalid:
+```typescript
+// deno-lint-ignore
+export function duplicateArgumentsFn(a, b, a) { }
+```
+
 ### Valid:
 ```typescript
 // deno-lint-ignore no-dupe-args
 export function duplicateArgumentsFn(a, b, a) { }
 ```
-
-### Invalid:
-```typescript
-// deno-lint-ignore
-export function duplicateArgumentsFn(a, b, a) { }
-```"#
+"#
   }
 }
 

--- a/src/rules/ban_untagged_todo.rs
+++ b/src/rules/ban_untagged_todo.rs
@@ -62,6 +62,12 @@ impl LintRule for BanUntaggedTodo {
 
 TODOs without reference to a user or an issue become stale with no easy way to get more information.
 
+### Invalid:
+```typescript
+// TODO Improve calc engine
+export function calcValue(): number { }
+```
+
 ### Valid:
 ```typescript
 // TODO Improve calc engine (@djones)
@@ -71,12 +77,7 @@ export function calcValue(): number { }
 // TODO Improve calc engine (#332)
 export function calcValue(): number { }
 ```
-
-### Invalid:
-```typescript
-// TODO Improve calc engine
-export function calcValue(): number { }
-```"#
+"#
   }
 }
 

--- a/src/rules/constructor_super.rs
+++ b/src/rules/constructor_super.rs
@@ -40,18 +40,6 @@ Defined constructors of derived classes (e.g. `class A extends B`) must always c
 `super()`.  Classes which extend non-constructors (e.g. `class A extends null`) must
 not have a constructor.
 
-### Valid:
-```typescript
-class A {}
-class B extends A {}
-class C extends A {
-  constructor() {
-    super();
-  }
-}
-class D extends null {}
-```
-
 ### Invalid:
 ```typescript
 class A {}
@@ -75,7 +63,20 @@ class E extends null {
     super();
   }
 }
-```"#
+```
+
+### Valid:
+```typescript
+class A {}
+class B extends A {}
+class C extends A {
+  constructor() {
+    super();
+  }
+}
+class D extends null {}
+```
+"#
   }
 }
 

--- a/src/rules/default_param_last.rs
+++ b/src/rules/default_param_last.rs
@@ -35,6 +35,12 @@ Parameters with default values are optional by nature but cannot be left out
 of the function call without mapping the function inputs to different parameters
 which is confusing and error prone.  Specifying them last allows them to be left
 out without changing the semantics of the other parameters.
+
+### Invalid:
+```typescript
+function f(a = 2, b) {}
+function f(a = 5, b, c = 5) {}
+```
     
 ### Valid:
 ```typescript
@@ -46,12 +52,7 @@ function f(a, b = 5, c = 5) {}
 function f(a, b = 5, ...c) {}
 function f(a = 2, b = 3) {}
 ```
-
-### Invalid:
-```typescript
-function f(a = 2, b) {}
-function f(a = 5, b, c = 5) {}
-```"#
+"#
   }
 }
 

--- a/src/rules/eqeqeq.rs
+++ b/src/rules/eqeqeq.rs
@@ -35,17 +35,18 @@ value.  On the other hand `==` and `!=` do type coercion before value checking
 which can lead to unexpected results.  For example `5 == "5"` is true, while
 `5 === "5"` is false.
 
+### Invalid:
+```typescript
+if (a == 5) {}
+if ("hello world" != input) {}
+```
+
 ### Valid:
 ```typescript
 if (a === 5) {}
 if ("hello world" !== input) {}
 ```
-
-### Invalid:
-```typescript
-if (a == 5) {}
-if ("hello world" != input) {}
-```"#
+"#
   }
 }
 

--- a/src/rules/explicit_function_return_type.rs
+++ b/src/rules/explicit_function_return_type.rs
@@ -31,18 +31,19 @@ impl LintRule for ExplicitFunctionReturnType {
 Explicit return types have a number of advantages including easier to understand
 code and better type safety.  It is clear from the signature what the return 
 type of the function (if any) will be.
+
+### Invalid:
+```typescript
+function someCalc() { return 2*2; }
+function anotherCalc() { return; }
+```
     
 ### Valid:
 ```typescript
 function someCalc(): number { return 2*2; }
 function anotherCalc(): void { return; }
 ```
-
-### Invalid:
-```typescript
-function someCalc() { return 2*2; }
-function anotherCalc() { return; }
-```"#
+"#
   }
 }
 

--- a/src/rules/explicit_module_boundary_types.rs
+++ b/src/rules/explicit_module_boundary_types.rs
@@ -35,6 +35,20 @@ inputs and outputs of a module (known as the module boundary).  This will make
 it very clear to any users of the module how to supply inputs and handle
 outputs in a type safe manner.
 
+### Invalid:
+```typescript
+// Missing return type (e.g. void)
+export function printDoc(doc: string, doubleSided: boolean) { return; }
+
+// Missing argument type (e.g. `arg` is of type string)
+export var arrowFn = (arg): string => `hello ${arg}`;
+
+// Missing return type (e.g. boolean)
+export function isValid() {
+  return true;
+}
+```
+
 ### Valid:
 ```typescript
 // Typed input parameters and return value
@@ -48,20 +62,7 @@ function isValid() {
   return true;
 }
 ```
-
-### Invalid:
-```typescript
-// Missing return type (e.g. void)
-export function printDoc(doc: string, doubleSided: boolean) { return; }
-
-// Missing argument type (e.g. `arg` is of type string)
-export var arrowFn = (arg): string => `hello ${arg}`;
-
-// Missing return type (e.g. boolean)
-export function isValid() {
-  return true;
-}
-```"#
+"#
   }
 }
 

--- a/src/rules/for_direction.rs
+++ b/src/rules/for_direction.rs
@@ -46,17 +46,18 @@ impl LintRule for ForDirection {
 Incrementing `for` loop control variables in the wrong direction leads to infinite
 loops.  This can occur through incorrect initialization, bad continuation step logic
 or wrong direction incrementing of the loop control variable.  
-    
-### Valid:
-```typescript
-for(let i = 0; i < 2; i++) {}
-```
 
 ### Invalid:
 ```typescript
 // Infinite loop
 for(let i = 0; i < 2; i--) {}
-```"#
+```
+
+### Valid:
+```typescript
+for(let i = 0; i < 2; i++) {}
+```
+"#
   }
 }
 

--- a/src/rules/getter_return.rs
+++ b/src/rules/getter_return.rs
@@ -44,6 +44,17 @@ impl LintRule for GetterReturn {
 
 Getter functions return the value of a property.  If the function returns no
 value then this contract is broken.
+
+### Invalid:
+```typescript
+let foo = { 
+  get bar() {}
+};
+
+class Person { 
+  get name() {}
+}
+```
     
 ### Valid:
 ```typescript
@@ -59,17 +70,7 @@ class Person {
   }
 }
 ```
-
-### Invalid:
-```typescript
-let foo = { 
-  get bar() {}
-};
-
-class Person { 
-  get name() {}
-}
-```"#
+"#
   }
 }
 

--- a/src/rules/no_array_constructor.rs
+++ b/src/rules/no_array_constructor.rs
@@ -45,13 +45,6 @@ the `Array` global may be redefined.
 
 The one exception to this rule is when creating a new array of fixed size, e.g.
 `new Array(6)`.  This is the conventional way to create arrays of fixed length.
-    
-### Valid:
-```typescript
-const a = new Array(100);
-const b = [];
-const c = [1,2,3];
-```
 
 ### Invalid:
 ```typescript
@@ -59,7 +52,15 @@ const c = [1,2,3];
 const a = new Array(100, 1, 2, 3);
 
 const b = new Array(); // use [] instead
-```"#
+```
+    
+### Valid:
+```typescript
+const a = new Array(100);
+const b = [];
+const c = [1,2,3];
+```
+"#
   }
 }
 

--- a/src/rules/no_async_promise_executor.rs
+++ b/src/rules/no_async_promise_executor.rs
@@ -46,18 +46,19 @@ sign that it is not actually necessary to use the new Promise constructor and th
 code can be restructured to avoid the use of a promise, or the scope of the new
 Promise constructor can be reduced, extracting the async code and changing it to
 be synchronous.
+
+### Invalid:
+```typescript
+new Promise(async function(resolve, reject) {});
+new Promise(async (resolve, reject) => {});
+```
     
 ### Valid:
 ```typescript
 new Promise(function(resolve, reject) {});
 new Promise((resolve, reject) => {});
 ```
-
-### Invalid:
-```typescript
-new Promise(async function(resolve, reject) {});
-new Promise(async (resolve, reject) => {});
-```"#
+"#
   }
 }
 

--- a/src/rules/no_await_in_loop.rs
+++ b/src/rules/no_await_in_loop.rs
@@ -39,6 +39,18 @@ until the current element finishes.
 A common solution is to refactor the code to run the loop body asynchronously and
 capture the promises generated.  After the loop finishes you can then await all
 the promises at once.
+
+### Invalid:
+```javascript
+async function doSomething(items) {
+  const results = [];
+  for (const item of items) {
+    // Each item in the array blocks on the previous one finishing
+    results.push(await someAsyncProcessing(item));
+  }
+  return processResults(results);
+}
+```
     
 ### Valid:
 ```javascript
@@ -52,18 +64,7 @@ async function doSomething(items) {
   return processResults(await Promise.all(results));
 }
 ```
-
-### Invalid:
-```javascript
-async function doSomething(items) {
-  const results = [];
-  for (const item of items) {
-    // Each item in the array blocks on the previous one finishing
-    results.push(await someAsyncProcessing(item));
-  }
-  return processResults(results);
-}
-```"#
+"#
   }
 }
 

--- a/src/rules/no_case_declarations.rs
+++ b/src/rules/no_case_declarations.rs
@@ -44,6 +44,24 @@ which only happens if that case/default is reached.  This can lead to unexpected
 errors.  The solution is to ensure each `case` or `default` block is wrapped in
 brackets to scope limit the declarations.
 
+### Invalid:
+```typescript
+switch (choice) {
+  // `let`, `const`, `function` and `class` are scoped the entire switch statement here
+  case 1:
+      let a = "choice 1";
+      break;
+  case 2:
+      const b = "choice 2";
+      break;
+  case 3:
+      function f() { return "choice 3"; }
+      break;
+  default:
+      class C {}
+}
+```
+
 ### Valid:
 ```typescript
 switch (choice) {
@@ -65,24 +83,7 @@ switch (choice) {
   }
 }
 ```
-
-### Invalid:
-```typescript
-switch (choice) {
-  // `let`, `const`, `function` and `class` are scoped the entire switch statement here
-  case 1:
-      let a = "choice 1";
-      break;
-  case 2:
-      const b = "choice 2";
-      break;
-  case 3:
-      function f() { return "choice 3"; }
-      break;
-  default:
-      class C {}
-}
-```"#
+"#
   }
 }
 

--- a/src/rules/no_compare_neg_zero.rs
+++ b/src/rules/no_compare_neg_zero.rs
@@ -35,17 +35,14 @@ Comparing a value directly against negative may not work as expected as it will 
 
 ### Invalid:
 ```typescript
-if (x === -0) {
-}
+if (x === -0) {}
 ```
+
 ### Valid:
 ```typescript
-if (x === 0) {
-}
-```
-```typescript
-if (Object.is(x, -0)) {
-}
+if (x === 0) {}
+
+if (Object.is(x, -0)) {}
 ```"#
   }
 }
@@ -69,10 +66,11 @@ impl<'c> VisitAll for NoCompareNegZeroVisitor<'c> {
     }
 
     if bin_expr.left.is_neg_zero() || bin_expr.right.is_neg_zero() {
-      self.context.add_diagnostic(
+      self.context.add_diagnostic_with_hint(
         bin_expr.span,
         "no-compare-neg-zero",
         "Do not compare against -0",
+        "Use `Object.is(x, -0)` for comparing against negative 0 (`-0`)",
       );
     }
   }

--- a/src/rules/no_cond_assign.rs
+++ b/src/rules/no_cond_assign.rs
@@ -31,6 +31,21 @@ impl LintRule for NoCondAssign {
 
 Use of the assignment operator within a conditional statement is often the result of mistyping the equality operator, `==`. If an assignment within a conditional statement is required then this rule allows it by wrapping the assignment in parentheses.
 
+### Invalid:
+```typescript
+var x;
+if (x = 0) {
+  var b = 1;
+}
+```
+```typescript
+function setHeight(someNode) {
+  do {
+    someNode.height = "100px";
+  } while (someNode = someNode.parentNode);
+}
+```
+
 ### Valid:
 ```typescript
 var x;
@@ -45,21 +60,7 @@ function setHeight(someNode) {
   } while ((someNode = someNode.parentNode));
 }
 ```
-
-### Invalid:
-```typescript
-var x;
-if (x = 0) {
-  var b = 1;
-}
-```
-```typescript
-function setHeight(someNode) {
-  do {
-    someNode.height = "100px";
-  } while (someNode = someNode.parentNode);
-}
-```"#
+"#
   }
 }
 
@@ -73,10 +74,11 @@ impl<'c> NoCondAssignVisitor<'c> {
   }
 
   fn add_diagnostic(&mut self, span: Span) {
-    self.context.add_diagnostic(
+    self.context.add_diagnostic_with_hint(
       span,
       "no-cond-assign",
       "Expected a conditional expression and instead saw an assignment",
+      "Change assignment (`=`) to comparison (`===`) or move assignment out of condition"
     );
   }
 

--- a/src/rules/no_const_assign.rs
+++ b/src/rules/no_const_assign.rs
@@ -31,6 +31,31 @@ impl LintRule for NoConstAssign {
     let mut visitor = NoConstAssignVisitor::new(context);
     visitor.visit_module(module, module);
   }
+
+  fn docs(&self) -> &'static str {
+    r#"Disallows modifying a variable declared as `const`.
+
+Modifying a variable declared as `const` will result in a runtime error.
+
+### Invalid:
+```typescript
+const a = 0;
+a = 1;
+a += 1;
+a++;
+++a;
+```
+
+### Valid:
+```typescript
+const a = 0;
+const b = a + 1;
+
+// `c` is out of scope on each loop iteration, allowing a new assignment
+for (const c in [1,2,3]) {}
+```
+"#
+  }
 }
 
 struct NoConstAssignVisitor<'c> {
@@ -94,10 +119,11 @@ impl<'c> NoConstAssignVisitor<'c> {
     let id = name.to_id();
     if let Some(v) = self.context.scope.var(&id) {
       if let BindingKind::Const = v.kind() {
-        self.context.add_diagnostic(
+        self.context.add_diagnostic_with_hint(
           span,
           "no-const-assign",
           "Reassigning constant variable is not allowed",
+          "Change `const` declaration to `let` or double check the correct variable is used"
         );
       }
     }

--- a/src/rules/no_constant_condition.rs
+++ b/src/rules/no_constant_condition.rs
@@ -28,6 +28,28 @@ impl LintRule for NoConstantCondition {
     let mut visitor = NoConstantConditionVisitor::new(context);
     module.visit_all_with(module, &mut visitor);
   }
+
+  fn docs(&self) -> &'static str {
+    r#"Disallows the use of a constant expression in conditional test
+
+Using a constant expression in a conditional test is often either a mistake or a
+temporary situation introduced during development and is not ready for production.
+
+### Invalid:
+```typescript
+if (true) {}
+if (2) {}
+do {} while (x = 2);  // infinite loop
+```
+
+### Valid:
+```typescript
+if (x) {}
+if (x === 0) {}
+do {} while (x === 2);
+```
+"#
+  }
 }
 
 struct NoConstantConditionVisitor<'c> {
@@ -40,10 +62,11 @@ impl<'c> NoConstantConditionVisitor<'c> {
   }
 
   fn add_diagnostic(&mut self, span: Span) {
-    self.context.add_diagnostic(
+    self.context.add_diagnostic_with_hint(
       span,
       "no-constant-condition",
       "Use of a constant expressions as conditions is not allowed.",
+      "Remove the constant expression",
     );
   }
 


### PR DESCRIPTION
This PR:
* Re-orders most examples to put the invalid examples above the valid ones.  This makes more semantic sense ("here's what's wrong followed by here's how it should look"), follows the pattern of eslint and sets a consistent pattern in the deno lint rules.
* Contributes to #159 with documentation now available on the following rules:
  * no-class-assign
  * no-const-assign
  * no-constant-condition