### PR TITLE
refactor(constructor-super): switch to `assert_lint_err!` macro

### DIFF
--- a/src/rules/constructor_super.rs
+++ b/src/rules/constructor_super.rs
@@ -317,98 +317,98 @@ mod tests {
       ConstructorSuper,
       "class A extends null { constructor() { super(); } }": [
         {
-          col: 37,
+          col: 23,
           message: unnecessary_constructor_message,
           hint: unnecessary_constructor_hint,
         }
       ],
       "class A extends null { constructor() { } }": [
         {
-          col: 37,
+          col: 23,
           message: unnecessary_constructor_message,
           hint: unnecessary_constructor_hint,
         }
       ],
-      "class A extends 100 { constructor() { super(); } }": [
+      "class A extends 1000 { constructor() { super(); } }": [
         {
-          col: 36,
+          col: 23,
           message: unnecessary_constructor_message,
           hint: unnecessary_constructor_hint,
         }
       ],
-      "class A extends 'test' { constructor() { super(); } }": [
+      "class A extends 'ab' { constructor() { super(); } }": [
         {
-          col: 39,
+          col: 23,
           message: unnecessary_constructor_message,
           hint: unnecessary_constructor_hint,
         }
       ],
       "class A extends B { constructor() { } }": [
         {
-          col: 34,
+          col: 20,
           message: no_super_message,
           hint: no_super_hint,
         }
       ],
       "class A extends B { constructor() { for (var a of b) super.foo(); } }": [
         {
-          col: 34,
+          col: 20,
           message: no_super_message,
           hint: no_super_hint,
         }
       ],
       "class A extends B { constructor() { class C extends D { constructor() { super(); } } } }": [
         {
-          col: 34,
+          col: 20,
           message: no_super_message,
           hint: no_super_hint,
         }
       ],
       "class A extends B { constructor() { var c = class extends D { constructor() { super(); } } } }": [
         {
-          col: 34,
+          col: 20,
           message: no_super_message,
           hint: no_super_hint,
         }
       ],
       "class A extends B { constructor() { var c = () => super(); } }": [
         {
-          col: 34,
+          col: 20,
           message: no_super_message,
           hint: no_super_hint,
         }
       ],
       "class A extends B { constructor() { class C extends D { constructor() { super(); } } } }": [
         {
-          col: 34,
+          col: 20,
           message: no_super_message,
           hint: no_super_hint,
         }
       ],
       "class A extends B { constructor() { var C = class extends D { constructor() { super(); } } } }": [
         {
-          col: 34,
+          col: 20,
           message: no_super_message,
           hint: no_super_hint,
         }
       ],
       "class A extends B { constructor() { super(); super(); } }": [
         {
-          col: 34,
+          col: 45,
           message: too_many_super_message,
           hint: too_many_super_hint,
         }
       ],
       "class A extends B { constructor() { return; super(); } }": [
         {
-          col: 34,
+          col: 20,
           message: no_super_message,
           hint: no_super_hint,
         }
       ],
       "class Foo extends Bar { constructor() { for (a in b) for (c in d); } }": [
         {
-          col: 38,
+          col: 24,
           message: no_super_message,
           hint: no_super_hint,
         }
@@ -425,7 +425,7 @@ class A extends B {
         "#: [
         {
           line: 5,
-          col: 20,
+          col: 6,
           message: no_super_message,
           hint: no_super_hint,
         }
@@ -444,7 +444,7 @@ class A extends B {
         "#: [
         {
           line: 8,
-          col: 20,
+          col: 6,
           message: no_super_message,
           hint: no_super_hint,
         }
@@ -463,7 +463,7 @@ class A extends B {
         "#: [
         {
           line: 5,
-          col: 20,
+          col: 6,
           message: unnecessary_constructor_message,
           hint: unnecessary_constructor_hint,
         }
@@ -480,7 +480,7 @@ class A extends B {
         "#: [
         {
           line: 5,
-          col: 20,
+          col: 6,
           message: unnecessary_constructor_message,
           hint: unnecessary_constructor_hint,
         }

--- a/src/rules/constructor_super.rs
+++ b/src/rules/constructor_super.rs
@@ -198,7 +198,7 @@ impl<'c> ConstructorSuperVisitor<'c> {
     let super_calls = super_call_spans(constructor);
 
     // in case where there are more than one `super()` calls.
-    for exceeded_super_span in super_call_spans(constructor).iter().skip(1) {
+    for exceeded_super_span in super_calls.iter().skip(1) {
       let kind = DiagnosticKind::TooManySuper;
       self.context.add_diagnostic_with_hint(
         *exceeded_super_span,

--- a/src/rules/constructor_super.rs
+++ b/src/rules/constructor_super.rs
@@ -308,13 +308,18 @@ mod tests {
       DiagnosticKind::NoSuper.message_and_hint();
     let (unnecessary_constructor_message, unnecessary_constructor_hint) =
       DiagnosticKind::UnnecessaryConstructor.message_and_hint();
-    // TODO(magurotuna): remove this `allow`
-    #[allow(unused)]
     let (unnecessary_super_message, unnecessary_super_hint) =
       DiagnosticKind::UnnecessarySuper.message_and_hint();
 
     assert_lint_err! {
       ConstructorSuper,
+      "class A { constructor() { super(); } }": [
+        {
+          col: 26,
+          message: unnecessary_super_message,
+          hint: unnecessary_super_hint,
+        }
+      ],
       "class A extends null { constructor() { super(); } }": [
         {
           col: 23,

--- a/src/rules/constructor_super.rs
+++ b/src/rules/constructor_super.rs
@@ -219,50 +219,48 @@ mod tests {
   fn constructor_super_valid() {
     assert_lint_ok! {
       ConstructorSuper,
-      r#"
-// non derived classes.
-class A { }
-class A { constructor() { } }
+      // non derived classes.
+      "class A { }",
+      "class A { constructor() { } }",
 
-/*
- * inherit from non constructors.
- * those are valid if we don't define the constructor.
- */
-class A extends null { }
+      // inherit from non constructors.
+      // those are valid if we don't define the constructor.
+      "class A extends null { }",
 
-// derived classes.
-class A extends B { }
-class A extends B { constructor() { super(); } }
-// class A extends B { constructor() { if (true) { super(); } else { super(); } } }
-class A extends (class B {}) { constructor() { super(); } }
-class A extends (B = C) { constructor() { super(); } }
-class A extends (B || C) { constructor() { super(); } }
-class A extends (a ? B : C) { constructor() { super(); } }
-class A extends (B, C) { constructor() { super(); } }
+      // derived classes.
+      "class A extends B { }",
+      "class A extends B { constructor() { super(); } }",
 
-// nested.
-class A { constructor() { class B extends C { constructor() { super(); } } } }
-class A extends B { constructor() { super(); class C extends D { constructor() { super(); } } } }
-class A extends B { constructor() { super(); class C { constructor() { } } } }
+      // TODO(magurotuna): these needs control flow analysis.
+      // "class A extends B { constructor() { if (true) { super(); } else { super(); } } }",
+      // "class A extends B { constructor() { a ? super() : super(); } }",
+      // "class A extends B { constructor() { if (a) super(); else super(); } }",
+      // "class A extends B { constructor() { switch (a) { case 0: super(); break; default: super(); } } }",
+      // "class A extends B { constructor() { try {} finally { super(); } } }",
+      // "class A extends B { constructor() { if (a) throw Error(); super(); } }",
 
-// multi code path.
-// class A extends B { constructor() { a ? super() : super(); } }
-// class A extends B { constructor() { if (a) super(); else super(); } }
-// class A extends B { constructor() { switch (a) { case 0: super(); break; default: super(); } } }
-// class A extends B { constructor() { try {} finally { super(); } } }
-// class A extends B { constructor() { if (a) throw Error(); super(); } }
+      // derived classes.
+      "class A extends (class B {}) { constructor() { super(); } }",
+      "class A extends (B = C) { constructor() { super(); } }",
+      "class A extends (B || C) { constructor() { super(); } }",
+      "class A extends (a ? B : C) { constructor() { super(); } }",
+      "class A extends (B, C) { constructor() { super(); } }",
 
-// returning value is a substitute of 'super()'.
-class A extends B { constructor() { if (true) return a; super(); } }
-class A extends null { constructor() { return a; } }
-class A { constructor() { return a; } }
+      // nested.
+      "class A { constructor() { class B extends C { constructor() { super(); } } } }",
+      "class A extends B { constructor() { super(); class C extends D { constructor() { super(); } } } }",
+      "class A extends B { constructor() { super(); class C { constructor() { } } } }",
 
-// https://github.com/eslint/eslint/issues/5261
-class A extends B { constructor(a) { super(); for (const b of a) { this.a(); } } }
+      // returning value is a substitute of 'super()'.
+      "class A extends B { constructor() { if (true) return a; super(); } }",
+      "class A extends null { constructor() { return a; } }",
+      "class A { constructor() { return a; } }",
 
-// https://github.com/eslint/eslint/issues/5319
-class Foo extends Object { constructor(method) { super(); this.method = method || function() {}; } }
-      "#,
+      // https://github.com/eslint/eslint/issues/5261
+      "class A extends B { constructor(a) { super(); for (const b of a) { this.a(); } } }",
+
+      // https://github.com/eslint/eslint/issues/5319
+      "class Foo extends Object { constructor(method) { super(); this.method = method || function() {}; } }",
     };
   }
 

--- a/src/rules/constructor_super.rs
+++ b/src/rules/constructor_super.rs
@@ -267,7 +267,7 @@ mod tests {
       "class A extends B { }",
       "class A extends B { constructor() { super(); } }",
 
-      // TODO(magurotuna): these needs control flow analysis.
+      // TODO(magurotuna): control flow analysis is required to handle these cases
       // "class A extends B { constructor() { if (true) { super(); } else { super(); } } }",
       // "class A extends B { constructor() { a ? super() : super(); } }",
       // "class A extends B { constructor() { if (a) super(); else super(); } }",


### PR DESCRIPTION
This is a part of #431 

Switches from the `assert_lint_err` functions to the `assert_lint_err!` macro and does some refactoring for readability.