### PR TITLE
refactor(ban-untagged-ignore): switch to `assert_lint_err!` macro

### DIFF
--- a/src/rules/ban_untagged_ignore.rs
+++ b/src/rules/ban_untagged_ignore.rs
@@ -69,7 +69,6 @@ export function duplicateArgumentsFn(a, b, a) { }
 #[cfg(test)]
 mod tests {
   use super::*;
-  use crate::test_util::*;
 
   #[test]
   fn ban_ts_ignore_valid() {
@@ -86,15 +85,21 @@ function bar() {
 
   #[test]
   fn ban_ts_ignore_invalid() {
-    assert_lint_err_on_line::<BanUntaggedIgnore>(
+    assert_lint_err! {
+      BanUntaggedIgnore,
       r#"
 // deno-lint-ignore
 function foo() {
   // pass
 }
-    "#,
-      2,
-      0,
-    );
+      "#: [
+        {
+          line: 2,
+          col: 0,
+          message: "Ignore directive requires lint rule name(s)",
+          hint: "Add one or more lint rule names.  E.g. // deno-lint-ignore adjacent-overload-signatures",
+        }
+      ]
+    };
   }
 }


### PR DESCRIPTION
This is a part of #431

Switches from the `assert_lint_err` functions to the `assert_lint_err!` macro in `ban-untagged-ignore`.