### PR TITLE
refactor(for-direction): switch to `assert_lint_err!` macro

### DIFF
--- a/src/rules/for_direction.rs
+++ b/src/rules/for_direction.rs
@@ -61,6 +61,11 @@ for(let i = 0; i < 2; i++) {}
   }
 }
 
+const MESSAGE: &'static str =
+  "Update clause moves variable in the wrong direction";
+const HINT: &'static str =
+  "Flip the update clause logic or change the continuation step condition";
+
 struct ForDirectionVisitor<'c> {
   context: &'c mut Context,
 }
@@ -180,8 +185,8 @@ impl<'c> VisitAll for ForDirectionVisitor<'c> {
           self.context.add_diagnostic_with_hint(
             for_stmt.span,
             "for-direction",
-            "Update clause moves variable in the wrong direction",
-            "Flip the update clause logic or change the continuation step condition"
+            MESSAGE,
+            HINT,
           );
         }
       }
@@ -192,7 +197,6 @@ impl<'c> VisitAll for ForDirectionVisitor<'c> {
 #[cfg(test)]
 mod tests {
   use super::*;
-  use crate::test_util::*;
 
   #[test]
   fn for_direction_valid() {
@@ -234,33 +238,138 @@ mod tests {
 
   #[test]
   fn for_direction_invalid() {
-    // ++, --
-    assert_lint_err::<ForDirection>("for(let i = 0; i < 2; i--) {}", 0);
-    assert_lint_err::<ForDirection>("for(let i = 0; i < 2; --i) {}", 0);
-    assert_lint_err::<ForDirection>("for(let i = 0; i <= 2; i--) {}", 0);
-    assert_lint_err::<ForDirection>("for(let i = 0; i <= 2; --i) {}", 0);
-    assert_lint_err::<ForDirection>("for(let i = 2; i > 2; i++) {}", 0);
-    assert_lint_err::<ForDirection>("for(let i = 2; i > 2; ++i) {}", 0);
-    assert_lint_err::<ForDirection>("for(let i = 2; i >= 0; i++) {}", 0);
-    assert_lint_err::<ForDirection>("for(let i = 2; i >= 0; ++i) {}", 0);
-    // +=, -=
-    assert_lint_err::<ForDirection>("for(let i = 0; i < 2; i -= 1) {}", 0);
-    assert_lint_err::<ForDirection>("for(let i = 0; i <= 2; i -= 1) {}", 0);
-    assert_lint_err::<ForDirection>("for(let i = 2; i > 2; i -= -1) {}", 0);
-    assert_lint_err::<ForDirection>("for(let i = 2; i >= 0; i -= -1) {}", 0);
-    assert_lint_err::<ForDirection>("for(let i = 2; i > 2; i += 1) {}", 0);
-    assert_lint_err::<ForDirection>("for(let i = 2; i >= 0; i += 1) {}", 0);
-    assert_lint_err::<ForDirection>("for(let i = 0; i < 2; i += -1) {}", 0);
-    assert_lint_err::<ForDirection>("for(let i = 0; i <= 2; i += -1) {}", 0);
-    // nested
-    assert_lint_err_on_line::<ForDirection>(
+    assert_lint_err! {
+      ForDirection,
+
+      // ++, --
+      "for(let i = 0; i < 2; i--) {}": [
+        {
+          col: 0,
+          message: MESSAGE,
+          hint: HINT,
+        }
+      ],
+      "for(let i = 0; i < 2; --i) {}": [
+        {
+          col: 0,
+          message: MESSAGE,
+          hint: HINT,
+        }
+      ],
+      "for(let i = 0; i <= 2; i--) {}": [
+        {
+          col: 0,
+          message: MESSAGE,
+          hint: HINT,
+        }
+      ],
+      "for(let i = 0; i <= 2; --i) {}": [
+        {
+          col: 0,
+          message: MESSAGE,
+          hint: HINT,
+        }
+      ],
+      "for(let i = 2; i > 2; i++) {}": [
+        {
+          col: 0,
+          message: MESSAGE,
+          hint: HINT,
+        }
+      ],
+      "for(let i = 2; i > 2; ++i) {}": [
+        {
+          col: 0,
+          message: MESSAGE,
+          hint: HINT,
+        }
+      ],
+      "for(let i = 2; i >= 0; i++) {}": [
+        {
+          col: 0,
+          message: MESSAGE,
+          hint: HINT,
+        }
+      ],
+      "for(let i = 2; i >= 0; ++i) {}": [
+        {
+          col: 0,
+          message: MESSAGE,
+          hint: HINT,
+        }
+      ],
+
+      // +=, -=
+      "for(let i = 0; i < 2; i -= 1) {}": [
+        {
+          col: 0,
+          message: MESSAGE,
+          hint: HINT,
+        }
+      ],
+      "for(let i = 0; i <= 2; i -= 1) {}": [
+        {
+          col: 0,
+          message: MESSAGE,
+          hint: HINT,
+        }
+      ],
+      "for(let i = 2; i > 2; i -= -1) {}": [
+        {
+          col: 0,
+          message: MESSAGE,
+          hint: HINT,
+        }
+      ],
+      "for(let i = 2; i >= 0; i -= -1) {}": [
+        {
+          col: 0,
+          message: MESSAGE,
+          hint: HINT,
+        }
+      ],
+      "for(let i = 2; i > 2; i += 1) {}": [
+        {
+          col: 0,
+          message: MESSAGE,
+          hint: HINT,
+        }
+      ],
+      "for(let i = 2; i >= 0; i += 1) {}": [
+        {
+          col: 0,
+          message: MESSAGE,
+          hint: HINT,
+        }
+      ],
+      "for(let i = 0; i < 2; i += -1) {}": [
+        {
+          col: 0,
+          message: MESSAGE,
+          hint: HINT,
+        }
+      ],
+      "for(let i = 0; i <= 2; i += -1) {}": [
+        {
+          col: 0,
+          message: MESSAGE,
+          hint: HINT,
+        }
+      ],
+
+      // nested
       r#"
 for (let i = 0; i < 2; i++) {
   for (let j = 0; j < 2; j--) {}
 }
-      "#,
-      3,
-      2,
-    );
+      "#: [
+        {
+          line: 3,
+          col: 2,
+          message: MESSAGE,
+          hint: HINT,
+        }
+      ]
+    };
   }
 }

--- a/src/rules/for_direction.rs
+++ b/src/rules/for_direction.rs
@@ -61,9 +61,8 @@ for(let i = 0; i < 2; i++) {}
   }
 }
 
-const MESSAGE: &'static str =
-  "Update clause moves variable in the wrong direction";
-const HINT: &'static str =
+const MESSAGE: &str = "Update clause moves variable in the wrong direction";
+const HINT: &str =
   "Flip the update clause logic or change the continuation step condition";
 
 struct ForDirectionVisitor<'c> {


### PR DESCRIPTION
This is a part of #431

Switches from the `assert_lint_err` functions to the `assert_lint_err!` macro in `for-direction`.