### PR TITLE
refactor: use assert_lint_err! macro

### DIFF
--- a/src/rules/no_async_promise_executor.rs
+++ b/src/rules/no_async_promise_executor.rs
@@ -11,7 +11,8 @@ pub struct NoAsyncPromiseExecutor;
 
 const CODE: &str = "no-async-promise-executor";
 const MESSAGE: &str = "Async promise executors are not allowed";
-const HINT: &str = "Remove `async` from executor function and adjust promise code as needed";
+const HINT: &str =
+  "Remove `async` from executor function and adjust promise code as needed";
 
 impl LintRule for NoAsyncPromiseExecutor {
   fn new() -> Box<Self> {

--- a/src/rules/no_await_in_loop.rs
+++ b/src/rules/no_await_in_loop.rs
@@ -10,13 +10,17 @@ use swc_ecmascript::visit::{noop_visit_type, Node, Visit};
 
 pub struct NoAwaitInLoop;
 
+const CODE: &str = "no-await-in-loop";
+const MESSAGE: &str = "Unexpected `await` inside a loop.";
+const HINT: &str = "Remove `await` in loop body, store all promises generated and then `await Promise.all(storedPromises)` after the loop";
+
 impl LintRule for NoAwaitInLoop {
   fn new() -> Box<Self> {
     Box::new(NoAwaitInLoop)
   }
 
   fn code(&self) -> &'static str {
-    "no-await-in-loop"
+    CODE
   }
 
   fn lint_module(
@@ -78,12 +82,9 @@ impl<'c> NoAwaitInLoopVisitor<'c> {
   }
 
   fn add_diagnostic(&mut self, span: Span) {
-    self.context.add_diagnostic_with_hint(
-      span,
-      "no-await-in-loop",
-      "Unexpected `await` inside a loop.",
-      "Remove `await` in loop body, store all promises generated and then `await Promise.all(storedPromises)` after the loop"
-    );
+    self
+      .context
+      .add_diagnostic_with_hint(span, CODE, MESSAGE, HINT);
   }
 }
 
@@ -278,7 +279,6 @@ impl<'a, 'b> Visit for FunctionVisitor<'a, 'b> {
 #[cfg(test)]
 mod tests {
   use super::*;
-  use crate::test_util::*;
 
   #[test]
   fn no_await_in_loop_valid() {
@@ -411,7 +411,8 @@ for (let thing in await things) {
 
   #[test]
   fn no_await_in_loop_invalid() {
-    assert_lint_err_on_line::<NoAwaitInLoop>(
+    assert_lint_err! {
+      NoAwaitInLoop,
       r#"
 async function foo(things) {
   const results = [];
@@ -420,112 +421,57 @@ async function foo(things) {
   }
   return baz(results);
 }
-      "#,
-      5,
-      17,
-    );
-
-    assert_lint_err_on_line::<NoAwaitInLoop>(
+      "#: [{ line: 5, col: 17, message: MESSAGE, hint: HINT }],
       r#"
 for (const thing of things) {
   results.push(await foo(thing));
 }
-      "#,
-      3,
-      15,
-    );
-
-    assert_lint_err_on_line::<NoAwaitInLoop>(
+      "#: [{ line: 3, col: 15, message: MESSAGE, hint: HINT }],
       r#"
 for (let i = 0; i < await foo(); i++) {
   bar();
 }
-      "#,
-      2,
-      20,
-    );
-
-    assert_lint_err_on_line::<NoAwaitInLoop>(
+      "#: [{ line: 2, col: 20, message: MESSAGE, hint: HINT }],
       r#"
 for (let i = 0; i < 42; await foo(i)) {
   bar();
 }
-      "#,
-      2,
-      24,
-    );
-
-    assert_lint_err_on_line::<NoAwaitInLoop>(
+      "#: [{ line: 2, col: 24, message: MESSAGE, hint: HINT }],
       r#"
 for (let i = 0; i < 42; i++) {
   await bar();
 }
-      "#,
-      3,
-      2,
-    );
-
-    assert_lint_err_on_line::<NoAwaitInLoop>(
+      "#: [{ line: 3, col: 2, message: MESSAGE, hint: HINT }],
       r#"
 for (const thing in things) {
   await foo(thing);
 }
-      "#,
-      3,
-      2,
-    );
-
-    assert_lint_err_on_line::<NoAwaitInLoop>(
+      "#: [{ line: 3, col: 2, message: MESSAGE, hint: HINT }],
       r#"
 while (await foo()) {
   bar();
 }
-      "#,
-      2,
-      7,
-    );
-
-    assert_lint_err_on_line::<NoAwaitInLoop>(
+      "#: [{ line: 2, col: 7, message: MESSAGE, hint: HINT }],
       r#"
 while (true) {
   await foo();
 }
-      "#,
-      3,
-      2,
-    );
-
-    assert_lint_err_on_line::<NoAwaitInLoop>(
+      "#: [{ line: 3, col: 2, message: MESSAGE, hint: HINT }],
       r#"
 while (true) {
   await foo();
 }
-      "#,
-      3,
-      2,
-    );
-
-    assert_lint_err_on_line::<NoAwaitInLoop>(
+      "#: [{ line: 3, col: 2, message: MESSAGE, hint: HINT }],
       r#"
 do {
   foo();
 } while (await bar());
-      "#,
-      4,
-      9,
-    );
-
-    assert_lint_err_on_line::<NoAwaitInLoop>(
+      "#: [{ line: 4, col: 9, message: MESSAGE, hint: HINT }],
       r#"
 do {
   await foo();
 } while (true);
-      "#,
-      3,
-      2,
-    );
-
-    assert_lint_err_on_line::<NoAwaitInLoop>(
+      "#: [{ line: 3, col: 2, message: MESSAGE, hint: HINT }],
       r#"
 for await (const thing of things) {
   async function foo() {
@@ -535,12 +481,8 @@ for await (const thing of things) {
   }
   await baz();
 }
-      "#,
-      5,
-      6,
-    );
+      "#: [{ line: 5, col: 6, message: MESSAGE, hint: HINT }],
 
-    assert_lint_err_on_line::<NoAwaitInLoop>(
       r#"
 function foo() {
   async function bar() {
@@ -549,12 +491,7 @@ function foo() {
     }
   }
 }
-      "#,
-      5,
-      6,
-    );
-
-    assert_lint_err_on_line::<NoAwaitInLoop>(
+      "#: [{ line: 5, col: 6, message: MESSAGE, hint: HINT }],
       r#"
 async function foo() {
   for (const thing of things) {
@@ -564,9 +501,7 @@ async function foo() {
     }
   }
 }
-      "#,
-      6,
-      6,
-    );
+      "#: [{ line: 6, col: 6, message: MESSAGE, hint: HINT }],
+    }
   }
 }

--- a/src/rules/no_empty_pattern.rs
+++ b/src/rules/no_empty_pattern.rs
@@ -64,11 +64,7 @@ impl<'c> Visit for NoEmptyPatternVisitor<'c> {
   fn visit_object_pat(&mut self, obj_pat: &ObjectPat, _parent: &dyn Node) {
     if obj_pat.props.is_empty() {
       if obj_pat.type_ann.is_none() {
-        self.context.add_diagnostic(
-          obj_pat.span,
-          CODE,
-          MESSAGE,
-        )
+        self.context.add_diagnostic(obj_pat.span, CODE, MESSAGE)
       }
     } else {
       for prop in &obj_pat.props {
@@ -79,11 +75,7 @@ impl<'c> Visit for NoEmptyPatternVisitor<'c> {
 
   fn visit_array_pat(&mut self, arr_pat: &ArrayPat, _parent: &dyn Node) {
     if arr_pat.elems.is_empty() {
-      self.context.add_diagnostic(
-        arr_pat.span,
-        CODE,
-        MESSAGE,
-      )
+      self.context.add_diagnostic(arr_pat.span, CODE, MESSAGE)
     } else {
       for elem in &arr_pat.elems {
         if let Some(element) = elem {

--- a/src/rules/no_empty_pattern.rs
+++ b/src/rules/no_empty_pattern.rs
@@ -8,6 +8,9 @@ use swc_ecmascript::visit::Visit;
 
 pub struct NoEmptyPattern;
 
+const CODE: &str = "no-empty-pattern";
+const MESSAGE: &str = "empty patterns are not allowed";
+
 impl LintRule for NoEmptyPattern {
   fn new() -> Box<Self> {
     Box::new(NoEmptyPattern)
@@ -18,7 +21,7 @@ impl LintRule for NoEmptyPattern {
   }
 
   fn code(&self) -> &'static str {
-    "no-empty-pattern"
+    CODE
   }
 
   fn lint_module(
@@ -63,8 +66,8 @@ impl<'c> Visit for NoEmptyPatternVisitor<'c> {
       if obj_pat.type_ann.is_none() {
         self.context.add_diagnostic(
           obj_pat.span,
-          "no-empty-pattern",
-          "empty patterns are not allowed",
+          CODE,
+          MESSAGE,
         )
       }
     } else {
@@ -78,8 +81,8 @@ impl<'c> Visit for NoEmptyPatternVisitor<'c> {
     if arr_pat.elems.is_empty() {
       self.context.add_diagnostic(
         arr_pat.span,
-        "no-empty-pattern",
-        "empty patterns are not allowed",
+        CODE,
+        MESSAGE,
       )
     } else {
       for elem in &arr_pat.elems {
@@ -98,7 +101,6 @@ impl<'c> Visit for NoEmptyPatternVisitor<'c> {
 #[cfg(test)]
 mod tests {
   use super::*;
-  use crate::test_util::*;
 
   #[test]
   fn no_empty_pattern_valid() {
@@ -116,14 +118,44 @@ mod tests {
 
   #[test]
   fn no_empty_pattern_invalid() {
-    assert_lint_err::<NoEmptyPattern>("const {} = foo", 6);
-    assert_lint_err::<NoEmptyPattern>("const [] = foo", 6);
-    assert_lint_err::<NoEmptyPattern>("const {a: {}} = foo", 10);
-    assert_lint_err::<NoEmptyPattern>("const {a, b: {}} = foo", 13);
-    assert_lint_err::<NoEmptyPattern>("const {a: []} = foo", 10);
-    assert_lint_err::<NoEmptyPattern>("function foo({}) {}", 13);
-    assert_lint_err::<NoEmptyPattern>("function foo([]) {}", 13);
-    assert_lint_err::<NoEmptyPattern>("function foo({a: {}}) {}", 17);
-    assert_lint_err::<NoEmptyPattern>("function foo({a: []}) {}", 17);
+    assert_lint_err! {
+      NoEmptyPattern,
+      "const {} = foo": [{
+        col: 6,
+        message: MESSAGE,
+      }],
+      "const [] = foo": [{
+        col: 6,
+        message: MESSAGE,
+      }],
+      "const {a: {}} = foo": [{
+        col: 10,
+        message: MESSAGE,
+      }],
+      "const {a, b: {}} = foo": [{
+        col: 13,
+        message: MESSAGE,
+      }],
+      "const {a: []} = foo": [{
+        col: 10,
+        message: MESSAGE,
+      }],
+      "function foo({}) {}": [{
+        col: 13,
+        message: MESSAGE,
+      }],
+      "function foo([]) {}": [{
+        col: 13,
+        message: MESSAGE,
+      }],
+      "function foo({a: {}}) {}": [{
+        col: 17,
+        message: MESSAGE,
+      }],
+      "function foo({a: []}) {}": [{
+        col: 17,
+        message: MESSAGE,
+      }],
+    }
   }
 }

--- a/src/rules/no_ex_assign.rs
+++ b/src/rules/no_ex_assign.rs
@@ -10,6 +10,9 @@ use swc_ecmascript::visit::Visit;
 
 pub struct NoExAssign;
 
+const CODE: &str = "no-ex-assign";
+const MESSAGE: &str = "Reassigning exception parameter is not allowed";
+
 impl LintRule for NoExAssign {
   fn new() -> Box<Self> {
     Box::new(NoExAssign)
@@ -20,7 +23,7 @@ impl LintRule for NoExAssign {
   }
 
   fn code(&self) -> &'static str {
-    "no-ex-assign"
+    CODE
   }
 
   fn lint_module(
@@ -54,11 +57,7 @@ impl<'c> Visit for NoExAssignVisitor<'c> {
 
       if let Some(var) = var {
         if let BindingKind::CatchClause = var.kind() {
-          self.context.add_diagnostic(
-            assign_expr.span,
-            "no-ex-assign",
-            "Reassigning exception parameter is not allowed",
-          );
+          self.context.add_diagnostic(assign_expr.span, CODE, MESSAGE);
         }
       }
     }
@@ -68,7 +67,6 @@ impl<'c> Visit for NoExAssignVisitor<'c> {
 #[cfg(test)]
 mod tests {
   use super::*;
-  use crate::test_util::assert_lint_err_on_line_n;
 
   #[test]
   fn no_ex_assign_valid() {
@@ -85,15 +83,41 @@ function foo() { try { } catch (e) { return false; } }
 
   #[test]
   fn no_ex_assign_invalid() {
-    assert_lint_err_on_line_n::<NoExAssign>(
+    assert_lint_err! {
+      NoExAssign,
       r#"
 try {} catch (e) { e = 1; }
 try {} catch (ex) { ex = 1; }
 try {} catch (ex) { [ex] = []; }
 try {} catch (ex) { ({x: ex = 0} = {}); }
 try {} catch ({message}) { message = 1; }
-      "#,
-      vec![(2, 19), (3, 20), (4, 20), (5, 21), (6, 27)],
-    );
+      "#: [
+        {
+          line: 2,
+          col: 19,
+          message: MESSAGE,
+        },
+        {
+          line: 3,
+          col: 20,
+          message: MESSAGE,
+        },
+        {
+          line: 4,
+          col: 20,
+          message: MESSAGE,
+        },
+        {
+          line: 5,
+          col: 21,
+          message: MESSAGE,
+        },
+        {
+          line: 6,
+          col: 27,
+          message: MESSAGE,
+        },
+      ]
+    }
   }
 }

--- a/src/rules/no_import_assign.rs
+++ b/src/rules/no_import_assign.rs
@@ -15,6 +15,9 @@ use swc_ecmascript::{
 
 pub struct NoImportAssign;
 
+const CODE: &str = "no-import-assign";
+const MESSAGE: &str = "Assignment to import is not allowed";
+
 impl LintRule for NoImportAssign {
   fn new() -> Box<Self> {
     Box::new(NoImportAssign)
@@ -25,7 +28,7 @@ impl LintRule for NoImportAssign {
   }
 
   fn code(&self) -> &'static str {
-    "no-import-assign"
+    CODE
   }
 
   fn lint_module(
@@ -142,20 +145,12 @@ impl<'c> NoImportAssignVisitor<'c> {
     }
 
     if self.ns_imports.contains(&i.to_id()) {
-      self.context.add_diagnostic(
-        span,
-        "no-import-assign",
-        "Assignment to import is not allowed",
-      );
+      self.context.add_diagnostic(span, CODE, MESSAGE);
       return;
     }
 
     if !is_assign_to_prop && self.imports.contains(&i.to_id()) {
-      self.context.add_diagnostic(
-        span,
-        "no-import-assign",
-        "Assignment to import is not allowed",
-      );
+      self.context.add_diagnostic(span, CODE, MESSAGE);
     }
   }
 
@@ -340,7 +335,6 @@ impl<'c> Visit for NoImportAssignVisitor<'c> {
 #[cfg(test)]
 mod tests {
   use super::*;
-  use crate::test_util::*;
 
   #[test]
   fn no_import_assign_valid() {
@@ -408,266 +402,66 @@ mod tests {
 
   #[test]
   fn no_import_assign_invalid() {
-    assert_lint_err::<NoImportAssign>("import mod1 from 'mod'; mod1 = 0", 24);
-
-    assert_lint_err::<NoImportAssign>("import mod2 from 'mod'; mod2 += 0", 24);
-
-    assert_lint_err::<NoImportAssign>("import mod3 from 'mod'; mod3++", 24);
-    assert_lint_err::<NoImportAssign>(
-      "import mod4 from 'mod'; for (mod4 in foo);",
-      29,
-    );
-
-    assert_lint_err::<NoImportAssign>(
-      "import mod5 from 'mod'; for (mod5 of foo);",
-      29,
-    );
-
-    assert_lint_err::<NoImportAssign>(
-      "import mod6 from 'mod'; [mod6] = foo",
-      25,
-    );
-    assert_lint_err::<NoImportAssign>(
-      "import mod7 from 'mod'; [mod7 = 0] = foo",
-      25,
-    );
-
-    assert_lint_err::<NoImportAssign>(
-      "import mod8 from 'mod'; [...mod8] = foo",
-      28,
-    );
-
-    assert_lint_err::<NoImportAssign>(
-      "import mod9 from 'mod'; ({ bar: mod9 } = foo)",
-      32,
-    );
-    assert_lint_err::<NoImportAssign>(
-      "import mod10 from 'mod'; ({ bar: mod10 = 0 } = foo)",
-      33,
-    );
-
-    assert_lint_err::<NoImportAssign>(
-      "import mod11 from 'mod'; ({ ...mod11 } = foo)",
-      31,
-    );
-
-    assert_lint_err::<NoImportAssign>(
-      "import {named1} from 'mod'; named1 = 0",
-      28,
-    );
-    assert_lint_err::<NoImportAssign>(
-      "import {named2} from 'mod'; named2 += 0",
-      28,
-    );
-
-    assert_lint_err::<NoImportAssign>(
-      "import {named3} from 'mod'; named3++",
-      28,
-    );
-
-    assert_lint_err::<NoImportAssign>(
-      "import {named4} from 'mod'; for (named4 in foo);",
-      33,
-    );
-    assert_lint_err::<NoImportAssign>(
-      "import {named5} from 'mod'; for (named5 of foo);",
-      33,
-    );
-
-    assert_lint_err::<NoImportAssign>(
-      "import {named6} from 'mod'; [named6] = foo",
-      29,
-    );
-
-    assert_lint_err::<NoImportAssign>(
-      "import {named7} from 'mod'; [named7 = 0] = foo",
-      29,
-    );
-    assert_lint_err::<NoImportAssign>(
-      "import {named8} from 'mod'; [...named8] = foo",
-      32,
-    );
-
-    assert_lint_err::<NoImportAssign>(
-      "import {named9} from 'mod'; ({ bar: named9 } = foo)",
-      36,
-    );
-
-    assert_lint_err::<NoImportAssign>(
-      "import {named10} from 'mod'; ({ bar: named10 = 0 } = foo)",
-      37,
-    );
-    assert_lint_err::<NoImportAssign>(
-      "import {named11} from 'mod'; ({ ...named11 } = foo)",
-      35,
-    );
-
-    assert_lint_err::<NoImportAssign>(
-      "import {named12 as foo} from 'mod'; foo = 0; named12 = 0",
-      36,
-    );
-
-    assert_lint_err::<NoImportAssign>(
-      "import * as mod1 from 'mod'; mod1 = 0",
-      29,
-    );
-    assert_lint_err::<NoImportAssign>(
-      "import * as mod2 from 'mod'; mod2 += 0",
-      29,
-    );
-
-    assert_lint_err::<NoImportAssign>(
-      "import * as mod3 from 'mod'; mod3++",
-      29,
-    );
-
-    assert_lint_err::<NoImportAssign>(
-      "import * as mod4 from 'mod'; for (mod4 in foo);",
-      34,
-    );
-    assert_lint_err::<NoImportAssign>(
-      "import * as mod5 from 'mod'; for (mod5 of foo);",
-      34,
-    );
-
-    assert_lint_err::<NoImportAssign>(
-      "import * as mod6 from 'mod'; [mod6] = foo",
-      30,
-    );
-
-    assert_lint_err::<NoImportAssign>(
-      "import * as mod7 from 'mod'; [mod7 = 0] = foo",
-      30,
-    );
-    assert_lint_err::<NoImportAssign>(
-      "import * as mod8 from 'mod'; [...mod8] = foo",
-      33,
-    );
-
-    assert_lint_err::<NoImportAssign>(
-      "import * as mod9 from 'mod'; ({ bar: mod9 } = foo)",
-      37,
-    );
-
-    assert_lint_err::<NoImportAssign>(
-      "import * as mod10 from 'mod'; ({ bar: mod10 = 0 } = foo)",
-      38,
-    );
-    assert_lint_err::<NoImportAssign>(
-      "import * as mod11 from 'mod'; ({ ...mod11 } = foo)",
-      36,
-    );
-
-    assert_lint_err::<NoImportAssign>(
-      "import * as mod1 from 'mod'; mod1.named = 0",
-      29,
-    );
-
-    assert_lint_err::<NoImportAssign>(
-      "import * as mod2 from 'mod'; mod2.named += 0",
-      29,
-    );
-    assert_lint_err::<NoImportAssign>(
-      "import * as mod3 from 'mod'; mod3.named++",
-      29,
-    );
-
-    assert_lint_err::<NoImportAssign>(
-      "import * as mod4 from 'mod'; for (mod4.named in foo);",
-      34,
-    );
-
-    assert_lint_err::<NoImportAssign>(
-      "import * as mod5 from 'mod'; for (mod5.named of foo);",
-      34,
-    );
-    assert_lint_err::<NoImportAssign>(
-      "import * as mod6 from 'mod'; [mod6.named] = foo",
-      30,
-    );
-
-    assert_lint_err::<NoImportAssign>(
-      "import * as mod7 from 'mod'; [mod7.named = 0] = foo",
-      30,
-    );
-
-    assert_lint_err::<NoImportAssign>(
-      "import * as mod8 from 'mod'; [...mod8.named] = foo",
-      33,
-    );
-    assert_lint_err::<NoImportAssign>(
-      "import * as mod9 from 'mod'; ({ bar: mod9.named } = foo)",
-      37,
-    );
-
-    assert_lint_err::<NoImportAssign>(
-      "import * as mod10 from 'mod'; ({ bar: mod10.named = 0 } = foo)",
-      38,
-    );
-
-    assert_lint_err::<NoImportAssign>(
-      "import * as mod11 from 'mod'; ({ ...mod11.named } = foo)",
-      36,
-    );
-    assert_lint_err::<NoImportAssign>(
-      "import * as mod12 from 'mod'; delete mod12.named",
-      30,
-    );
-
-    assert_lint_err::<NoImportAssign>(
-      "import * as mod from 'mod'; Object.assign(mod, obj)",
-      28,
-    );
-
-    assert_lint_err::<NoImportAssign>(
-      "import * as mod from 'mod'; Object.defineProperty(mod, key, d)",
-      28,
-    );
-    assert_lint_err::<NoImportAssign>(
-      "import * as mod from 'mod'; Object.setPrototypeOf(mod, proto)",
-      28,
-    );
-
-    assert_lint_err::<NoImportAssign>(
-      "import * as mod from 'mod'; Object.freeze(mod)",
-      28,
-    );
-
-    assert_lint_err::<NoImportAssign>(
-      "import * as mod from 'mod'; Reflect.defineProperty(mod, key, d)",
-      28,
-    );
-    assert_lint_err::<NoImportAssign>(
-      "import * as mod from 'mod'; Reflect.deleteProperty(mod, key)",
-      28,
-    );
-
-    assert_lint_err::<NoImportAssign>(
-      "import * as mod from 'mod'; Reflect.set(mod, key, value)",
-      28,
-    );
-
-    assert_lint_err::<NoImportAssign>(
-      "import * as mod from 'mod'; Reflect.setPrototypeOf(mod, proto)",
-      28,
-    );
-    assert_lint_err::<NoImportAssign>(
-      "import mod, * as mod_ns from 'mod'; mod.prop = 0; mod_ns.prop = 0",
-      50,
-    );
-
-    assert_lint_err::<NoImportAssign>(
-      "import * as mod from 'mod'; Object?.defineProperty(mod, key, d)",
-      28,
-    );
-
-    assert_lint_err::<NoImportAssign>(
-      "import * as mod from 'mod'; (Object?.defineProperty)(mod, key, d)",
-      28,
-    );
-    assert_lint_err::<NoImportAssign>(
-      "import * as mod from 'mod'; delete mod?.prop",
-      28,
-    );
+    assert_lint_err! {
+      NoImportAssign,
+      "import mod1 from 'mod'; mod1 = 0": [{ col: 24, message: MESSAGE }],
+      "import mod2 from 'mod'; mod2 += 0": [{ col: 24, message: MESSAGE }],
+      "import mod3 from 'mod'; mod3++": [{ col: 24, message: MESSAGE }],
+      "import mod4 from 'mod'; for (mod4 in foo);": [{ col: 29, message: MESSAGE }],
+      "import mod5 from 'mod'; for (mod5 of foo);": [{ col: 29, message: MESSAGE }],
+      "import mod6 from 'mod'; [mod6] = foo": [{ col: 25, message: MESSAGE }],
+      "import mod7 from 'mod'; [mod7 = 0] = foo": [{ col: 25, message: MESSAGE }],
+      "import mod8 from 'mod'; [...mod8] = foo": [{ col: 28, message: MESSAGE }],
+      "import mod9 from 'mod'; ({ bar: mod9 } = foo)": [{ col: 32, message: MESSAGE }],
+      "import mod10 from 'mod'; ({ bar: mod10 = 0 } = foo)": [{ col: 33, message: MESSAGE }],
+      "import mod11 from 'mod'; ({ ...mod11 } = foo)": [{ col: 31, message: MESSAGE }],
+      "import {named1} from 'mod'; named1 = 0": [{ col: 28, message: MESSAGE }],
+      "import {named2} from 'mod'; named2 += 0": [{ col: 28, message: MESSAGE }],
+      "import {named3} from 'mod'; named3++": [{ col: 28, message: MESSAGE }],
+      "import {named4} from 'mod'; for (named4 in foo);": [{ col: 33, message: MESSAGE }],
+      "import {named5} from 'mod'; for (named5 of foo);": [{ col: 33, message: MESSAGE }],
+      "import {named6} from 'mod'; [named6] = foo": [{ col: 29, message: MESSAGE }],
+      "import {named7} from 'mod'; [named7 = 0] = foo": [{ col: 29, message: MESSAGE }],
+      "import {named8} from 'mod'; [...named8] = foo": [{ col: 32, message: MESSAGE }],
+      "import {named9} from 'mod'; ({ bar: named9 } = foo)": [{ col: 36, message: MESSAGE }],
+      "import {named10} from 'mod'; ({ bar: named10 = 0 } = foo)": [{ col: 37, message: MESSAGE }],
+      "import {named11} from 'mod'; ({ ...named11 } = foo)": [{ col: 35, message: MESSAGE }],
+      "import {named12 as foo} from 'mod'; foo = 0; named12 = 0": [{ col: 36, message: MESSAGE }],
+      "import * as mod1 from 'mod'; mod1 = 0": [{ col: 29, message: MESSAGE }],
+      "import * as mod2 from 'mod'; mod2 += 0": [{ col: 29, message: MESSAGE }],
+      "import * as mod3 from 'mod'; mod3++": [{ col: 29, message: MESSAGE }],
+      "import * as mod4 from 'mod'; for (mod4 in foo);": [{ col: 34, message: MESSAGE }],
+      "import * as mod5 from 'mod'; for (mod5 of foo);": [{ col: 34, message: MESSAGE }],
+      "import * as mod6 from 'mod'; [mod6] = foo": [{ col: 30, message: MESSAGE }],
+      "import * as mod7 from 'mod'; [mod7 = 0] = foo": [{ col: 30, message: MESSAGE }],
+      "import * as mod8 from 'mod'; [...mod8] = foo": [{ col: 33, message: MESSAGE }],
+      "import * as mod9 from 'mod'; ({ bar: mod9 } = foo)": [{ col: 37, message: MESSAGE }],
+      "import * as mod10 from 'mod'; ({ bar: mod10 = 0 } = foo)": [{ col: 38, message: MESSAGE }],
+      "import * as mod11 from 'mod'; ({ ...mod11 } = foo)": [{ col: 36, message: MESSAGE }],
+      "import * as mod1 from 'mod'; mod1.named = 0": [{ col: 29, message: MESSAGE }],
+      "import * as mod2 from 'mod'; mod2.named += 0": [{ col: 29, message: MESSAGE }],
+      "import * as mod3 from 'mod'; mod3.named++": [{ col: 29, message: MESSAGE }],
+      "import * as mod4 from 'mod'; for (mod4.named in foo);": [{ col: 34, message: MESSAGE }],
+      "import * as mod5 from 'mod'; for (mod5.named of foo);": [{ col: 34, message: MESSAGE }],
+      "import * as mod6 from 'mod'; [mod6.named] = foo": [{ col: 30, message: MESSAGE }],
+      "import * as mod7 from 'mod'; [mod7.named = 0] = foo": [{ col: 30, message: MESSAGE }],
+      "import * as mod8 from 'mod'; [...mod8.named] = foo": [{ col: 33, message: MESSAGE }],
+      "import * as mod9 from 'mod'; ({ bar: mod9.named } = foo)": [{ col: 37, message: MESSAGE }],
+      "import * as mod10 from 'mod'; ({ bar: mod10.named = 0 } = foo)": [{ col: 38, message: MESSAGE }],
+      "import * as mod11 from 'mod'; ({ ...mod11.named } = foo)": [{ col: 36, message: MESSAGE }],
+      "import * as mod12 from 'mod'; delete mod12.named": [{ col: 30, message: MESSAGE }],
+      "import * as mod from 'mod'; Object.assign(mod, obj)": [{ col: 28, message: MESSAGE }],
+      "import * as mod from 'mod'; Object.defineProperty(mod, key, d)": [{ col: 28, message: MESSAGE }],
+      "import * as mod from 'mod'; Object.setPrototypeOf(mod, proto)": [{ col: 28, message: MESSAGE }],
+      "import * as mod from 'mod'; Object.freeze(mod)": [{ col: 28, message: MESSAGE }],
+      "import * as mod from 'mod'; Reflect.defineProperty(mod, key, d)": [{ col: 28, message: MESSAGE }],
+      "import * as mod from 'mod'; Reflect.deleteProperty(mod, key)": [{ col: 28, message: MESSAGE }],
+      "import * as mod from 'mod'; Reflect.set(mod, key, value)": [{ col: 28, message: MESSAGE }],
+      "import * as mod from 'mod'; Reflect.setPrototypeOf(mod, proto)": [{ col: 28, message: MESSAGE }],
+      "import mod, * as mod_ns from 'mod'; mod.prop = 0; mod_ns.prop = 0": [{ col: 50, message: MESSAGE }],
+      "import * as mod from 'mod'; Object?.defineProperty(mod, key, d)": [{ col: 28, message: MESSAGE }],
+      "import * as mod from 'mod'; (Object?.defineProperty)(mod, key, d)": [{ col: 28, message: MESSAGE }],
+      "import * as mod from 'mod'; delete mod?.prop": [{ col: 28, message: MESSAGE }],
+    }
   }
 }

--- a/src/rules/no_with.rs
+++ b/src/rules/no_with.rs
@@ -8,6 +8,9 @@ use swc_ecmascript::visit::Visit;
 
 pub struct NoWith;
 
+const CODE: &str = "no-with";
+const MESSAGE: &str = "`with` statement is not allowed";
+
 impl LintRule for NoWith {
   fn new() -> Box<Self> {
     Box::new(NoWith)
@@ -18,7 +21,7 @@ impl LintRule for NoWith {
   }
 
   fn code(&self) -> &'static str {
-    "no-with"
+    CODE
   }
 
   fn lint_module(
@@ -45,21 +48,19 @@ impl<'c> Visit for NoWithVisitor<'c> {
   noop_visit_type!();
 
   fn visit_with_stmt(&mut self, with_stmt: &WithStmt, _parent: &dyn Node) {
-    self.context.add_diagnostic(
-      with_stmt.span,
-      "no-with",
-      "`with` statement is not allowed",
-    );
+    self.context.add_diagnostic(with_stmt.span, CODE, MESSAGE);
   }
 }
 
 #[cfg(test)]
 mod tests {
   use super::*;
-  use crate::test_util::*;
 
   #[test]
   fn no_with_invalid() {
-    assert_lint_err::<NoWith>("with (someVar) { console.log('asdf'); }", 0)
+    assert_lint_err! {
+      NoWith,
+      "with (someVar) { console.log('asdf'); }": [{ col: 0, message: MESSAGE }],
+    }
   }
 }


### PR DESCRIPTION
Refactored to use `assert_lint_err!` in following rules:
- no-empty-character-class
- no-empty-pattern
- no-ex-assign
- no-explicit-any
- no-import-assign
- require-yield
- prefer-namespace-keyword
- no-with
- no-async-promise-executor
- no-array-constructor
- no-await-in-loop

Ref #431 