### PR TITLE
feat(example): add all-rules subcommand

### DIFF
--- a/examples/dlint/main.rs
+++ b/examples/dlint/main.rs
@@ -23,15 +23,8 @@ fn create_cli_app<'a, 'b>() -> App<'a, 'b> {
           Arg::with_name("RULE_NAME")
             .help("Show detailed information about rule"),
         )
-        .arg(Arg::with_name("json").long("json")),
-    )
-    .subcommand(
-      SubCommand::with_name("all-rules")
-        .arg(
-          Arg::with_name("RULE_NAME")
-            .help("Show detailed information about rule"),
-        )
-        .arg(Arg::with_name("json").long("json")),
+        .arg(Arg::with_name("json").long("json"))
+        .arg(Arg::with_name("all").long("all")),
     )
     .subcommand(
       SubCommand::with_name("run").arg(
@@ -251,25 +244,16 @@ fn main() {
     }
     ("rules", Some(rules_matches)) => {
       let json = rules_matches.is_present("json");
+      let tag = if rules_matches.is_present("all") {
+        RuleTag::All
+      } else {
+        RuleTag::Recommended
+      };
       let mut rules =
         if let Some(rule_name) = rules_matches.value_of("RULE_NAME") {
-          filter_rules(get_rules_by_tag(RuleTag::Recommended), rule_name)
+          filter_rules(get_rules_by_tag(tag), rule_name)
         } else {
-          get_rules_by_tag(RuleTag::Recommended)
-        };
-      if json {
-        print_rules::<JsonFormatter>(&mut rules);
-      } else {
-        print_rules::<PrettyFormatter>(&mut rules);
-      }
-    }
-    ("all-rules", Some(all_rules_matches)) => {
-      let json = all_rules_matches.is_present("json");
-      let mut rules =
-        if let Some(rule_name) = all_rules_matches.value_of("RULE_NAME") {
-          filter_rules(get_rules_by_tag(RuleTag::All), rule_name)
-        } else {
-          get_rules_by_tag(RuleTag::All)
+          get_rules_by_tag(tag)
         };
       if json {
         print_rules::<JsonFormatter>(&mut rules);

--- a/examples/dlint/main.rs
+++ b/examples/dlint/main.rs
@@ -146,6 +146,8 @@ fn run_linter(paths: Vec<String>) {
 struct Rule {
   code: &'static str,
   docs: &'static str,
+  #[serde(skip_serializing)]
+  recommended: bool,
 }
 
 enum RuleTag {
@@ -158,6 +160,7 @@ fn get_rules_by_tag(tag: RuleTag) -> Vec<Rule> {
     Rule {
       code: rule.code(),
       docs: rule.docs(),
+      recommended: rule.tags().contains(&"recommended"),
     }
   }
 
@@ -203,8 +206,14 @@ impl RuleFormatter for PrettyFormatter {
 
     rules.sort_by_key(|r| r.code);
     let mut list = Vec::with_capacity(1 + rules.len());
-    list.push("Available rules:".to_string());
-    list.extend(rules.iter().map(|r| format!(" - {}", r.code)));
+    list.push("Available rules (trailing ✔️ mark indicates it is included in the recommended rule set):".to_string());
+    list.extend(rules.iter().map(|r| {
+      let mut s = format!(" - {}", r.code);
+      if r.recommended {
+        s += " ✔️";
+      }
+      s
+    }));
     Ok(list.join("\n"))
   }
 }


### PR DESCRIPTION
Sometimes I feel like having the list of all rules. For example, in case where a check box list is wanted just like #431.
So I added a new subcommand `all-rules` to dlint example. This is how it works:

### pretty format
![image](https://user-images.githubusercontent.com/23649474/97097785-7359f180-16b8-11eb-8340-ba08c61fbe8b.png)

### json format
![image](https://user-images.githubusercontent.com/23649474/97097801-aef4bb80-16b8-11eb-94ef-b4719c23dcab.png)

### pretty format (with particular rule name)
![image](https://user-images.githubusercontent.com/23649474/97097815-d9467900-16b8-11eb-839b-fae454883c49.png)

### json format (with particular rule name)
![image](https://user-images.githubusercontent.com/23649474/97097840-2d515d80-16b9-11eb-9983-22a8a664e84e.png)

