### PR TITLE
refactor: Initial support for linting scripts

### DIFF
--- a/examples/dlint/main.rs
+++ b/examples/dlint/main.rs
@@ -28,12 +28,18 @@ fn create_cli_app<'a, 'b>() -> App<'a, 'b> {
         .arg(Arg::with_name("json").long("json")),
     )
     .subcommand(
-      SubCommand::with_name("run").arg(
-        Arg::with_name("FILES")
-          .help("Sets the input file to use")
-          .required(true)
-          .multiple(true),
-      ),
+      SubCommand::with_name("run")
+        .arg(
+          Arg::with_name("script")
+            .long("script")
+            .help("Treat files as scripts instead of modules"),
+        )
+        .arg(
+          Arg::with_name("FILES")
+            .help("Sets the input file to use")
+            .required(true)
+            .multiple(true),
+        ),
     )
 }
 
@@ -105,11 +111,17 @@ fn display_diagnostic(diagnostic: &LintDiagnostic, source: &str) {
   eprintln!("{}", display_list);
 }
 
-fn run_linter(paths: Vec<String>) {
+fn run_linter(paths: Vec<String>, is_script: bool) {
   let error_counts = Arc::new(AtomicUsize::new(0));
   let output_lock = Arc::new(Mutex::new(())); // prevent threads outputting at the same time
 
   paths.par_iter().for_each(|file_path| {
+    let file_type = if is_script {
+      FileType::Script
+    } else {
+      FileType::Module
+    };
+
     let source_code =
       std::fs::read_to_string(&file_path).expect("Failed to read file");
 
@@ -118,7 +130,7 @@ fn run_linter(paths: Vec<String>) {
       .build();
 
     let file_diagnostics = linter
-      .lint(file_path.to_string(), source_code.clone(), FileType::Module)
+      .lint(file_path.to_string(), source_code.clone(), file_type)
       .expect("Failed to lint");
 
     error_counts.fetch_add(file_diagnostics.len(), Ordering::Relaxed);
@@ -219,7 +231,8 @@ fn main() {
         .unwrap()
         .map(|p| p.to_string())
         .collect();
-      run_linter(paths);
+      let is_script = run_matches.is_present("script");
+      run_linter(paths, is_script);
     }
     ("rules", Some(rules_matches)) => {
       let json = rules_matches.is_present("json");

--- a/examples/dlint/main.rs
+++ b/examples/dlint/main.rs
@@ -7,6 +7,7 @@ use clap::Arg;
 use clap::SubCommand;
 use deno_lint::diagnostic::LintDiagnostic;
 use deno_lint::diagnostic::Range;
+use deno_lint::linter::FileType;
 use deno_lint::linter::LinterBuilder;
 use deno_lint::rules::get_recommended_rules;
 use rayon::prelude::*;
@@ -117,7 +118,7 @@ fn run_linter(paths: Vec<String>) {
       .build();
 
     let file_diagnostics = linter
-      .lint(file_path.to_string(), source_code.clone())
+      .lint(file_path.to_string(), source_code.clone(), FileType::Module)
       .expect("Failed to lint");
 
     error_counts.fetch_add(file_diagnostics.len(), Ordering::Relaxed);

--- a/src/control_flow.rs
+++ b/src/control_flow.rs
@@ -15,12 +15,12 @@ pub struct ControlFlow {
 }
 
 impl ControlFlow {
-  pub fn analyze(m: &Module) -> Self {
+  pub fn analyze(program: &Program) -> Self {
     let mut v = Analyzer {
-      scope: Scope::new(None, BlockKind::Module),
+      scope: Scope::new(None, BlockKind::Program),
       info: Default::default(),
     };
-    m.visit_with(&Invalid { span: DUMMY_SP }, &mut v);
+    program.visit_with(&Invalid { span: DUMMY_SP }, &mut v);
     ControlFlow { meta: v.info }
   }
 
@@ -36,8 +36,8 @@ impl ControlFlow {
 /// Kind of a basic block.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum BlockKind {
-  /// Module
-  Module,
+  /// Program (module or script)
+  Program,
   /// Function's body
   Function,
   /// Switch case
@@ -177,7 +177,7 @@ impl Analyzer<'_> {
 
     if let Some(end) = end {
       match kind {
-        BlockKind::Module => {}
+        BlockKind::Program => {}
         BlockKind::Function => {
           match end {
             End::Forced | End::Continue => self.mark_as_end(lo, end),
@@ -658,7 +658,7 @@ mod tests {
 
   fn analyze_flow(src: &str) -> ControlFlow {
     let module = parse(src);
-    ControlFlow::analyze(&module)
+    ControlFlow::analyze(&Program::Module(module))
   }
 
   macro_rules! assert_flow {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,7 +38,11 @@ mod lint_tests {
       .build();
 
     linter
-      .lint("lint_test.ts".to_string(), source.to_string())
+      .lint(
+        "lint_test.ts".to_string(),
+        source.to_string(),
+        FileType::Module,
+      )
       .expect("Failed to lint")
   }
 

--- a/src/linter.rs
+++ b/src/linter.rs
@@ -16,8 +16,16 @@ use swc_common::comments::SingleThreadedComments;
 use swc_common::BytePos;
 use swc_common::SourceMap;
 use swc_common::Span;
+use swc_common::Spanned;
 use swc_common::{comments::Comment, SyntaxContext};
 use swc_ecmascript::parser::Syntax;
+
+/// Describes if file should be treated as a script
+/// or ES module.
+pub enum FileType {
+  Module,
+  Script,
+}
 
 pub struct Context {
   pub file_name: String,
@@ -192,6 +200,7 @@ impl Linter {
     &mut self,
     file_name: String,
     source_code: String,
+    file_type: FileType,
   ) -> Result<Vec<LintDiagnostic>, SwcDiagnosticBuffer> {
     assert!(
       !self.has_linted,
@@ -199,21 +208,40 @@ impl Linter {
     );
     self.has_linted = true;
     let start = Instant::now();
-    let diagnostics = if source_code.is_empty() {
-      vec![]
-    } else {
-      let (parse_result, comments) =
-        self
-          .ast_parser
-          .parse_module(&file_name, self.syntax, &source_code);
-      let end_parse_module = Instant::now();
-      debug!(
-        "ast_parser.parse_module took {:#?}",
-        end_parse_module - start
-      );
-      let module = parse_result?;
-      self.lint_module(file_name, module, comments)
-    };
+    let mut diagnostics = vec![];
+
+    if !source_code.is_empty() {
+      let (program, comments) = match file_type {
+        FileType::Script => {
+          let (parse_result, comments) =
+            self
+              .ast_parser
+              .parse_script(&file_name, self.syntax, &source_code);
+          let end_parse_script = Instant::now();
+          debug!(
+            "ast_parser.parse_script took {:#?}",
+            end_parse_script - start
+          );
+          let script = parse_result?;
+          (swc_ecmascript::ast::Program::Script(script), comments)
+        }
+        FileType::Module => {
+          let (parse_result, comments) =
+            self
+              .ast_parser
+              .parse_module(&file_name, self.syntax, &source_code);
+          let end_parse_module = Instant::now();
+          debug!(
+            "ast_parser.parse_module took {:#?}",
+            end_parse_module - start
+          );
+          let module = parse_result?;
+          (swc_ecmascript::ast::Program::Module(module), comments)
+        }
+      };
+
+      diagnostics = self.lint_program(file_name, program, comments);
+    }
 
     let end = Instant::now();
     debug!("Linter::lint took {:#?}", end - start);
@@ -285,32 +313,33 @@ impl Linter {
     filtered_diagnostics
   }
 
-  fn lint_module(
+  fn lint_program(
     &self,
     file_name: String,
-    module: swc_ecmascript::ast::Module,
+    program: swc_ecmascript::ast::Program,
     comments: SingleThreadedComments,
   ) -> Vec<LintDiagnostic> {
     let start = Instant::now();
-    let file_ignore_directive = comments.with_leading(module.span.lo(), |c| {
-      let directives = c
-        .iter()
-        .filter_map(|comment| {
-          parse_ignore_comment(
-            &self.ignore_file_directives,
-            &*self.ast_parser.source_map,
-            comment,
-            true,
-          )
-        })
-        .collect::<Vec<IgnoreDirective>>();
+    let file_ignore_directive =
+      comments.with_leading(program.span().lo(), |c| {
+        let directives = c
+          .iter()
+          .filter_map(|comment| {
+            parse_ignore_comment(
+              &self.ignore_file_directives,
+              &*self.ast_parser.source_map,
+              comment,
+              true,
+            )
+          })
+          .collect::<Vec<IgnoreDirective>>();
 
-      if directives.is_empty() {
-        None
-      } else {
-        Some(directives[0].clone())
-      }
-    });
+        if directives.is_empty() {
+          None
+        } else {
+          Some(directives[0].clone())
+        }
+      });
 
     // If there's a file ignore directive that has no codes specified we must ignore
     // whole file and skip linting it.
@@ -341,8 +370,8 @@ impl Linter {
       ignore_directives.insert(0, ignore_directive);
     }
 
-    let scope = analyze(&module);
-    let control_flow = ControlFlow::analyze(&module);
+    let scope = analyze(&program);
+    let control_flow = ControlFlow::analyze(&program);
 
     let mut context = Context {
       file_name,
@@ -359,7 +388,7 @@ impl Linter {
     };
 
     for rule in &self.rules {
-      rule.lint_module(&mut context, &module);
+      rule.lint_program(&mut context, &program);
     }
 
     let d = self.filter_diagnostics(&mut context, &self.rules);

--- a/src/linter.rs
+++ b/src/linter.rs
@@ -322,23 +322,14 @@ impl Linter {
     let start = Instant::now();
     let file_ignore_directive =
       comments.with_leading(program.span().lo(), |c| {
-        let directives = c
-          .iter()
-          .filter_map(|comment| {
-            parse_ignore_comment(
-              &self.ignore_file_directives,
-              &*self.ast_parser.source_map,
-              comment,
-              true,
-            )
-          })
-          .collect::<Vec<IgnoreDirective>>();
-
-        if directives.is_empty() {
-          None
-        } else {
-          Some(directives[0].clone())
-        }
+        c.iter().find_map(|comment| {
+          parse_ignore_comment(
+            &self.ignore_file_directives,
+            &*self.ast_parser.source_map,
+            comment,
+            true,
+          )
+        })
       });
 
     // If there's a file ignore directive that has no codes specified we must ignore

--- a/src/rules.rs
+++ b/src/rules.rs
@@ -89,19 +89,7 @@ pub trait LintRule {
   fn new() -> Box<Self>
   where
     Self: Sized;
-  fn lint_program(&self, context: &mut Context, program: &Program) {
-    match program {
-      Program::Module(module) => {
-        self.lint_module(context, module);
-      }
-      Program::Script(_script) => todo!(),
-    }
-  }
-  fn lint_module(
-    &self,
-    context: &mut Context,
-    module: &swc_ecmascript::ast::Module,
-  );
+  fn lint_program(&self, context: &mut Context, program: &Program);
   fn code(&self) -> &'static str;
   fn tags(&self) -> &[&'static str] {
     &[]

--- a/src/rules.rs
+++ b/src/rules.rs
@@ -88,6 +88,16 @@ pub trait LintRule {
   fn new() -> Box<Self>
   where
     Self: Sized;
+  fn lint_program(
+    &self,
+    context: &mut Context,
+    program: &swc_ecmascript::ast::Program,
+  ) {
+    if let swc_ecmascript::ast::Program::Module(module) = program {
+      self.lint_module(context, module)
+    }
+    todo!();
+  }
   fn lint_module(
     &self,
     context: &mut Context,

--- a/src/rules.rs
+++ b/src/rules.rs
@@ -1,5 +1,6 @@
 // Copyright 2020 the Deno authors. All rights reserved. MIT license.
 use crate::linter::Context;
+use swc_ecmascript::ast::Program;
 
 pub mod adjacent_overload_signatures;
 pub mod ban_ts_comment;
@@ -88,15 +89,13 @@ pub trait LintRule {
   fn new() -> Box<Self>
   where
     Self: Sized;
-  fn lint_program(
-    &self,
-    context: &mut Context,
-    program: &swc_ecmascript::ast::Program,
-  ) {
-    if let swc_ecmascript::ast::Program::Module(module) = program {
-      self.lint_module(context, module)
+  fn lint_program(&self, context: &mut Context, program: &Program) {
+    match program {
+      Program::Module(module) => {
+        self.lint_module(context, module);
+      }
+      Program::Script(_script) => todo!(),
     }
-    todo!();
   }
   fn lint_module(
     &self,

--- a/src/rules/adjacent_overload_signatures.rs
+++ b/src/rules/adjacent_overload_signatures.rs
@@ -7,7 +7,7 @@ use swc_common::Span;
 use swc_common::Spanned;
 use swc_ecmascript::ast::{
   Class, ClassMember, ClassMethod, Decl, ExportDecl, Expr, FnDecl, Ident, Lit,
-  Module, ModuleDecl, ModuleItem, Stmt, Str, TsInterfaceBody,
+  Module, ModuleDecl, ModuleItem, Program, Stmt, Str, TsInterfaceBody,
   TsMethodSignature, TsModuleBlock, TsTypeElement, TsTypeLit,
 };
 use swc_ecmascript::visit::VisitAllWith;
@@ -28,9 +28,9 @@ impl LintRule for AdjacentOverloadSignatures {
     "adjacent-overload-signatures"
   }
 
-  fn lint_module(&self, context: &mut Context, module: &Module) {
+  fn lint_program(&self, context: &mut Context, program: &Program) {
     let mut visitor = AdjacentOverloadSignaturesVisitor::new(context);
-    module.visit_all_with(module, &mut visitor);
+    program.visit_all_with(program, &mut visitor);
   }
 
   fn docs(&self) -> &'static str {

--- a/src/rules/ban_ts_comment.rs
+++ b/src/rules/ban_ts_comment.rs
@@ -44,10 +44,10 @@ impl LintRule for BanTsComment {
     "ban-ts-comment"
   }
 
-  fn lint_module(
+  fn lint_program(
     &self,
     context: &mut Context,
-    _module: &swc_ecmascript::ast::Module,
+    _program: &swc_ecmascript::ast::Program,
   ) {
     let mut violated_comment_spans = Vec::new();
 

--- a/src/rules/ban_types.rs
+++ b/src/rules/ban_types.rs
@@ -25,13 +25,13 @@ impl LintRule for BanTypes {
     "ban-types"
   }
 
-  fn lint_module(
+  fn lint_program(
     &self,
     context: &mut Context,
-    module: &swc_ecmascript::ast::Module,
+    program: &swc_ecmascript::ast::Program,
   ) {
     let mut visitor = BanTypesVisitor::new(context);
-    visitor.visit_module(module, module);
+    visitor.visit_program(program, program);
   }
 
   fn docs(&self) -> &'static str {

--- a/src/rules/ban_untagged_ignore.rs
+++ b/src/rules/ban_untagged_ignore.rs
@@ -18,10 +18,10 @@ impl LintRule for BanUntaggedIgnore {
     "ban-untagged-ignore"
   }
 
-  fn lint_module(
+  fn lint_program(
     &self,
     context: &mut Context,
-    _module: &swc_ecmascript::ast::Module,
+    _program: &swc_ecmascript::ast::Program,
   ) {
     let violated_spans: Vec<Span> = context
       .ignore_directives

--- a/src/rules/ban_untagged_todo.rs
+++ b/src/rules/ban_untagged_todo.rs
@@ -29,10 +29,10 @@ impl LintRule for BanUntaggedTodo {
     "ban-untagged-todo"
   }
 
-  fn lint_module(
+  fn lint_program(
     &self,
     context: &mut Context,
-    _module: &swc_ecmascript::ast::Module,
+    _program: &swc_ecmascript::ast::Program,
   ) {
     let mut violated_comment_spans = Vec::new();
 

--- a/src/rules/camelcase.rs
+++ b/src/rules/camelcase.rs
@@ -10,9 +10,9 @@ use swc_ecmascript::ast::{
   ArrayPat, AssignPat, AssignPatProp, ClassDecl, ClassExpr,
   ExportNamespaceSpecifier, Expr, FnDecl, FnExpr, GetterProp, Ident,
   ImportDefaultSpecifier, ImportNamedSpecifier, ImportStarAsSpecifier,
-  KeyValuePatProp, KeyValueProp, MethodProp, Module, ObjectLit, ObjectPat,
-  ObjectPatProp, Param, Pat, Prop, PropName, PropOrSpread, RestPat, SetterProp,
-  VarDeclarator,
+  KeyValuePatProp, KeyValueProp, MethodProp, ObjectLit, ObjectPat,
+  ObjectPatProp, Param, Pat, Program, Prop, PropName, PropOrSpread, RestPat,
+  SetterProp, VarDeclarator,
 };
 use swc_ecmascript::visit::{noop_visit_type, Node, Visit, VisitWith};
 
@@ -31,9 +31,9 @@ impl LintRule for Camelcase {
     "camelcase"
   }
 
-  fn lint_module(&self, context: &mut Context, module: &Module) {
+  fn lint_program(&self, context: &mut Context, program: &Program) {
     let mut visitor = CamelcaseVisitor::new(context);
-    visitor.visit_module(module, module);
+    visitor.visit_program(program, program);
     visitor.report_errors();
   }
 }

--- a/src/rules/constructor_super.rs
+++ b/src/rules/constructor_super.rs
@@ -25,13 +25,13 @@ impl LintRule for ConstructorSuper {
     "constructor-super"
   }
 
-  fn lint_module(
+  fn lint_program(
     &self,
     context: &mut Context,
-    module: &swc_ecmascript::ast::Module,
+    program: &swc_ecmascript::ast::Program,
   ) {
     let mut visitor = ConstructorSuperVisitor::new(context);
-    visitor.visit_module(module, module);
+    visitor.visit_program(program, program);
   }
 
   fn docs(&self) -> &'static str {

--- a/src/rules/default_param_last.rs
+++ b/src/rules/default_param_last.rs
@@ -19,13 +19,13 @@ impl LintRule for DefaultParamLast {
     "default-param-last"
   }
 
-  fn lint_module(
+  fn lint_program(
     &self,
     context: &mut Context,
-    module: &swc_ecmascript::ast::Module,
+    program: &swc_ecmascript::ast::Program,
   ) {
     let mut visitor = DefaultParamLastVisitor::new(context);
-    module.visit_all_with(module, &mut visitor);
+    program.visit_all_with(program, &mut visitor);
   }
 
   fn docs(&self) -> &'static str {

--- a/src/rules/eqeqeq.rs
+++ b/src/rules/eqeqeq.rs
@@ -17,13 +17,13 @@ impl LintRule for Eqeqeq {
     "eqeqeq"
   }
 
-  fn lint_module(
+  fn lint_program(
     &self,
     context: &mut Context,
-    module: &swc_ecmascript::ast::Module,
+    program: &swc_ecmascript::ast::Program,
   ) {
     let mut visitor = EqeqeqVisitor::new(context);
-    visitor.visit_module(module, module);
+    visitor.visit_program(program, program);
   }
 
   fn docs(&self) -> &'static str {

--- a/src/rules/explicit_function_return_type.rs
+++ b/src/rules/explicit_function_return_type.rs
@@ -16,13 +16,13 @@ impl LintRule for ExplicitFunctionReturnType {
     "explicit-function-return-type"
   }
 
-  fn lint_module(
+  fn lint_program(
     &self,
     context: &mut Context,
-    module: &swc_ecmascript::ast::Module,
+    program: &swc_ecmascript::ast::Program,
   ) {
     let mut visitor = ExplicitFunctionReturnTypeVisitor::new(context);
-    visitor.visit_module(module, module);
+    visitor.visit_program(program, program);
   }
 
   fn docs(&self) -> &'static str {

--- a/src/rules/explicit_module_boundary_types.rs
+++ b/src/rules/explicit_module_boundary_types.rs
@@ -7,8 +7,8 @@ use swc_ecmascript::visit::Node;
 use swc_ecmascript::visit::Visit;
 
 use swc_ecmascript::ast::{
-  ArrowExpr, Class, ClassMember, Decl, DefaultDecl, Expr, Function, Module,
-  ModuleDecl, Pat, TsKeywordTypeKind, TsType, TsTypeAnn, VarDecl,
+  ArrowExpr, Class, ClassMember, Decl, DefaultDecl, Expr, Function, ModuleDecl,
+  Pat, Program, TsKeywordTypeKind, TsType, TsTypeAnn, VarDecl,
 };
 
 pub struct ExplicitModuleBoundaryTypes;
@@ -22,9 +22,9 @@ impl LintRule for ExplicitModuleBoundaryTypes {
     "explicit-module-boundary-types"
   }
 
-  fn lint_module(&self, context: &mut Context, module: &Module) {
+  fn lint_program(&self, context: &mut Context, program: &Program) {
     let mut visitor = ExplicitModuleBoundaryTypesVisitor::new(context);
-    visitor.visit_module(module, module);
+    visitor.visit_program(program, program);
   }
 
   fn docs(&self) -> &'static str {

--- a/src/rules/for_direction.rs
+++ b/src/rules/for_direction.rs
@@ -31,13 +31,13 @@ impl LintRule for ForDirection {
     "for-direction"
   }
 
-  fn lint_module(
+  fn lint_program(
     &self,
     context: &mut Context,
-    module: &swc_ecmascript::ast::Module,
+    program: &swc_ecmascript::ast::Program,
   ) {
     let mut visitor = ForDirectionVisitor::new(context);
-    module.visit_all_with(module, &mut visitor);
+    program.visit_all_with(program, &mut visitor);
   }
 
   fn docs(&self) -> &'static str {

--- a/src/rules/getter_return.rs
+++ b/src/rules/getter_return.rs
@@ -29,13 +29,13 @@ impl LintRule for GetterReturn {
     "getter-return"
   }
 
-  fn lint_module(
+  fn lint_program(
     &self,
     context: &mut Context,
-    module: &swc_ecmascript::ast::Module,
+    program: &swc_ecmascript::ast::Program,
   ) {
     let mut visitor = GetterReturnVisitor::new(context);
-    visitor.visit_module(module, module);
+    visitor.visit_program(program, program);
     visitor.report();
   }
 

--- a/src/rules/no_array_constructor.rs
+++ b/src/rules/no_array_constructor.rs
@@ -23,13 +23,13 @@ impl LintRule for NoArrayConstructor {
     "no-array-constructor"
   }
 
-  fn lint_module(
+  fn lint_program(
     &self,
     context: &mut Context,
-    module: &swc_ecmascript::ast::Module,
+    program: &swc_ecmascript::ast::Program,
   ) {
     let mut visitor = NoArrayConstructorVisitor::new(context);
-    module.visit_all_with(module, &mut visitor);
+    program.visit_all_with(program, &mut visitor);
   }
 
   fn docs(&self) -> &'static str {

--- a/src/rules/no_async_promise_executor.rs
+++ b/src/rules/no_async_promise_executor.rs
@@ -22,13 +22,13 @@ impl LintRule for NoAsyncPromiseExecutor {
     "no-async-promise-executor"
   }
 
-  fn lint_module(
+  fn lint_program(
     &self,
     context: &mut Context,
-    module: &swc_ecmascript::ast::Module,
+    program: &swc_ecmascript::ast::Program,
   ) {
     let mut visitor = NoAsyncPromiseExecutorVisitor::new(context);
-    module.visit_all_with(module, &mut visitor);
+    program.visit_all_with(program, &mut visitor);
   }
 
   fn docs(&self) -> &'static str {

--- a/src/rules/no_await_in_loop.rs
+++ b/src/rules/no_await_in_loop.rs
@@ -19,13 +19,13 @@ impl LintRule for NoAwaitInLoop {
     "no-await-in-loop"
   }
 
-  fn lint_module(
+  fn lint_program(
     &self,
     context: &mut Context,
-    module: &swc_ecmascript::ast::Module,
+    program: &swc_ecmascript::ast::Program,
   ) {
     let mut visitor = NoAwaitInLoopVisitor::new(context);
-    visitor.visit_module(module, module);
+    visitor.visit_program(program, program);
   }
 
   fn docs(&self) -> &'static str {

--- a/src/rules/no_case_declarations.rs
+++ b/src/rules/no_case_declarations.rs
@@ -25,13 +25,13 @@ impl LintRule for NoCaseDeclarations {
     "no-case-declarations"
   }
 
-  fn lint_module(
+  fn lint_program(
     &self,
     context: &mut Context,
-    module: &swc_ecmascript::ast::Module,
+    program: &swc_ecmascript::ast::Program,
   ) {
     let mut visitor = NoCaseDeclarationsVisitor::new(context);
-    module.visit_all_with(module, &mut visitor);
+    program.visit_all_with(program, &mut visitor);
   }
 
   fn docs(&self) -> &'static str {

--- a/src/rules/no_class_assign.rs
+++ b/src/rules/no_class_assign.rs
@@ -23,13 +23,13 @@ impl LintRule for NoClassAssign {
     "no-class-assign"
   }
 
-  fn lint_module(
+  fn lint_program(
     &self,
     context: &mut Context,
-    module: &swc_ecmascript::ast::Module,
+    program: &swc_ecmascript::ast::Program,
   ) {
     let mut visitor = NoClassAssignVisitor::new(context);
-    module.visit_all_with(module, &mut visitor);
+    program.visit_all_with(program, &mut visitor);
   }
 
   fn docs(&self) -> &'static str {

--- a/src/rules/no_compare_neg_zero.rs
+++ b/src/rules/no_compare_neg_zero.rs
@@ -5,7 +5,7 @@ use swc_ecmascript::ast::Expr::{Lit, Unary};
 use swc_ecmascript::ast::Lit::Num;
 use swc_ecmascript::ast::UnaryExpr;
 use swc_ecmascript::ast::UnaryOp::Minus;
-use swc_ecmascript::ast::{BinExpr, BinaryOp, Expr, Module};
+use swc_ecmascript::ast::{BinExpr, BinaryOp, Expr, Program};
 use swc_ecmascript::visit::{noop_visit_type, Node, VisitAll, VisitAllWith};
 
 pub struct NoCompareNegZero;
@@ -23,9 +23,9 @@ impl LintRule for NoCompareNegZero {
     "no-compare-neg-zero"
   }
 
-  fn lint_module(&self, context: &mut Context, module: &Module) {
+  fn lint_program(&self, context: &mut Context, program: &Program) {
     let mut visitor = NoCompareNegZeroVisitor::new(context);
-    module.visit_all_with(module, &mut visitor);
+    program.visit_all_with(program, &mut visitor);
   }
 
   fn docs(&self) -> &'static str {

--- a/src/rules/no_cond_assign.rs
+++ b/src/rules/no_cond_assign.rs
@@ -3,7 +3,7 @@ use super::{Context, LintRule};
 use swc_common::Span;
 use swc_ecmascript::ast::Expr;
 use swc_ecmascript::ast::Expr::{Assign, Bin, Paren};
-use swc_ecmascript::ast::Module;
+use swc_ecmascript::ast::Program;
 use swc_ecmascript::visit::{noop_visit_type, Node, VisitAll, VisitAllWith};
 
 pub struct NoCondAssign;
@@ -21,9 +21,9 @@ impl LintRule for NoCondAssign {
     "no-cond-assign"
   }
 
-  fn lint_module(&self, context: &mut Context, module: &Module) {
+  fn lint_program(&self, context: &mut Context, program: &Program) {
     let mut visitor = NoCondAssignVisitor::new(context);
-    module.visit_all_with(module, &mut visitor);
+    program.visit_all_with(program, &mut visitor);
   }
 
   fn docs(&self) -> &'static str {

--- a/src/rules/no_const_assign.rs
+++ b/src/rules/no_const_assign.rs
@@ -23,13 +23,13 @@ impl LintRule for NoConstAssign {
     "no-const-assign"
   }
 
-  fn lint_module(
+  fn lint_program(
     &self,
     context: &mut Context,
-    module: &swc_ecmascript::ast::Module,
+    program: &swc_ecmascript::ast::Program,
   ) {
     let mut visitor = NoConstAssignVisitor::new(context);
-    visitor.visit_module(module, module);
+    visitor.visit_program(program, program);
   }
 
   fn docs(&self) -> &'static str {

--- a/src/rules/no_constant_condition.rs
+++ b/src/rules/no_constant_condition.rs
@@ -5,7 +5,7 @@ use super::LintRule;
 use swc_common::Span;
 use swc_common::Spanned;
 use swc_ecmascript::ast::{
-  BinaryOp, CondExpr, Expr, IfStmt, Lit, Module, UnaryOp,
+  BinaryOp, CondExpr, Expr, IfStmt, Lit, Program, UnaryOp,
 };
 use swc_ecmascript::visit::{noop_visit_type, Node, VisitAll, VisitAllWith};
 
@@ -24,9 +24,9 @@ impl LintRule for NoConstantCondition {
     "no-constant-condition"
   }
 
-  fn lint_module(&self, context: &mut Context, module: &Module) {
+  fn lint_program(&self, context: &mut Context, program: &Program) {
     let mut visitor = NoConstantConditionVisitor::new(context);
-    module.visit_all_with(module, &mut visitor);
+    program.visit_all_with(program, &mut visitor);
   }
 
   fn docs(&self) -> &'static str {

--- a/src/rules/no_control_regex.rs
+++ b/src/rules/no_control_regex.rs
@@ -25,13 +25,13 @@ impl LintRule for NoControlRegex {
     "no-control-regex"
   }
 
-  fn lint_module(
+  fn lint_program(
     &self,
     context: &mut Context,
-    module: &swc_ecmascript::ast::Module,
+    program: &swc_ecmascript::ast::Program,
   ) {
     let mut visitor = NoControlRegexVisitor::new(context);
-    visitor.visit_module(module, module);
+    visitor.visit_program(program, program);
   }
 
   fn docs(&self) -> &'static str {

--- a/src/rules/no_debugger.rs
+++ b/src/rules/no_debugger.rs
@@ -21,13 +21,13 @@ impl LintRule for NoDebugger {
     "no-debugger"
   }
 
-  fn lint_module(
+  fn lint_program(
     &self,
     context: &mut Context,
-    module: &swc_ecmascript::ast::Module,
+    program: &swc_ecmascript::ast::Program,
   ) {
     let mut visitor = NoDebuggerVisitor::new(context);
-    visitor.visit_module(module, module);
+    visitor.visit_program(program, program);
   }
 
   fn docs(&self) -> &'static str {

--- a/src/rules/no_delete_var.rs
+++ b/src/rules/no_delete_var.rs
@@ -23,13 +23,13 @@ impl LintRule for NoDeleteVar {
     "no-delete-var"
   }
 
-  fn lint_module(
+  fn lint_program(
     &self,
     context: &mut Context,
-    module: &swc_ecmascript::ast::Module,
+    program: &swc_ecmascript::ast::Program,
   ) {
     let mut visitor = NoDeleteVarVisitor::new(context);
-    visitor.visit_module(module, module);
+    visitor.visit_program(program, program);
   }
 
   fn docs(&self) -> &'static str {

--- a/src/rules/no_dupe_args.rs
+++ b/src/rules/no_dupe_args.rs
@@ -26,13 +26,13 @@ impl LintRule for NoDupeArgs {
     "no-dupe-args"
   }
 
-  fn lint_module(
+  fn lint_program(
     &self,
     context: &mut Context,
-    module: &swc_ecmascript::ast::Module,
+    program: &swc_ecmascript::ast::Program,
   ) {
     let mut visitor = NoDupeArgsVisitor::new(context);
-    module.visit_all_with(module, &mut visitor);
+    program.visit_all_with(program, &mut visitor);
     visitor.report_errors();
   }
 

--- a/src/rules/no_dupe_class_members.rs
+++ b/src/rules/no_dupe_class_members.rs
@@ -27,13 +27,13 @@ impl LintRule for NoDupeClassMembers {
     "no-dupe-class-members"
   }
 
-  fn lint_module(
+  fn lint_program(
     &self,
     context: &mut Context,
-    module: &swc_ecmascript::ast::Module,
+    program: &swc_ecmascript::ast::Program,
   ) {
     let mut visitor = NoDupeClassMembersVisitor::new(context);
-    visitor.visit_module(module, module);
+    visitor.visit_program(program, program);
   }
 
   fn docs(&self) -> &'static str {

--- a/src/rules/no_dupe_else_if.rs
+++ b/src/rules/no_dupe_else_if.rs
@@ -4,7 +4,7 @@ use crate::swc_util::DropSpan;
 use std::collections::HashSet;
 use swc_common::{Span, Spanned};
 use swc_ecmascript::ast::{
-  BinExpr, BinaryOp, Expr, IfStmt, Module, ParenExpr, Stmt,
+  BinExpr, BinaryOp, Expr, IfStmt, ParenExpr, Program, Stmt,
 };
 use swc_ecmascript::visit::{noop_visit_type, Node, Visit};
 
@@ -23,9 +23,9 @@ impl LintRule for NoDupeElseIf {
     "no-dupe-else-if"
   }
 
-  fn lint_module(&self, context: &mut Context, module: &Module) {
+  fn lint_program(&self, context: &mut Context, program: &Program) {
     let mut visitor = NoDupeElseIfVisitor::new(context);
-    visitor.visit_module(module, module);
+    visitor.visit_program(program, program);
   }
 
   fn docs(&self) -> &'static str {

--- a/src/rules/no_dupe_keys.rs
+++ b/src/rules/no_dupe_keys.rs
@@ -6,7 +6,7 @@ use std::collections::hash_map::Entry;
 use std::collections::HashMap;
 use swc_common::Span;
 use swc_ecmascript::ast::{
-  GetterProp, KeyValueProp, MethodProp, Module, ObjectLit, Prop, PropOrSpread,
+  GetterProp, KeyValueProp, MethodProp, ObjectLit, Program, Prop, PropOrSpread,
   SetterProp,
 };
 use swc_ecmascript::visit::{noop_visit_type, Node, VisitAll, VisitAllWith};
@@ -26,9 +26,9 @@ impl LintRule for NoDupeKeys {
     "no-dupe-keys"
   }
 
-  fn lint_module(&self, context: &mut Context, module: &Module) {
+  fn lint_program(&self, context: &mut Context, program: &Program) {
     let mut visitor = NoDupeKeysVisitor::new(context);
-    module.visit_all_with(module, &mut visitor);
+    program.visit_all_with(program, &mut visitor);
   }
 
   fn docs(&self) -> &'static str {

--- a/src/rules/no_duplicate_case.rs
+++ b/src/rules/no_duplicate_case.rs
@@ -22,13 +22,13 @@ impl LintRule for NoDuplicateCase {
     "no-duplicate-case"
   }
 
-  fn lint_module(
+  fn lint_program(
     &self,
     context: &mut Context,
-    module: &swc_ecmascript::ast::Module,
+    program: &swc_ecmascript::ast::Program,
   ) {
     let mut visitor = NoDuplicateCaseVisitor::new(context);
-    visitor.visit_module(module, module);
+    visitor.visit_program(program, program);
   }
 
   fn docs(&self) -> &'static str {

--- a/src/rules/no_empty.rs
+++ b/src/rules/no_empty.rs
@@ -1,7 +1,7 @@
 // Copyright 2020 the Deno authors. All rights reserved. MIT license.
 use super::{Context, LintRule};
 use swc_ecmascript::ast::{
-  ArrowExpr, BlockStmt, BlockStmtOrExpr, Constructor, Function, Module,
+  ArrowExpr, BlockStmt, BlockStmtOrExpr, Constructor, Function, Program,
   SwitchStmt,
 };
 use swc_ecmascript::visit::{noop_visit_type, Node, Visit, VisitWith};
@@ -21,9 +21,9 @@ impl LintRule for NoEmpty {
     "no-empty"
   }
 
-  fn lint_module(&self, context: &mut Context, module: &Module) {
+  fn lint_program(&self, context: &mut Context, program: &Program) {
     let mut visitor = NoEmptyVisitor::new(context);
-    visitor.visit_module(module, module);
+    visitor.visit_program(program, program);
   }
 
   fn docs(&self) -> &'static str {

--- a/src/rules/no_empty_character_class.rs
+++ b/src/rules/no_empty_character_class.rs
@@ -22,13 +22,13 @@ impl LintRule for NoEmptyCharacterClass {
     "no-empty-character-class"
   }
 
-  fn lint_module(
+  fn lint_program(
     &self,
     context: &mut Context,
-    module: &swc_ecmascript::ast::Module,
+    program: &swc_ecmascript::ast::Program,
   ) {
     let mut visitor = NoEmptyCharacterClassVisitor::new(context);
-    visitor.visit_module(module, module);
+    visitor.visit_program(program, program);
   }
 }
 

--- a/src/rules/no_empty_interface.rs
+++ b/src/rules/no_empty_interface.rs
@@ -20,13 +20,13 @@ impl LintRule for NoEmptyInterface {
     "no-empty-interface"
   }
 
-  fn lint_module(
+  fn lint_program(
     &self,
     context: &mut Context,
-    module: &swc_ecmascript::ast::Module,
+    program: &swc_ecmascript::ast::Program,
   ) {
     let mut visitor = NoEmptyInterfaceVisitor::new(context);
-    visitor.visit_module(module, module);
+    visitor.visit_program(program, program);
   }
 }
 

--- a/src/rules/no_empty_pattern.rs
+++ b/src/rules/no_empty_pattern.rs
@@ -21,13 +21,13 @@ impl LintRule for NoEmptyPattern {
     "no-empty-pattern"
   }
 
-  fn lint_module(
+  fn lint_program(
     &self,
     context: &mut Context,
-    module: &swc_ecmascript::ast::Module,
+    program: &swc_ecmascript::ast::Program,
   ) {
     let mut visitor = NoEmptyPatternVisitor::new(context);
-    visitor.visit_module(module, module);
+    visitor.visit_program(program, program);
   }
 }
 

--- a/src/rules/no_eval.rs
+++ b/src/rules/no_eval.rs
@@ -19,13 +19,13 @@ impl LintRule for NoEval {
     "no-eval"
   }
 
-  fn lint_module(
+  fn lint_program(
     &self,
     context: &mut Context,
-    module: &swc_ecmascript::ast::Module,
+    program: &swc_ecmascript::ast::Program,
   ) {
     let mut visitor = NoEvalVisitor::new(context);
-    visitor.visit_module(module, module);
+    visitor.visit_program(program, program);
   }
 }
 

--- a/src/rules/no_ex_assign.rs
+++ b/src/rules/no_ex_assign.rs
@@ -23,13 +23,13 @@ impl LintRule for NoExAssign {
     "no-ex-assign"
   }
 
-  fn lint_module(
+  fn lint_program(
     &self,
     context: &mut Context,
-    module: &swc_ecmascript::ast::Module,
+    program: &swc_ecmascript::ast::Program,
   ) {
     let mut visitor = NoExAssignVisitor::new(context);
-    visitor.visit_module(module, module);
+    visitor.visit_program(program, program);
   }
 }
 

--- a/src/rules/no_explicit_any.rs
+++ b/src/rules/no_explicit_any.rs
@@ -20,13 +20,13 @@ impl LintRule for NoExplicitAny {
     "no-explicit-any"
   }
 
-  fn lint_module(
+  fn lint_program(
     &self,
     context: &mut Context,
-    module: &swc_ecmascript::ast::Module,
+    program: &swc_ecmascript::ast::Program,
   ) {
     let mut visitor = NoExplicitAnyVisitor::new(context);
-    visitor.visit_module(module, module);
+    visitor.visit_program(program, program);
   }
 }
 

--- a/src/rules/no_extra_boolean_cast.rs
+++ b/src/rules/no_extra_boolean_cast.rs
@@ -25,13 +25,13 @@ impl LintRule for NoExtraBooleanCast {
     "no-extra-boolean-cast"
   }
 
-  fn lint_module(
+  fn lint_program(
     &self,
     context: &mut Context,
-    module: &swc_ecmascript::ast::Module,
+    program: &swc_ecmascript::ast::Program,
   ) {
     let mut visitor = NoExtraBooleanCastVisitor::new(context);
-    visitor.visit_module(module, module);
+    visitor.visit_program(program, program);
   }
 }
 

--- a/src/rules/no_extra_non_null_assertion.rs
+++ b/src/rules/no_extra_non_null_assertion.rs
@@ -24,13 +24,13 @@ impl LintRule for NoExtraNonNullAssertion {
     "no-extra-non-null-assertion"
   }
 
-  fn lint_module(
+  fn lint_program(
     &self,
     context: &mut Context,
-    module: &swc_ecmascript::ast::Module,
+    program: &swc_ecmascript::ast::Program,
   ) {
     let mut visitor = NoExtraNonNullAssertionVisitor::new(context);
-    visitor.visit_module(module, module);
+    visitor.visit_program(program, program);
   }
 }
 

--- a/src/rules/no_extra_semi.rs
+++ b/src/rules/no_extra_semi.rs
@@ -24,13 +24,13 @@ impl LintRule for NoExtraSemi {
     "no-extra-semi"
   }
 
-  fn lint_module(
+  fn lint_program(
     &self,
     context: &mut Context,
-    module: &swc_ecmascript::ast::Module,
+    program: &swc_ecmascript::ast::Program,
   ) {
     let mut visitor = NoExtraSemiVisitor::new(context);
-    visitor.visit_module(module, module);
+    visitor.visit_program(program, program);
   }
 }
 

--- a/src/rules/no_fallthrough.rs
+++ b/src/rules/no_fallthrough.rs
@@ -21,13 +21,13 @@ impl LintRule for NoFallthrough {
     "no-fallthrough"
   }
 
-  fn lint_module(
+  fn lint_program(
     &self,
     context: &mut Context,
-    module: &swc_ecmascript::ast::Module,
+    program: &swc_ecmascript::ast::Program,
   ) {
     let mut visitor = NoFallthroughVisitor { context };
-    visitor.visit_module(module, module);
+    visitor.visit_program(program, program);
   }
 }
 

--- a/src/rules/no_func_assign.rs
+++ b/src/rules/no_func_assign.rs
@@ -22,13 +22,13 @@ impl LintRule for NoFuncAssign {
     "no-func-assign"
   }
 
-  fn lint_module(
+  fn lint_program(
     &self,
     context: &mut Context,
-    module: &swc_ecmascript::ast::Module,
+    program: &swc_ecmascript::ast::Program,
   ) {
     let mut visitor = NoFuncAssignVisitor::new(context);
-    visitor.visit_module(module, module);
+    visitor.visit_program(program, program);
   }
 }
 

--- a/src/rules/no_global_assign.rs
+++ b/src/rules/no_global_assign.rs
@@ -26,18 +26,18 @@ impl LintRule for NoGlobalAssign {
     "no-global-assign"
   }
 
-  fn lint_module(
+  fn lint_program(
     &self,
     context: &mut Context,
-    module: &swc_ecmascript::ast::Module,
+    program: &swc_ecmascript::ast::Program,
   ) {
     let mut collector = Collector {
       bindings: Default::default(),
     };
-    module.visit_with(module, &mut collector);
+    program.visit_with(program, &mut collector);
 
     let mut visitor = NoGlobalAssignVisitor::new(context, collector.bindings);
-    module.visit_with(module, &mut visitor);
+    program.visit_with(program, &mut visitor);
   }
 }
 

--- a/src/rules/no_import_assign.rs
+++ b/src/rules/no_import_assign.rs
@@ -28,17 +28,17 @@ impl LintRule for NoImportAssign {
     "no-import-assign"
   }
 
-  fn lint_module(
+  fn lint_program(
     &self,
     context: &mut Context,
-    module: &swc_ecmascript::ast::Module,
+    program: &swc_ecmascript::ast::Program,
   ) {
     let mut collector = Collector {
       imports: Default::default(),
       ns_imports: Default::default(),
       other_bindings: Default::default(),
     };
-    module.visit_with(module, &mut collector);
+    program.visit_with(program, &mut collector);
 
     let mut visitor = NoImportAssignVisitor::new(
       context,
@@ -46,7 +46,7 @@ impl LintRule for NoImportAssign {
       collector.ns_imports,
       collector.other_bindings,
     );
-    module.visit_with(module, &mut visitor);
+    program.visit_with(program, &mut visitor);
   }
 }
 

--- a/src/rules/no_inferrable_types.rs
+++ b/src/rules/no_inferrable_types.rs
@@ -23,13 +23,13 @@ impl LintRule for NoInferrableTypes {
     "no-inferrable-types"
   }
 
-  fn lint_module(
+  fn lint_program(
     &self,
     context: &mut Context,
-    module: &swc_ecmascript::ast::Module,
+    program: &swc_ecmascript::ast::Program,
   ) {
     let mut visitor = NoInferrableTypesVisitor::new(context);
-    visitor.visit_module(module, module);
+    visitor.visit_program(program, program);
   }
 }
 

--- a/src/rules/no_inner_declarations.rs
+++ b/src/rules/no_inner_declarations.rs
@@ -22,13 +22,13 @@ impl LintRule for NoInnerDeclarations {
     "no-inner-declarations"
   }
 
-  fn lint_module(&self, context: &mut Context, module: &ast::Module) {
+  fn lint_program(&self, context: &mut Context, program: &ast::Program) {
     let mut valid_visitor = ValidDeclsVisitor::new();
-    valid_visitor.visit_module(module, module);
+    valid_visitor.visit_program(program, program);
     let mut valid_decls = valid_visitor.valid_decls;
     valid_decls.dedup();
     let mut visitor = NoInnerDeclarationsVisitor::new(context, valid_decls);
-    visitor.visit_module(module, module);
+    visitor.visit_program(program, program);
   }
 }
 

--- a/src/rules/no_invalid_regexp.rs
+++ b/src/rules/no_invalid_regexp.rs
@@ -24,13 +24,13 @@ impl LintRule for NoInvalidRegexp {
     "no-invalid-regexp"
   }
 
-  fn lint_module(
+  fn lint_program(
     &self,
     context: &mut Context,
-    module: &swc_ecmascript::ast::Module,
+    program: &swc_ecmascript::ast::Program,
   ) {
     let mut visitor = NoInvalidRegexpVisitor::new(context);
-    visitor.visit_module(module, module);
+    visitor.visit_program(program, program);
   }
 }
 

--- a/src/rules/no_irregular_whitespace.rs
+++ b/src/rules/no_irregular_whitespace.rs
@@ -2,8 +2,8 @@ use super::{Context, LintRule};
 use regex::{Matches, Regex};
 
 use once_cell::sync::Lazy;
-use swc_common::{hygiene::SyntaxContext, BytePos, Span};
-use swc_ecmascript::ast::Module;
+use swc_common::{hygiene::SyntaxContext, BytePos, Span, Spanned};
+use swc_ecmascript::ast::Program;
 use swc_ecmascript::ast::Str;
 use swc_ecmascript::visit::Node;
 use swc_ecmascript::visit::Visit;
@@ -46,13 +46,14 @@ impl LintRule for NoIrregularWhitespace {
     "no-irregular-whitespace"
   }
 
-  fn lint_module(&self, context: &mut Context, module: &Module) {
+  fn lint_program(&self, context: &mut Context, program: &Program) {
     let mut visitor = NoIrregularWhitespaceVisitor::default();
-    visitor.visit_module(module, module);
+    visitor.visit_program(program, program);
 
     let excluded_ranges = visitor.ranges.iter();
 
-    let file_and_lines = context.source_map.span_to_lines(module.span).unwrap();
+    let file_and_lines =
+      context.source_map.span_to_lines(program.span()).unwrap();
     let file = file_and_lines.file;
 
     for line_index in 0..file.count_lines() {

--- a/src/rules/no_misused_new.rs
+++ b/src/rules/no_misused_new.rs
@@ -2,7 +2,7 @@
 use super::Context;
 use super::LintRule;
 use swc_ecmascript::ast::{
-  ClassDecl, ClassMember, Expr, Ident, Module, PropName, TsEntityName,
+  ClassDecl, ClassMember, Expr, Ident, Program, PropName, TsEntityName,
   TsInterfaceDecl, TsType, TsTypeAliasDecl, TsTypeAnn,
   TsTypeElement::{TsConstructSignatureDecl, TsMethodSignature},
 };
@@ -16,9 +16,9 @@ impl LintRule for NoMisusedNew {
     Box::new(NoMisusedNew)
   }
 
-  fn lint_module(&self, context: &mut Context, module: &Module) {
+  fn lint_program(&self, context: &mut Context, program: &Program) {
     let mut visitor = NoMisusedNewVisitor::new(context);
-    visitor.visit_module(module, module);
+    visitor.visit_program(program, program);
   }
 
   fn tags(&self) -> &[&'static str] {

--- a/src/rules/no_mixed_spaces_and_tabs.rs
+++ b/src/rules/no_mixed_spaces_and_tabs.rs
@@ -31,15 +31,16 @@ impl LintRule for NoMixedSpacesAndTabs {
     "no-mixed-spaces-and-tabs"
   }
 
-  fn lint_module(
+  fn lint_program(
     &self,
     context: &mut Context,
-    module: &swc_ecmascript::ast::Module,
+    program: &swc_ecmascript::ast::Program,
   ) {
     let mut visitor = NoMixedSpacesAndTabsVisitor::default();
-    visitor.visit_module(module, module);
+    visitor.visit_program(program, program);
 
-    let file_and_lines = context.source_map.span_to_lines(module.span).unwrap();
+    let file_and_lines =
+      context.source_map.span_to_lines(program.span()).unwrap();
     let file = file_and_lines.file;
 
     let mut excluded_ranges = visitor.ranges;

--- a/src/rules/no_namespace.rs
+++ b/src/rules/no_namespace.rs
@@ -20,13 +20,13 @@ impl LintRule for NoNamespace {
     "no-namespace"
   }
 
-  fn lint_module(
+  fn lint_program(
     &self,
     context: &mut Context,
-    module: &swc_ecmascript::ast::Module,
+    program: &swc_ecmascript::ast::Program,
   ) {
     let mut visitor = NoNamespaceVisitor::new(context);
-    visitor.visit_module(module, module);
+    visitor.visit_program(program, program);
   }
 }
 

--- a/src/rules/no_new_symbol.rs
+++ b/src/rules/no_new_symbol.rs
@@ -21,13 +21,13 @@ impl LintRule for NoNewSymbol {
     "no-new-symbol"
   }
 
-  fn lint_module(
+  fn lint_program(
     &self,
     context: &mut Context,
-    module: &swc_ecmascript::ast::Module,
+    program: &swc_ecmascript::ast::Program,
   ) {
     let mut visitor = NoNewSymbolVisitor::new(context);
-    visitor.visit_module(module, module);
+    visitor.visit_program(program, program);
   }
 }
 

--- a/src/rules/no_non_null_asserted_optional_chain.rs
+++ b/src/rules/no_non_null_asserted_optional_chain.rs
@@ -18,13 +18,13 @@ impl LintRule for NoNonNullAssertedOptionalChain {
     "no-non-null-asserted-optional-chain"
   }
 
-  fn lint_module(
+  fn lint_program(
     &self,
     context: &mut Context,
-    module: &swc_ecmascript::ast::Module,
+    program: &swc_ecmascript::ast::Program,
   ) {
     let mut visitor = NoNonNullAssertedOptionalChainVisitor::new(context);
-    visitor.visit_module(module, module);
+    visitor.visit_program(program, program);
   }
 }
 

--- a/src/rules/no_non_null_assertion.rs
+++ b/src/rules/no_non_null_assertion.rs
@@ -15,13 +15,13 @@ impl LintRule for NoNonNullAssertion {
     "no-non-null-assertion"
   }
 
-  fn lint_module(
+  fn lint_program(
     &self,
     context: &mut Context,
-    module: &swc_ecmascript::ast::Module,
+    program: &swc_ecmascript::ast::Program,
   ) {
     let mut visitor = NoNonNullAssertionVisitor::new(context);
-    visitor.visit_module(module, module);
+    visitor.visit_program(program, program);
   }
 }
 

--- a/src/rules/no_obj_calls.rs
+++ b/src/rules/no_obj_calls.rs
@@ -25,13 +25,13 @@ impl LintRule for NoObjCalls {
     "no-obj-calls"
   }
 
-  fn lint_module(
+  fn lint_program(
     &self,
     context: &mut Context,
-    module: &swc_ecmascript::ast::Module,
+    program: &swc_ecmascript::ast::Program,
   ) {
     let mut visitor = NoObjCallsVisitor::new(context);
-    visitor.visit_module(module, module);
+    visitor.visit_program(program, program);
   }
 }
 

--- a/src/rules/no_octal.rs
+++ b/src/rules/no_octal.rs
@@ -22,13 +22,13 @@ impl LintRule for NoOctal {
     "no-octal"
   }
 
-  fn lint_module(
+  fn lint_program(
     &self,
     context: &mut Context,
-    module: &swc_ecmascript::ast::Module,
+    program: &swc_ecmascript::ast::Program,
   ) {
     let mut visitor = NoOctalVisitor::new(context);
-    visitor.visit_module(module, module);
+    visitor.visit_program(program, program);
   }
 }
 

--- a/src/rules/no_prototype_builtins.rs
+++ b/src/rules/no_prototype_builtins.rs
@@ -27,13 +27,13 @@ impl LintRule for NoPrototypeBuiltins {
     "no-prototype-builtins"
   }
 
-  fn lint_module(
+  fn lint_program(
     &self,
     context: &mut Context,
-    module: &swc_ecmascript::ast::Module,
+    program: &swc_ecmascript::ast::Program,
   ) {
     let mut visitor = NoPrototypeBuiltinsVisitor::new(context);
-    visitor.visit_module(module, module);
+    visitor.visit_program(program, program);
   }
 }
 

--- a/src/rules/no_redeclare.rs
+++ b/src/rules/no_redeclare.rs
@@ -24,12 +24,12 @@ impl LintRule for NoRedeclare {
     "no-redeclare"
   }
 
-  fn lint_module(&self, context: &mut Context, module: &Module) {
+  fn lint_program(&self, context: &mut Context, program: &Program) {
     let mut visitor = NoRedeclareVisitor {
       context,
       bindings: Default::default(),
     };
-    module.visit_with(module, &mut visitor);
+    program.visit_with(program, &mut visitor);
   }
 }
 

--- a/src/rules/no_regex_spaces.rs
+++ b/src/rules/no_regex_spaces.rs
@@ -24,13 +24,13 @@ impl LintRule for NoRegexSpaces {
     "no-regex-spaces"
   }
 
-  fn lint_module(
+  fn lint_program(
     &self,
     context: &mut Context,
-    module: &swc_ecmascript::ast::Module,
+    program: &swc_ecmascript::ast::Program,
   ) {
     let mut visitor = NoRegexSpacesVisitor::new(context);
-    visitor.visit_module(module, module);
+    visitor.visit_program(program, program);
   }
 }
 

--- a/src/rules/no_self_assign.rs
+++ b/src/rules/no_self_assign.rs
@@ -35,13 +35,13 @@ impl LintRule for NoSelfAssign {
     "no-self-assign"
   }
 
-  fn lint_module(
+  fn lint_program(
     &self,
     context: &mut Context,
-    module: &swc_ecmascript::ast::Module,
+    program: &swc_ecmascript::ast::Program,
   ) {
     let mut visitor = NoSelfAssignVisitor::new(context);
-    visitor.visit_module(module, module);
+    visitor.visit_program(program, program);
   }
 }
 

--- a/src/rules/no_setter_return.rs
+++ b/src/rules/no_setter_return.rs
@@ -26,13 +26,13 @@ impl LintRule for NoSetterReturn {
     "no-setter-return"
   }
 
-  fn lint_module(
+  fn lint_program(
     &self,
     context: &mut Context,
-    module: &swc_ecmascript::ast::Module,
+    program: &swc_ecmascript::ast::Program,
   ) {
     let mut visitor = NoSetterReturnVisitor::new(context);
-    visitor.visit_module(module, module);
+    visitor.visit_program(program, program);
   }
 }
 

--- a/src/rules/no_shadow_restricted_names.rs
+++ b/src/rules/no_shadow_restricted_names.rs
@@ -2,8 +2,8 @@
 use super::Context;
 use super::LintRule;
 use swc_ecmascript::ast::{
-  ArrowExpr, AssignExpr, CatchClause, Expr, FnDecl, FnExpr, Ident, Module,
-  ObjectPatProp, Pat, PatOrExpr, VarDecl,
+  ArrowExpr, AssignExpr, CatchClause, Expr, FnDecl, FnExpr, Ident,
+  ObjectPatProp, Pat, PatOrExpr, Program, VarDecl,
 };
 use swc_ecmascript::{
   utils::ident::IdentLike,
@@ -17,9 +17,9 @@ impl LintRule for NoShadowRestrictedNames {
     Box::new(NoShadowRestrictedNames)
   }
 
-  fn lint_module(&self, context: &mut Context, module: &Module) {
+  fn lint_program(&self, context: &mut Context, program: &Program) {
     let mut visitor = NoShadowRestrictedNamesVisitor::new(context);
-    visitor.visit_module(module, module);
+    visitor.visit_program(program, program);
   }
 
   fn tags(&self) -> &[&'static str] {

--- a/src/rules/no_sparse_arrays.rs
+++ b/src/rules/no_sparse_arrays.rs
@@ -16,13 +16,13 @@ impl LintRule for NoSparseArrays {
     "no-sparse-arrays"
   }
 
-  fn lint_module(
+  fn lint_program(
     &self,
     context: &mut Context,
-    module: &swc_ecmascript::ast::Module,
+    program: &swc_ecmascript::ast::Program,
   ) {
     let mut visitor = NoSparseArraysVisitor::new(context);
-    visitor.visit_module(module, module);
+    visitor.visit_program(program, program);
   }
 }
 

--- a/src/rules/no_this_alias.rs
+++ b/src/rules/no_this_alias.rs
@@ -21,13 +21,13 @@ impl LintRule for NoThisAlias {
     "no-this-alias"
   }
 
-  fn lint_module(
+  fn lint_program(
     &self,
     context: &mut Context,
-    module: &swc_ecmascript::ast::Module,
+    program: &swc_ecmascript::ast::Program,
   ) {
     let mut visitor = NoThisAliasVisitor::new(context);
-    visitor.visit_module(module, module);
+    visitor.visit_program(program, program);
   }
 }
 

--- a/src/rules/no_this_before_super.rs
+++ b/src/rules/no_this_before_super.rs
@@ -21,13 +21,13 @@ impl LintRule for NoThisBeforeSuper {
     "no-this-before-super"
   }
 
-  fn lint_module(
+  fn lint_program(
     &self,
     context: &mut Context,
-    module: &swc_ecmascript::ast::Module,
+    program: &swc_ecmascript::ast::Program,
   ) {
     let mut visitor = NoThisBeforeSuperVisitor::new(context);
-    visitor.visit_module(module, module);
+    visitor.visit_program(program, program);
   }
 }
 

--- a/src/rules/no_throw_literal.rs
+++ b/src/rules/no_throw_literal.rs
@@ -17,13 +17,13 @@ impl LintRule for NoThrowLiteral {
     "no-throw-literal"
   }
 
-  fn lint_module(
+  fn lint_program(
     &self,
     context: &mut Context,
-    module: &swc_ecmascript::ast::Module,
+    program: &swc_ecmascript::ast::Program,
   ) {
     let mut visitor = NoThrowLiteralVisitor::new(context);
-    visitor.visit_module(module, module);
+    visitor.visit_program(program, program);
   }
 }
 

--- a/src/rules/no_undef.rs
+++ b/src/rules/no_undef.rs
@@ -29,15 +29,15 @@ impl LintRule for NoUndef {
     "no-undef"
   }
 
-  fn lint_module(&self, context: &mut Context, module: &Module) {
+  fn lint_program(&self, context: &mut Context, program: &Program) {
     let mut collector = BindingCollector {
       top_level_ctxt: context.top_level_ctxt,
       declared: Default::default(),
     };
-    module.visit_with(module, &mut collector);
+    program.visit_with(program, &mut collector);
 
     let mut visitor = NoUndefVisitor::new(context, collector.declared);
-    module.visit_with(module, &mut visitor);
+    program.visit_with(program, &mut visitor);
   }
 }
 

--- a/src/rules/no_unreachable.rs
+++ b/src/rules/no_unreachable.rs
@@ -22,13 +22,13 @@ impl LintRule for NoUnreachable {
     "no-unreachable"
   }
 
-  fn lint_module(
+  fn lint_program(
     &self,
     context: &mut Context,
-    module: &swc_ecmascript::ast::Module,
+    program: &swc_ecmascript::ast::Program,
   ) {
     let mut visitor = NoUnreachableVisitor::new(context);
-    visitor.visit_module(module, module);
+    visitor.visit_program(program, program);
   }
 }
 

--- a/src/rules/no_unsafe_finally.rs
+++ b/src/rules/no_unsafe_finally.rs
@@ -1,7 +1,7 @@
 // Copyright 2020 the Deno authors. All rights reserved. MIT license.
 use super::{Context, LintRule};
 use swc_common::Span;
-use swc_ecmascript::ast::Module;
+use swc_ecmascript::ast::Program;
 use swc_ecmascript::ast::Stmt::{Break, Continue, Return, Throw};
 use swc_ecmascript::ast::TryStmt;
 use swc_ecmascript::visit::{noop_visit_type, Node, VisitAll, VisitAllWith};
@@ -21,9 +21,9 @@ impl LintRule for NoUnsafeFinally {
     "no-unsafe-finally"
   }
 
-  fn lint_module(&self, context: &mut Context, module: &Module) {
+  fn lint_program(&self, context: &mut Context, program: &Program) {
     let mut visitor = NoUnsafeFinallyVisitor::new(context);
-    module.visit_all_with(module, &mut visitor);
+    program.visit_all_with(program, &mut visitor);
   }
 
   fn docs(&self) -> &'static str {

--- a/src/rules/no_unsafe_negation.rs
+++ b/src/rules/no_unsafe_negation.rs
@@ -24,13 +24,13 @@ impl LintRule for NoUnsafeNegation {
     "no-unsafe-negation"
   }
 
-  fn lint_module(
+  fn lint_program(
     &self,
     context: &mut Context,
-    module: &swc_ecmascript::ast::Module,
+    program: &swc_ecmascript::ast::Program,
   ) {
     let mut visitor = NoUnsafeNegationVisitor::new(context);
-    visitor.visit_module(module, module);
+    visitor.visit_program(program, program);
   }
 }
 

--- a/src/rules/no_unused_labels.rs
+++ b/src/rules/no_unused_labels.rs
@@ -24,13 +24,13 @@ impl LintRule for NoUnusedLabels {
     "no-unused-labels"
   }
 
-  fn lint_module(
+  fn lint_program(
     &self,
     context: &mut Context,
-    module: &swc_ecmascript::ast::Module,
+    program: &swc_ecmascript::ast::Program,
   ) {
     let mut visitor = NoUnusedLabelsVisitor::new(context);
-    visitor.visit_module(module, module);
+    visitor.visit_program(program, program);
   }
 }
 

--- a/src/rules/no_unused_vars.rs
+++ b/src/rules/no_unused_vars.rs
@@ -11,7 +11,7 @@ use swc_ecmascript::{
     ArrowExpr, CatchClause, ClassDecl, ClassMethod, ClassProp, Constructor,
     Decl, ExportDecl, ExportNamedSpecifier, Expr, FnDecl, FnExpr, Ident,
     ImportDefaultSpecifier, ImportNamedSpecifier, ImportStarAsSpecifier,
-    KeyValueProp, MemberExpr, MethodKind, Module, NamedExport, Param, Pat,
+    KeyValueProp, MemberExpr, MethodKind, NamedExport, Param, Pat, Program,
     Prop, SetterProp, TsEntityName, TsEnumDecl, TsExprWithTypeArgs,
     TsModuleDecl, TsNamespaceDecl, TsPropertySignature, TsTypeRef, VarDecl,
     VarDeclOrPat, VarDeclarator,
@@ -32,20 +32,20 @@ impl LintRule for NoUnusedVars {
     "no-unused-vars"
   }
 
-  fn lint_module(&self, context: &mut Context, module: &Module) {
+  fn lint_program(&self, context: &mut Context, program: &Program) {
     let mut collector = Collector {
       used_vars: Default::default(),
       cur_defining: Default::default(),
       used_types: Default::default(),
     };
-    module.visit_with(module, &mut collector);
+    program.visit_with(program, &mut collector);
 
     let mut visitor = NoUnusedVarVisitor::new(
       context,
       collector.used_vars,
       collector.used_types,
     );
-    module.visit_with(module, &mut visitor);
+    program.visit_with(program, &mut visitor);
   }
 }
 

--- a/src/rules/no_var.rs
+++ b/src/rules/no_var.rs
@@ -18,13 +18,13 @@ impl LintRule for NoVar {
     "no-var"
   }
 
-  fn lint_module(
+  fn lint_program(
     &self,
     context: &mut Context,
-    module: &swc_ecmascript::ast::Module,
+    program: &swc_ecmascript::ast::Program,
   ) {
     let mut visitor = NoVarVisitor::new(context);
-    visitor.visit_module(module, module);
+    visitor.visit_program(program, program);
   }
 }
 

--- a/src/rules/no_with.rs
+++ b/src/rules/no_with.rs
@@ -21,13 +21,13 @@ impl LintRule for NoWith {
     "no-with"
   }
 
-  fn lint_module(
+  fn lint_program(
     &self,
     context: &mut Context,
-    module: &swc_ecmascript::ast::Module,
+    program: &swc_ecmascript::ast::Program,
   ) {
     let mut visitor = NoWithVisitor::new(context);
-    visitor.visit_module(module, module);
+    visitor.visit_program(program, program);
   }
 }
 

--- a/src/rules/prefer_as_const.rs
+++ b/src/rules/prefer_as_const.rs
@@ -24,13 +24,13 @@ impl LintRule for PreferAsConst {
     "prefer-as-const"
   }
 
-  fn lint_module(
+  fn lint_program(
     &self,
     context: &mut Context,
-    module: &swc_ecmascript::ast::Module,
+    program: &swc_ecmascript::ast::Program,
   ) {
     let mut visitor = PreferAsConstVisitor::new(context);
-    visitor.visit_module(module, module);
+    visitor.visit_program(program, program);
   }
 }
 

--- a/src/rules/prefer_const.rs
+++ b/src/rules/prefer_const.rs
@@ -33,17 +33,17 @@ impl LintRule for PreferConst {
     "prefer-const"
   }
 
-  fn lint_module(
+  fn lint_program(
     &self,
     context: &mut Context,
-    module: &swc_ecmascript::ast::Module,
+    program: &swc_ecmascript::ast::Program,
   ) {
     let mut collector = VariableCollector::new();
-    collector.visit_module(module, module);
+    collector.visit_program(program, program);
 
     let mut visitor =
       PreferConstVisitor::new(context, mem::take(&mut collector.scopes));
-    visitor.visit_module(module, module);
+    visitor.visit_program(program, program);
   }
 }
 

--- a/src/rules/prefer_namespace_keyword.rs
+++ b/src/rules/prefer_namespace_keyword.rs
@@ -22,13 +22,13 @@ impl LintRule for PreferNamespaceKeyword {
     "prefer-namespace-keyword"
   }
 
-  fn lint_module(
+  fn lint_program(
     &self,
     context: &mut Context,
-    module: &swc_ecmascript::ast::Module,
+    program: &swc_ecmascript::ast::Program,
   ) {
     let mut visitor = PreferNamespaceKeywordVisitor::new(context);
-    visitor.visit_module(module, module);
+    visitor.visit_program(program, program);
   }
 }
 

--- a/src/rules/require_yield.rs
+++ b/src/rules/require_yield.rs
@@ -27,13 +27,13 @@ impl LintRule for RequireYield {
     "require-yield"
   }
 
-  fn lint_module(
+  fn lint_program(
     &self,
     context: &mut Context,
-    module: &swc_ecmascript::ast::Module,
+    program: &swc_ecmascript::ast::Program,
   ) {
     let mut visitor = RequireYieldVisitor::new(context);
-    visitor.visit_module(module, module);
+    visitor.visit_program(program, program);
   }
 }
 

--- a/src/rules/single_var_declarator.rs
+++ b/src/rules/single_var_declarator.rs
@@ -17,13 +17,13 @@ impl LintRule for SingleVarDeclarator {
     "single-var-declarator"
   }
 
-  fn lint_module(
+  fn lint_program(
     &self,
     context: &mut Context,
-    module: &swc_ecmascript::ast::Module,
+    program: &swc_ecmascript::ast::Program,
   ) {
     let mut visitor = SingleVarDeclaratorVisitor::new(context);
-    visitor.visit_module(module, module);
+    visitor.visit_program(program, program);
   }
 }
 

--- a/src/rules/triple_slash_reference.rs
+++ b/src/rules/triple_slash_reference.rs
@@ -32,10 +32,10 @@ impl LintRule for TripleSlashReference {
     "triple-slash-reference"
   }
 
-  fn lint_module(
+  fn lint_program(
     &self,
     context: &mut Context,
-    _module: &swc_ecmascript::ast::Module,
+    _program: &swc_ecmascript::ast::Program,
   ) {
     let mut violated_comment_spans = Vec::new();
 

--- a/src/rules/use_isnan.rs
+++ b/src/rules/use_isnan.rs
@@ -20,13 +20,13 @@ impl LintRule for UseIsNaN {
     "use-isnan"
   }
 
-  fn lint_module(
+  fn lint_program(
     &self,
     context: &mut Context,
-    module: &swc_ecmascript::ast::Module,
+    program: &swc_ecmascript::ast::Program,
   ) {
     let mut visitor = UseIsNaNVisitor::new(context);
-    visitor.visit_module(module, module);
+    visitor.visit_program(program, program);
   }
 }
 

--- a/src/rules/valid_typeof.rs
+++ b/src/rules/valid_typeof.rs
@@ -5,7 +5,7 @@ use swc_ecmascript::ast::BinaryOp::{EqEq, EqEqEq, NotEq, NotEqEq};
 use swc_ecmascript::ast::Expr::{Lit, Unary};
 use swc_ecmascript::ast::Lit::Str;
 use swc_ecmascript::ast::UnaryOp::TypeOf;
-use swc_ecmascript::ast::{BinExpr, Module};
+use swc_ecmascript::ast::{BinExpr, Program};
 use swc_ecmascript::visit::{noop_visit_type, Node, Visit};
 
 pub struct ValidTypeof;
@@ -26,9 +26,9 @@ impl LintRule for ValidTypeof {
     CODE
   }
 
-  fn lint_module(&self, context: &mut Context, module: &Module) {
+  fn lint_program(&self, context: &mut Context, program: &Program) {
     let mut visitor = ValidTypeofVisitor::new(context);
-    visitor.visit_module(module, module);
+    visitor.visit_program(program, program);
   }
 
   fn docs(&self) -> &'static str {

--- a/src/scopes.rs
+++ b/src/scopes.rs
@@ -5,7 +5,7 @@ use swc_ecmascript::ast::{
   ArrowExpr, BlockStmt, BlockStmtOrExpr, CatchClause, ClassDecl, ClassExpr,
   DoWhileStmt, Expr, FnDecl, ForInStmt, ForOfStmt, ForStmt, Function, Ident,
   ImportDefaultSpecifier, ImportNamedSpecifier, ImportStarAsSpecifier, Invalid,
-  Module, Param, Pat, SwitchStmt, VarDecl, VarDeclKind, WhileStmt, WithStmt,
+  Param, Pat, Program, SwitchStmt, VarDecl, VarDeclKind, WhileStmt, WithStmt,
 };
 use swc_ecmascript::utils::find_ids;
 use swc_ecmascript::utils::ident::IdentLike;
@@ -75,14 +75,14 @@ pub enum ScopeKind {
   Catch,
 }
 
-pub fn analyze(module: &Module) -> Scope {
+pub fn analyze(program: &Program) -> Scope {
   let mut scope = Scope {
     vars: Default::default(),
     symbols: Default::default(),
   };
   let mut path = vec![];
 
-  module.visit_with(
+  program.visit_with(
     &Invalid { span: DUMMY_SP },
     &mut Analyzer {
       scope: &mut scope,
@@ -299,6 +299,7 @@ impl Visit for Analyzer<'_> {
 mod tests {
   use super::{analyze, BindingKind, Scope, ScopeKind, Var};
   use crate::swc_util::{self, AstParser};
+  use swc_ecmascript::ast::Program;
   use swc_ecmascript::utils::Id;
 
   fn test_scope(source_code: &str) -> Scope {
@@ -308,7 +309,7 @@ mod tests {
       ast_parser.parse_module("file_name.ts", syntax, source_code);
     let module = parse_result.unwrap();
 
-    analyze(&module)
+    analyze(&Program::Module(module))
   }
 
   fn id(scope: &Scope, s: &str) -> Id {

--- a/src/swc_util.rs
+++ b/src/swc_util.rs
@@ -161,6 +161,47 @@ impl AstParser {
     }
   }
 
+  pub(crate) fn parse_script(
+    &self,
+    file_name: &str,
+    syntax: Syntax,
+    source_code: &str,
+  ) -> (
+    Result<swc_ecmascript::ast::Script, SwcDiagnosticBuffer>,
+    SingleThreadedComments,
+  ) {
+    let swc_source_file = self.source_map.new_source_file(
+      FileName::Custom(file_name.to_string()),
+      source_code.to_string(),
+    );
+
+    let buffered_err = self.buffered_error.clone();
+
+    let comments = SingleThreadedComments::default();
+    let lexer = Lexer::new(
+      syntax,
+      JscTarget::Es2019,
+      StringInput::from(&*swc_source_file),
+      Some(&comments),
+    );
+
+    let mut parser = Parser::new_from(lexer);
+
+    let parse_result = parser.parse_script().map_err(move |err| {
+      let mut diagnostic_builder = err.into_diagnostic(&self.handler);
+      diagnostic_builder.emit();
+      SwcDiagnosticBuffer::from_swc_error(buffered_err, self)
+    });
+
+    let parse_result = parse_result.map(|module| {
+      GLOBALS.set(&self.globals, || {
+        module.fold_with(&mut ts_resolver(self.top_level_mark))
+      })
+    });
+
+    (parse_result, comments)
+  }
+
   pub(crate) fn parse_module(
     &self,
     file_name: &str,

--- a/src/swc_util.rs
+++ b/src/swc_util.rs
@@ -193,9 +193,9 @@ impl AstParser {
       SwcDiagnosticBuffer::from_swc_error(buffered_err, self)
     });
 
-    let parse_result = parse_result.map(|module| {
+    let parse_result = parse_result.map(|script| {
       GLOBALS.set(&self.globals, || {
-        module.fold_with(&mut ts_resolver(self.top_level_mark))
+        script.fold_with(&mut ts_resolver(self.top_level_mark))
       })
     });
 

--- a/src/test_util.rs
+++ b/src/test_util.rs
@@ -1,6 +1,7 @@
 // Copyright 2020 the Deno authors. All rights reserved. MIT license.
 
 use crate::diagnostic::LintDiagnostic;
+use crate::linter::FileType;
 use crate::linter::LinterBuilder;
 use crate::rules::LintRule;
 use crate::swc_util;
@@ -147,7 +148,11 @@ fn lint(rule: Box<dyn LintRule>, source: &str) -> Vec<LintDiagnostic> {
     .build();
 
   linter
-    .lint("deno_lint_test.tsx".to_string(), source.to_string())
+    .lint(
+      "deno_lint_test.tsx".to_string(),
+      source.to_string(),
+      FileType::Module,
+    )
     .expect("Failed to lint")
 }
 


### PR DESCRIPTION
Change "LintRule" trait to have "lint_program" instead of "lint_module".

Towards #366