### PR TITLE
refactor(getter-return): switch to `assert_lint_err!` macro

### DIFF
--- a/src/swc_util.rs
+++ b/src/swc_util.rs
@@ -273,6 +273,12 @@ pub(crate) trait Key {
   fn get_key(&self) -> Option<String>;
 }
 
+impl Key for Ident {
+  fn get_key(&self) -> Option<String> {
+    Some(self.sym.to_string())
+  }
+}
+
 impl Key for PropOrSpread {
   fn get_key(&self) -> Option<String> {
     use PropOrSpread::*;
@@ -370,6 +376,12 @@ impl Key for MemberExpr {
     }
 
     (&*self.prop).get_key()
+  }
+}
+
+impl<K: Key> Key for Option<K> {
+  fn get_key(&self) -> Option<String> {
+    self.as_ref().and_then(|k| k.get_key())
   }
 }
 

--- a/src/test_util.rs
+++ b/src/test_util.rs
@@ -61,16 +61,16 @@ pub struct LintErrTester<T: LintRule + 'static> {
 pub struct LintErr {
   pub line: usize,
   pub col: usize,
-  pub message: &'static str,
-  pub hint: Option<&'static str>,
+  pub message: String,
+  pub hint: Option<String>,
 }
 
 #[derive(Default)]
 pub struct LintErrBuilder {
   line: Option<usize>,
   col: Option<usize>,
-  message: Option<&'static str>,
-  hint: Option<&'static str>,
+  message: Option<String>,
+  hint: Option<String>,
 }
 
 impl LintErrBuilder {
@@ -90,21 +90,21 @@ impl LintErrBuilder {
     self
   }
 
-  pub fn message(&mut self, message: &'static str) -> &mut Self {
-    self.message = Some(message);
+  pub fn message(&mut self, message: impl Into<String>) -> &mut Self {
+    self.message = Some(message.into());
     self
   }
 
-  pub fn hint(&mut self, hint: &'static str) -> &mut Self {
-    self.hint = Some(hint);
+  pub fn hint(&mut self, hint: impl Into<String>) -> &mut Self {
+    self.hint = Some(hint.into());
     self
   }
 
-  pub fn build(&self) -> LintErr {
+  pub fn build(self) -> LintErr {
     LintErr {
       line: self.line.unwrap_or(1),
       col: self.col.unwrap_or(0),
-      message: self.message.unwrap_or(""),
+      message: self.message.unwrap_or_else(|| "".to_string()),
       hint: self.hint,
     }
   }
@@ -132,7 +132,13 @@ impl<T: LintRule + 'static> LintErrTester<T> {
         hint,
       } = error;
       assert_diagnostic_2(
-        diagnostic, rule_code, *line, *col, self.src, message, hint,
+        diagnostic,
+        rule_code,
+        *line,
+        *col,
+        self.src,
+        message,
+        hint.as_deref(),
       );
     }
   }
@@ -183,7 +189,7 @@ fn assert_diagnostic_2(
   col: usize,
   source: &str,
   message: &str,
-  hint: &Option<&str>,
+  hint: Option<&str>,
 ) {
   assert_eq!(
     code, diagnostic.code,
@@ -207,7 +213,7 @@ fn assert_diagnostic_2(
   );
   assert_eq!(
     hint,
-    &diagnostic.hint.as_deref(),
+    diagnostic.hint.as_deref(),
     "Diagnostic hint is expected to be \"{:?}\", but got \"{:?}\"\n\nsource:\n{}\n",
     hint,
     diagnostic.hint.as_deref(),


### PR DESCRIPTION
This is a part of #431

Switches from the `assert_lint_err` functions to the `assert_lint_err!` macro in `getter-return`. Additionally, fixes some more things.