### PR TITLE
refactor: use assert_lint_err! macro

### DIFF
--- a/src/rules/no_delete_var.rs
+++ b/src/rules/no_delete_var.rs
@@ -10,6 +10,10 @@ use swc_ecmascript::visit::Visit;
 
 pub struct NoDeleteVar;
 
+const CODE: &str = "no-delete-var";
+const MESSAGE: &str = "Variables shouldn't be deleted";
+const HINT: &str = "Remove the deletion statement";
+
 impl LintRule for NoDeleteVar {
   fn new() -> Box<Self> {
     Box::new(NoDeleteVar)
@@ -20,7 +24,7 @@ impl LintRule for NoDeleteVar {
   }
 
   fn code(&self) -> &'static str {
-    "no-delete-var"
+    CODE
   }
 
   fn lint_program(
@@ -81,9 +85,9 @@ impl<'c> Visit for NoDeleteVarVisitor<'c> {
     if let Expr::Ident(_) = *unary_expr.arg {
       self.context.add_diagnostic_with_hint(
         unary_expr.span,
-        "no-delete-var",
-        "Variables shouldn't be deleted",
-        "Remove the deletion statement",
+        CODE,
+        MESSAGE,
+        HINT,
       );
     }
   }
@@ -92,13 +96,12 @@ impl<'c> Visit for NoDeleteVarVisitor<'c> {
 #[cfg(test)]
 mod tests {
   use super::*;
-  use crate::test_util::*;
 
   #[test]
-  fn no_delete_var_test() {
-    assert_lint_err::<NoDeleteVar>(
-      r#"var someVar = "someVar"; delete someVar;"#,
-      25,
-    );
+  fn no_delete_var_invalid() {
+    assert_lint_err! {
+      NoDeleteVar,
+      r#"var someVar = "someVar"; delete someVar;"#: [{ col: 25, message: MESSAGE, hint: HINT }],
+    }
   }
 }

--- a/src/rules/no_invalid_regexp.rs
+++ b/src/rules/no_invalid_regexp.rs
@@ -11,6 +11,9 @@ use swc_ecmascript::visit::Visit;
 
 pub struct NoInvalidRegexp;
 
+const CODE: &str = "no-invalid-regexp";
+const MESSAGE: &str = "Invalid RegExp literal";
+
 impl LintRule for NoInvalidRegexp {
   fn new() -> Box<Self> {
     Box::new(NoInvalidRegexp)
@@ -21,7 +24,7 @@ impl LintRule for NoInvalidRegexp {
   }
 
   fn code(&self) -> &'static str {
-    "no-invalid-regexp"
+    CODE
   }
 
   fn lint_program(
@@ -86,11 +89,7 @@ impl<'c> NoInvalidRegexpVisitor<'c> {
       || (self.check_for_invalid_pattern(pattern, true)
         && self.check_for_invalid_pattern(pattern, false))
     {
-      self.context.add_diagnostic(
-        span,
-        "no-invalid-regexp",
-        "Invalid RegExp literal",
-      );
+      self.context.add_diagnostic(span, CODE, MESSAGE);
     }
   }
 
@@ -142,7 +141,6 @@ impl<'c> Visit for NoInvalidRegexpVisitor<'c> {
 #[cfg(test)]
 mod tests {
   use super::*;
-  use crate::test_util::*;
 
   #[test]
   fn no_invalid_regexp_valid() {
@@ -187,22 +185,16 @@ let re = new RegExp('foo', x);"#,
 
   #[test]
   fn no_invalid_regexp_invalid() {
-    assert_lint_err_on_line::<NoInvalidRegexp>(r#"RegExp('[');"#, 1, 0);
-    assert_lint_err_on_line::<NoInvalidRegexp>(r#"RegExp('.', 'z');"#, 1, 0);
-    assert_lint_err_on_line::<NoInvalidRegexp>(r#"new RegExp(')');"#, 1, 0);
-    assert_lint_err_on_line::<NoInvalidRegexp>(r#"new RegExp('\\');"#, 1, 0);
-
-    assert_lint_err_on_line::<NoInvalidRegexp>(
-      r#"var foo = new RegExp('(', '');"#,
-      1,
-      10,
-    );
-    assert_lint_err_on_line::<NoInvalidRegexp>(r#"/(?<a>a)\k</"#, 1, 0);
-    assert_lint_err_on_line::<NoInvalidRegexp>(r#"/(?<!a){1}/"#, 1, 0);
-    assert_lint_err_on_line::<NoInvalidRegexp>(
-      r#"/(a)(a)(a)(a)(a)(a)(a)(a)(a)(a)\11/u"#,
-      1,
-      0,
-    );
+    assert_lint_err! {
+      NoInvalidRegexp,
+      r#"RegExp('[');"#: [{ col: 0, message: MESSAGE }],
+      r#"RegExp('.', 'z');"#: [{ col: 0, message: MESSAGE }],
+      r#"new RegExp(')');"#: [{ col: 0, message: MESSAGE }],
+      r#"new RegExp('\\');"#: [{ col: 0, message: MESSAGE }],
+      r#"var foo = new RegExp('(', '');"#: [{ col: 10, message: MESSAGE }],
+      r#"/(?<a>a)\k</"#: [{ col: 0, message: MESSAGE }],
+      r#"/(?<!a){1}/"#: [{ col: 0, message: MESSAGE }],
+      r#"/(a)(a)(a)(a)(a)(a)(a)(a)(a)(a)\11/u"#: [{ col: 0, message: MESSAGE }],
+    }
   }
 }

--- a/src/rules/no_unreachable.rs
+++ b/src/rules/no_unreachable.rs
@@ -9,6 +9,9 @@ use swc_ecmascript::visit::VisitWith;
 
 pub struct NoUnreachable;
 
+const CODE: &str = "no-unreachable";
+const MESSAGE: &str = "This statement is unreachable";
+
 impl LintRule for NoUnreachable {
   fn new() -> Box<Self> {
     Box::new(NoUnreachable)
@@ -19,7 +22,7 @@ impl LintRule for NoUnreachable {
   }
 
   fn code(&self) -> &'static str {
-    "no-unreachable"
+    CODE
   }
 
   fn lint_program(
@@ -65,11 +68,7 @@ impl<'c> Visit for NoUnreachableVisitor<'c> {
 
     if let Some(meta) = self.context.control_flow.meta(stmt.span().lo) {
       if meta.unreachable {
-        self.context.add_diagnostic(
-          stmt.span(),
-          "no-unreachable",
-          "This statement is unreachable",
-        )
+        self.context.add_diagnostic(stmt.span(), CODE, MESSAGE)
       }
     }
   }
@@ -78,7 +77,6 @@ impl<'c> Visit for NoUnreachableVisitor<'c> {
 #[cfg(test)]
 mod tests {
   use super::*;
-  use crate::test_util::*;
 
   #[test]
   fn no_unreachable_valid() {
@@ -331,109 +329,43 @@ console.log("unreachable???");
 
   #[test]
   fn no_unreachable_invalid() {
-    assert_lint_err::<NoUnreachable>(
-      "function foo() { return x; var x = 1; }",
-      27,
-    );
-
-    assert_lint_err::<NoUnreachable>(
-      "function foo() { return x; var x, y = 1; }",
-      27,
-    );
-
-    assert_lint_err::<NoUnreachable>(
-      "while (true) { continue; var x = 1; }",
-      25,
-    );
-    assert_lint_err::<NoUnreachable>("function foo() { return; x = 1; }", 25);
-
-    assert_lint_err::<NoUnreachable>(
-      "function foo() { throw error; x = 1; }",
-      30,
-    );
-
-    assert_lint_err::<NoUnreachable>("while (true) { break; x = 1; }", 22);
-    assert_lint_err::<NoUnreachable>("while (true) { continue; x = 1; }", 25);
-
-    assert_lint_err::<NoUnreachable>(
-      "function foo() { switch (foo) { case 1: return; x = 1; } }",
-      48,
-    );
-
-    assert_lint_err::<NoUnreachable>(
-      "function foo() { switch (foo) { case 1: throw e; x = 1; } }",
-      49,
-    );
-    assert_lint_err::<NoUnreachable>(
-      "while (true) { switch (foo) { case 1: break; x = 1; } }",
-      45,
-    );
-
-    assert_lint_err::<NoUnreachable>(
-      "while (true) { switch (foo) { case 1: continue; x = 1; } }",
-      48,
-    );
-
-    assert_lint_err::<NoUnreachable>(
-      "var x = 1; throw 'uh oh'; var y = 2;",
-      26,
-    );
-    assert_lint_err::<NoUnreachable>("function foo() { var x = 1; if (x) { return; } else { throw e; } x = 2; }", 65);
-
-    assert_lint_err::<NoUnreachable>(
-      "function foo() { var x = 1; if (x) return; else throw -1; x = 2; }",
-      58,
-    );
-
-    assert_lint_err::<NoUnreachable>(
-      "function foo() { var x = 1; try { return; } finally {} x = 2; }",
-      55,
-    );
-    assert_lint_err::<NoUnreachable>(
-      "function foo() { var x = 1; try { } finally { return; } x = 2; }",
-      56,
-    );
-
-    assert_lint_err::<NoUnreachable>(
-      "function foo() { var x = 1; do { return; } while (x); x = 2; }",
-      54,
-    );
-
-    assert_lint_err::<NoUnreachable>("function foo() { var x = 1; while (x) { if (x) break; else continue; x = 2; } }", 69);
-    assert_lint_err::<NoUnreachable>(
-      "function foo() { var x = 1; for (;;) { if (x) continue; } x = 2; }",
-      58,
-    );
-
-    assert_lint_err::<NoUnreachable>(
-      "function foo() { var x = 1; while (true) { } x = 2; }",
-      45,
-    );
-
-    assert_lint_err_on_line::<NoUnreachable>(
-      "const arrow_direction = arrow => {
+    assert_lint_err! {
+        NoUnreachable,
+        "function foo() { return x; var x = 1; }": [{ col: 27, message: MESSAGE }],
+        "function foo() { return x; var x, y = 1; }": [{ col: 27, message: MESSAGE }],
+        "while (true) { continue; var x = 1; }": [{ col: 25, message: MESSAGE }],
+        "function foo() { return; x = 1; }": [{ col: 25, message: MESSAGE }],
+        "function foo() { throw error; x = 1; }": [{ col: 30, message: MESSAGE }],
+        "while (true) { break; x = 1; }": [{ col: 22, message: MESSAGE }],
+        "while (true) { continue; x = 1; }": [{ col: 25, message: MESSAGE }],
+        "function foo() { switch (foo) { case 1: return; x = 1; } }": [{ col: 48, message: MESSAGE }],
+        "function foo() { switch (foo) { case 1: throw e; x = 1; } }": [{ col: 49, message: MESSAGE }],
+        "while (true) { switch (foo) { case 1: break; x = 1; } }": [{ col: 45, message: MESSAGE }],
+        "while (true) { switch (foo) { case 1: continue; x = 1; } }": [{ col: 48, message: MESSAGE }],
+        "var x = 1; throw 'uh oh'; var y = 2;": [{ col: 26, message: MESSAGE }],
+        "function foo() { var x = 1; if (x) { return; } else { throw e; } x = 2; }": [{ col: 65, message: MESSAGE }],
+        "function foo() { var x = 1; if (x) return; else throw -1; x = 2; }": [{ col: 58, message: MESSAGE }],
+        "function foo() { var x = 1; try { return; } finally {} x = 2; }": [{ col: 55, message: MESSAGE }],
+        "function foo() { var x = 1; try { } finally { return; } x = 2; }": [{ col: 56, message: MESSAGE }],
+        "function foo() { var x = 1; do { return; } while (x); x = 2; }": [{ col: 54, message: MESSAGE }],
+        "function foo() { var x = 1; while (x) { if (x) break; else continue; x = 2; } }": [{ col: 69, message: MESSAGE }],
+        "function foo() { var x = 1; for (;;) { if (x) continue; } x = 2; }": [{ col: 58, message: MESSAGE }],
+        "function foo() { var x = 1; while (true) { } x = 2; }": [{ col: 45, message: MESSAGE }],
+        "const arrow_direction = arrow => {
         switch (arrow) {
           default:
             throw new Error();
         }
         g()
-      }",
-      6,
-      8,
-    );
-    assert_lint_err_on_line_n::<NoUnreachable>(
-      "function foo() {
+      }": [{ line: 6, col: 8, message: MESSAGE }],
+        "function foo() {
       return;
       a();
       b()
       // comment
       c();
-  }",
-      vec![(3, 6), (4, 6), (6, 6)],
-    );
-
-    assert_lint_err_on_line_n::<NoUnreachable>(
-      "function foo() {
+  }": [{ line: 3, col: 6, message: MESSAGE }, {line: 4, col: 6, message: MESSAGE }, { line: 6, col: 6, message: MESSAGE }],
+        "function foo() {
       if (a) {
           return
           b();
@@ -442,11 +374,8 @@ console.log("unreachable???");
           throw err
           d();
       }
-  }",
-      vec![(4, 10), (5, 10), (8, 10)],
-    );
-    assert_lint_err_on_line_n::<NoUnreachable>(
-      "function foo() {
+  }": [{ line: 4, col: 10, message: MESSAGE }, { line: 5, col: 10, message: MESSAGE }, { line: 8, col: 10, message: MESSAGE }],
+        "function foo() {
       if (a) {
           return
           b();
@@ -456,48 +385,31 @@ console.log("unreachable???");
           d();
       }
       e();
-  }",
-      vec![(4, 10), (5, 10), (8, 10), (10, 6)],
-    );
-
-    assert_lint_err_on_line::<NoUnreachable>(
-      "function* foo() {
+  }": [{ line: 4, col: 10, message: MESSAGE }, { line: 5, col: 10, message: MESSAGE }, { line: 8, col: 10, message: MESSAGE}, { line: 10, col: 6, message: MESSAGE }],
+        "function* foo() {
       try {
           return;
       } catch (err) {
           return err;
       }
-  }",
-      5,
-      10,
-    );
-
-    assert_lint_err_on_line::<NoUnreachable>(
-      "function foo() {
+  }": [{ line: 5, col: 10, message: MESSAGE }],
+        "function foo() {
       try {
           return;
       } catch (err) {
           return err;
       }
-  }",
-      5,
-      10,
-    );
-    assert_lint_err_on_line_n::<NoUnreachable>(
-      "function foo() {
+  }": [{ line: 5, col: 10, message: MESSAGE }],
+        "function foo() {
       try {
           return;
           let a = 1;
       } catch (err) {
           return err;
       }
-  }",
-      vec![(4, 10), (6, 10)],
-    );
-
-    // https://github.com/denoland/deno_lint/issues/348
-    assert_lint_err_on_line::<NoUnreachable>(
-      r#"
+  }": [{ line: 4, col: 10, message: MESSAGE }, { line: 6, col: 10, message: MESSAGE }],
+      // https://github.com/denoland/deno_lint/issues/348
+        r#"
 const obj = {
   get root() {
     let primary = this;
@@ -511,9 +423,7 @@ const obj = {
     return 1;
   }
 };
-      "#,
-      12,
-      4,
-    );
+      "#: [{ line: 12, col: 4, message: MESSAGE }],
+    }
   }
 }


### PR DESCRIPTION
Rewrite tests to use assert_lint_err! macro.

Affects the following rules:
- no-delete-var
- no-invalid-regexp
- no-unreachable