### PR TITLE
refactor: assert_lint_err! macro

### DIFF
--- a/src/rules/no_obj_calls.rs
+++ b/src/rules/no_obj_calls.rs
@@ -12,6 +12,12 @@ use swc_ecmascript::visit::Visit;
 
 pub struct NoObjCalls;
 
+const CODE: &str = "no-obj-calls";
+
+fn get_message(callee_name: &str) -> String {
+  format!("`{}` call as function is not allowed", callee_name)
+}
+
 impl LintRule for NoObjCalls {
   fn new() -> Box<Self> {
     Box::new(NoObjCalls)
@@ -22,7 +28,7 @@ impl LintRule for NoObjCalls {
   }
 
   fn code(&self) -> &'static str {
-    "no-obj-calls"
+    CODE
   }
 
   fn lint_program(
@@ -51,7 +57,7 @@ impl<'c> NoObjCallsVisitor<'c> {
         self.context.add_diagnostic(
           span,
           "no-obj-calls",
-          format!("`{}` call as function is not allowed", callee_name),
+          get_message(callee_name),
         );
       }
       _ => {}
@@ -80,7 +86,6 @@ impl<'c> Visit for NoObjCallsVisitor<'c> {
 #[cfg(test)]
 mod tests {
   use super::*;
-  use crate::test_util::*;
 
   #[test]
   fn no_obj_calls_valid() {
@@ -95,13 +100,16 @@ mod tests {
 
   #[test]
   fn no_obj_calls_invalid() {
-    assert_lint_err::<NoObjCalls>(r#"Math();"#, 0);
-    assert_lint_err::<NoObjCalls>(r#"new Math();"#, 0);
-    assert_lint_err::<NoObjCalls>(r#"JSON();"#, 0);
-    assert_lint_err::<NoObjCalls>(r#"new JSON();"#, 0);
-    assert_lint_err::<NoObjCalls>(r#"Reflect();"#, 0);
-    assert_lint_err::<NoObjCalls>(r#"new Reflect();"#, 0);
-    assert_lint_err::<NoObjCalls>(r#"Atomics();"#, 0);
-    assert_lint_err::<NoObjCalls>(r#"new Atomics();"#, 0);
+    assert_lint_err! {
+      NoObjCalls,
+      "Math();": [{col: 0, message: get_message("Math")}],
+      "new Math();": [{col: 0, message: get_message("Math")}],
+      "JSON();": [{col: 0, message: get_message("JSON")}],
+      "new JSON();": [{col: 0, message: get_message("JSON")}],
+      "Reflect();": [{col: 0, message: get_message("Reflect")}],
+      "new Reflect();": [{col: 0, message: get_message("Reflect")}],
+      "Atomics();": [{col: 0, message: get_message("Atomics")}],
+      "new Atomics();": [{col: 0, message: get_message("Atomics")}],
+    }
   }
 }

--- a/src/rules/no_octal.rs
+++ b/src/rules/no_octal.rs
@@ -9,6 +9,9 @@ use swc_ecmascript::visit::Visit;
 
 pub struct NoOctal;
 
+const CODE: &str = "no-octal";
+const MESSAGE: &str = "`Octal number` is not allowed";
+
 impl LintRule for NoOctal {
   fn new() -> Box<Self> {
     Box::new(NoOctal)
@@ -19,7 +22,7 @@ impl LintRule for NoOctal {
   }
 
   fn code(&self) -> &'static str {
-    "no-octal"
+    CODE
   }
 
   fn lint_program(
@@ -53,11 +56,7 @@ impl<'c> Visit for NoOctalVisitor<'c> {
       .expect("error in loading snippet");
 
     if OCTAL.is_match(&raw_number) {
-      self.context.add_diagnostic(
-        literal_num.span,
-        "no-octal",
-        "`Octal number` is not allowed",
-      );
+      self.context.add_diagnostic(literal_num.span, CODE, MESSAGE);
     }
   }
 }
@@ -65,7 +64,6 @@ impl<'c> Visit for NoOctalVisitor<'c> {
 #[cfg(test)]
 mod tests {
   use super::*;
-  use crate::test_util::*;
 
   #[test]
   fn no_octal_valid() {
@@ -80,7 +78,10 @@ mod tests {
 
   #[test]
   fn no_octal_invalid() {
-    assert_lint_err::<NoOctal>("07", 0);
-    assert_lint_err::<NoOctal>("let x = 7 + 07", 12);
+    assert_lint_err! {
+      NoOctal,
+      "07": [{col: 0, message: MESSAGE}],
+      "let x = 7 + 07": [{col: 12, message: MESSAGE}],
+    }
   }
 }

--- a/src/rules/no_redeclare.rs
+++ b/src/rules/no_redeclare.rs
@@ -11,6 +11,9 @@ use std::collections::HashSet;
 
 pub struct NoRedeclare;
 
+const CODE: &str = "no-redeclare";
+const MESSAGE: &str = "Redeclaration is not allowed";
+
 impl LintRule for NoRedeclare {
   fn new() -> Box<Self> {
     Box::new(NoRedeclare)
@@ -21,7 +24,7 @@ impl LintRule for NoRedeclare {
   }
 
   fn code(&self) -> &'static str {
-    "no-redeclare"
+    CODE
   }
 
   fn lint_program(&self, context: &mut Context, program: &Program) {
@@ -44,11 +47,7 @@ impl<'c> NoRedeclareVisitor<'c> {
     let id = i.to_id();
 
     if !self.bindings.insert(id) {
-      self.context.add_diagnostic(
-        i.span,
-        "no-redeclare",
-        "Redeclaration is not allowed",
-      );
+      self.context.add_diagnostic(i.span, CODE, MESSAGE);
     }
   }
 }
@@ -94,7 +93,6 @@ impl<'c> Visit for NoRedeclareVisitor<'c> {
 #[cfg(test)]
 mod tests {
   use super::*;
-  use crate::test_util::*;
 
   #[test]
   fn no_redeclare_valid() {
@@ -114,86 +112,35 @@ mod tests {
 
   #[test]
   fn no_redeclare_invalid() {
-    assert_lint_err::<NoRedeclare>("var a = 3; var a = 10;", 15);
-    assert_lint_err_on_line::<NoRedeclare>(
-      "switch(foo) { case a: var b = 3;\ncase b: var b = 4}",
-      2,
-      12,
-    );
-    assert_lint_err::<NoRedeclare>("var a = 3; var a = 10;", 15);
-    assert_lint_err::<NoRedeclare>("var a = {}; var a = [];", 16);
-
-    assert_lint_err::<NoRedeclare>("var a; function a() {}", 16);
-
-    assert_lint_err::<NoRedeclare>("function a() {} function a() {}", 25);
-    assert_lint_err::<NoRedeclare>(
-      "var a = function() { }; var a = function() { }",
-      28,
-    );
-
-    assert_lint_err::<NoRedeclare>(
-      "var a = function() { }; var a = new Date();",
-      28,
-    );
-
-    assert_lint_err_n::<NoRedeclare>(
-      "var a = 3; var a = 10; var a = 15;",
-      vec![15, 27],
-    );
-    assert_lint_err::<NoRedeclare>("var a; var a;", 11);
-
-    assert_lint_err::<NoRedeclare>("export var a; var a;", 18);
-    assert_lint_err_on_line_n::<NoRedeclare>(
-      "var a; var {a = 0, b: Object = 0} = {};",
-      vec![(1, 12)],
-    );
-    assert_lint_err_on_line_n::<NoRedeclare>(
-      "var a; var {a = 0, b: Object = 0} = {};",
-      vec![(1, 12)],
-    );
-
-    assert_lint_err_on_line_n::<NoRedeclare>(
-      "var a; var {a = 0, b: Object = 0} = {};",
-      vec![(1, 12)],
-    );
-    assert_lint_err_on_line_n::<NoRedeclare>(
-      "var a; var {a = 0, b: globalThis = 0} = {};",
-      vec![(1, 12)],
-    );
-    assert_lint_err::<NoRedeclare>("function f() { var a; var a; }", 26);
-
-    assert_lint_err::<NoRedeclare>("function f(a) { var a; }", 20);
-
-    assert_lint_err::<NoRedeclare>(
-      "function f() { var a; if (test) { var a; } }",
-      38,
-    );
-    assert_lint_err::<NoRedeclare>("for (var a, a;;);", 12);
-
-    assert_lint_err::<NoRedeclare>("let a; let a;", 11);
-
-    assert_lint_err::<NoRedeclare>("let a; const a = 0;", 13);
-    assert_lint_err::<NoRedeclare>("let a; const a = 0;", 13);
-
-    assert_lint_err::<NoRedeclare>("const a = 0; const a = 0;", 19);
-
-    assert_lint_err::<NoRedeclare>("if (test) { let a; let a; }", 23);
-    assert_lint_err::<NoRedeclare>(
-      "switch (test) { case 0: let a; let a; }",
-      35,
-    );
-
-    assert_lint_err::<NoRedeclare>("for (let a, a;;);", 12);
-
-    assert_lint_err::<NoRedeclare>("for (let [a, a] in xs);", 13);
-    assert_lint_err::<NoRedeclare>("for (let [a, a] in xs);", 13);
-
-    assert_lint_err::<NoRedeclare>("function f() { let a; let a; }", 26);
-
-    assert_lint_err::<NoRedeclare>("function f(a) { let a; }", 20);
-    assert_lint_err::<NoRedeclare>(
-      "function f() { if (test) { let a; let a; } }",
-      38,
-    );
+    assert_lint_err! {
+      NoRedeclare,
+      "var a = 3; var a = 10;": [{col: 15, message: MESSAGE}],
+      "switch(foo) { case a: var b = 3;\ncase b: var b = 4}": [{col: 12, line: 2, message: MESSAGE}],
+      "var a = 3; var a = 10;": [{col: 15, message: MESSAGE}],
+      "var a = {}; var a = [];": [{col: 16, message: MESSAGE}],
+      "var a; function a() {}": [{col: 16, message: MESSAGE}],
+      "function a() {} function a() {}": [{col: 25, message: MESSAGE}],
+      "var a = function() { }; var a = function() { }": [{col: 28, message: MESSAGE}],
+      "var a = function() { }; var a = new Date();": [{col: 28, message: MESSAGE}],
+      "var a; var a;": [{col: 11, message: MESSAGE}],
+      "export var a; var a;": [{col: 18, message: MESSAGE}],
+      "function f() { var a; var a; }": [{col: 26, message: MESSAGE}],
+      "function f(a) { var a; }": [{col: 20, message: MESSAGE}],
+      "function f() { var a; if (test) { var a; } }": [{col: 38, message: MESSAGE}],
+      "for (var a, a;;);": [{col: 12, message: MESSAGE}],
+      "let a; let a;": [{col: 11, message: MESSAGE}],
+      "let a; const a = 0;": [{col: 13, message: MESSAGE}],
+      "const a = 0; const a = 0;": [{col: 19, message: MESSAGE}],
+      "if (test) { let a; let a; }": [{col: 23, message: MESSAGE}],
+      "switch (test) { case 0: let a; let a; }": [{col: 35, message: MESSAGE}],
+      "for (let a, a;;);": [{col: 12, message: MESSAGE}],
+      "for (let [a, a] in xs);": [{col: 13, message: MESSAGE}],
+      "function f() { let a; let a; }": [{col: 26, message: MESSAGE}],
+      "function f(a) { let a; }": [{col: 20, message: MESSAGE}],
+      "function f() { if (test) { let a; let a; } }": [{col: 38, message: MESSAGE}],
+      "var a = 3; var a = 10; var a = 15;": [{col: 15, message: MESSAGE}, {col: 27, message: MESSAGE}],
+      "var a; var {a = 0, b: Object = 0} = {};": [{line: 1, col: 12, message: MESSAGE}],
+      "var a; var {a = 0, b: globalThis = 0} = {};": [{line: 1, col: 12, message: MESSAGE}],
+    }
   }
 }


### PR DESCRIPTION
Part of #431 

Switches from the `assert_lint_err` functions to the `assert_lint_err!` macro:

- `no-obj-calls`
- `no-octal`
- `no-prototype-builtins`
- `no-redeclare`

Hopefully you don't mind me going ahead and completing a few without commenting on the issue. :-)