### PR TITLE
fix(no-empty): fix contains_comments logic

### DIFF
--- a/src/rules/no_empty.rs
+++ b/src/rules/no_empty.rs
@@ -8,6 +8,8 @@ use swc_ecmascript::visit::{noop_visit_type, Node, Visit, VisitWith};
 
 pub struct NoEmpty;
 
+const CODE: &str = "no-empty";
+
 impl LintRule for NoEmpty {
   fn new() -> Box<Self> {
     Box::new(NoEmpty)
@@ -18,7 +20,7 @@ impl LintRule for NoEmpty {
   }
 
   fn code(&self) -> &'static str {
-    "no-empty"
+    CODE
   }
 
   fn lint_program(&self, context: &mut Context, program: &Program) {
@@ -125,7 +127,7 @@ impl<'c> Visit for NoEmptyVisitor<'c> {
       if !block_stmt.contains_comments(&self.context) {
         self.context.add_diagnostic_with_hint(
           block_stmt.span,
-          "no-empty",
+          CODE,
           "Empty block statement",
           "Add code or comment to the empty block",
         );
@@ -139,7 +141,7 @@ impl<'c> Visit for NoEmptyVisitor<'c> {
     if switch.cases.is_empty() {
       self.context.add_diagnostic_with_hint(
         switch.span,
-        "no-empty",
+        CODE,
         "Empty switch statement",
         "Add case statement(s) to the empty switch, or remove",
       );

--- a/src/rules/no_empty.rs
+++ b/src/rules/no_empty.rs
@@ -206,6 +206,14 @@ if (foo) {
           return 1;
       }
       "#,
+      // https://github.com/denoland/deno_lint/issues/469
+      "try { foo(); } catch { /* pass */ }",
+      r#"
+try {
+  foo();
+} catch { // pass
+}
+      "#,
     };
   }
 

--- a/src/rules/no_empty.rs
+++ b/src/rules/no_empty.rs
@@ -1,5 +1,8 @@
 // Copyright 2020 the Deno authors. All rights reserved. MIT license.
 use super::{Context, LintRule};
+use std::collections::HashMap;
+use swc_common::comments::Comment;
+use swc_common::BytePos;
 use swc_ecmascript::ast::{
   ArrowExpr, BlockStmt, BlockStmtOrExpr, Constructor, Function, Program,
   SwitchStmt,
@@ -156,16 +159,14 @@ trait ContainsComments {
 
 impl ContainsComments for BlockStmt {
   fn contains_comments(&self, context: &Context) -> bool {
-    context
-      .leading_comments
-      .values()
-      .flatten()
-      .any(|comment| self.span.contains(comment.span))
-      || context
-        .trailing_comments
+    let contains = |comments: &HashMap<BytePos, Vec<Comment>>| {
+      comments
         .values()
         .flatten()
         .any(|comment| self.span.contains(comment.span))
+    };
+
+    contains(&context.leading_comments) || contains(&context.trailing_comments)
   }
 }
 

--- a/src/rules/no_empty.rs
+++ b/src/rules/no_empty.rs
@@ -161,6 +161,11 @@ impl ContainsComments for BlockStmt {
       .values()
       .flatten()
       .any(|comment| self.span.contains(comment.span))
+      || context
+        .trailing_comments
+        .values()
+        .flatten()
+        .any(|comment| self.span.contains(comment.span))
   }
 }
 

--- a/src/rules/no_empty.rs
+++ b/src/rules/no_empty.rs
@@ -167,7 +167,6 @@ impl ContainsComments for BlockStmt {
 #[cfg(test)]
 mod tests {
   use super::*;
-  use crate::test_util::*;
 
   #[test]
   fn no_empty_valid() {
@@ -222,34 +221,146 @@ try {
 
   #[test]
   fn no_empty_invalid() {
-    assert_lint_err::<NoEmpty>("if (foo) { }", 9);
-    assert_lint_err_on_line::<NoEmpty>(
+    assert_lint_err! {
+      NoEmpty,
+      "if (foo) { }": [
+        {
+          col: 9,
+          message: "Empty block statement",
+          hint: "Add code or comment to the empty block",
+        }
+      ],
       r#"
 // This is an empty block
 if (foo) { }
-      "#,
-      3,
-      9,
-    );
-    assert_lint_err::<NoEmpty>("while (foo) { }", 12);
-    assert_lint_err::<NoEmpty>("do { } while (foo);", 3);
-    assert_lint_err::<NoEmpty>("for(;;) { }", 8);
-    assert_lint_err::<NoEmpty>("for(var foo in bar) { }", 20);
-    assert_lint_err::<NoEmpty>("for(var foo of bar) { }", 20);
-    assert_lint_err::<NoEmpty>("switch (foo) { }", 0);
-    assert_lint_err_n::<NoEmpty>("try { } catch (err) { }", vec![4, 20]);
-    assert_lint_err_n::<NoEmpty>(
-      "try { } catch (err) { } finally { }",
-      vec![4, 20, 32],
-    );
-    assert_lint_err::<NoEmpty>("if (foo) { if (bar) { } }", 20);
-    assert_lint_err::<NoEmpty>("if (foo) { while (bar) { } }", 23);
-    assert_lint_err::<NoEmpty>("if (foo) { do { } while (bar); }", 14);
-    assert_lint_err::<NoEmpty>("if (foo) { for(;;) { } }", 19);
-    assert_lint_err::<NoEmpty>("if (foo) { for(var bar in foo) { } }", 31);
-    assert_lint_err::<NoEmpty>("if (foo) { for(var bar of foo) { } }", 31);
-    assert_lint_err::<NoEmpty>("if (foo) { switch (foo) { } }", 11);
-    assert_lint_err_on_line::<NoEmpty>(
+      "#: [
+        {
+          line: 3,
+          col: 9,
+          message: "Empty block statement",
+          hint: "Add code or comment to the empty block",
+        }
+      ],
+      "while (foo) { }": [
+        {
+          col: 12,
+          message: "Empty block statement",
+          hint: "Add code or comment to the empty block",
+        }
+      ],
+      "do { } while (foo);": [
+        {
+          col: 3,
+          message: "Empty block statement",
+          hint: "Add code or comment to the empty block",
+        }
+      ],
+      "for(;;) { }": [
+        {
+          col: 8,
+          message: "Empty block statement",
+          hint: "Add code or comment to the empty block",
+        }
+      ],
+      "for(var foo in bar) { }": [
+        {
+          col: 20,
+          message: "Empty block statement",
+          hint: "Add code or comment to the empty block",
+        }
+      ],
+      "for(var foo of bar) { }": [
+        {
+          col: 20,
+          message: "Empty block statement",
+          hint: "Add code or comment to the empty block",
+        }
+      ],
+      "switch (foo) { }": [
+        {
+          col: 0,
+          message: "Empty switch statement",
+          hint: "Add case statement(s) to the empty switch, or remove",
+        }
+      ],
+      "try { } catch (err) { }": [
+        {
+          col: 4,
+          message: "Empty block statement",
+          hint: "Add code or comment to the empty block",
+        },
+        {
+          col: 20,
+          message: "Empty block statement",
+          hint: "Add code or comment to the empty block",
+        }
+      ],
+      "try { } catch (err) { } finally { }": [
+        {
+          col: 4,
+          message: "Empty block statement",
+          hint: "Add code or comment to the empty block",
+        },
+        {
+          col: 20,
+          message: "Empty block statement",
+          hint: "Add code or comment to the empty block",
+        },
+        {
+          col: 32,
+          message: "Empty block statement",
+          hint: "Add code or comment to the empty block",
+        }
+      ],
+      "if (foo) { if (bar) { } }": [
+        {
+          col: 20,
+          message: "Empty block statement",
+          hint: "Add code or comment to the empty block",
+        }
+      ],
+      "if (foo) { while (bar) { } }": [
+        {
+          col: 23,
+          message: "Empty block statement",
+          hint: "Add code or comment to the empty block",
+        }
+      ],
+      "if (foo) { do { } while (bar); }": [
+        {
+          col: 14,
+          message: "Empty block statement",
+          hint: "Add code or comment to the empty block",
+        }
+      ],
+      "if (foo) { for(;;) { } }": [
+        {
+          col: 19,
+          message: "Empty block statement",
+          hint: "Add code or comment to the empty block",
+        }
+      ],
+      "if (foo) { for(var bar in foo) { } }": [
+        {
+          col: 31,
+          message: "Empty block statement",
+          hint: "Add code or comment to the empty block",
+        }
+      ],
+      "if (foo) { for(var bar of foo) { } }": [
+        {
+          col: 31,
+          message: "Empty block statement",
+          hint: "Add code or comment to the empty block",
+        }
+      ],
+      "if (foo) { switch (foo) { } }": [
+        {
+          col: 11,
+          message: "Empty switch statement",
+          hint: "Add case statement(s) to the empty switch, or remove",
+        }
+      ],
       r#"
 switch (
   (() => {
@@ -264,9 +375,14 @@ switch (
     bar();
     break;
 }
-      "#,
-      4,
-      14,
-    );
+      "#: [
+        {
+          line: 4,
+          col: 14,
+          message: "Empty block statement",
+          hint: "Add code or comment to the empty block",
+        }
+      ]
+    };
   }
 }

--- a/src/rules/no_empty.rs
+++ b/src/rules/no_empty.rs
@@ -185,6 +185,11 @@ if (foo) {
 }
     "#,
       r#"
+if (foo) {
+  /* This block is not empty */
+}
+    "#,
+      r#"
     switch (foo) {
       case bar:
         break;
@@ -379,6 +384,35 @@ switch (
         {
           line: 4,
           col: 14,
+          message: "Empty block statement",
+          hint: "Add code or comment to the empty block",
+        }
+      ],
+
+      // https://github.com/denoland/deno_lint/issues/469
+      "try { foo(); } catch /* outside block */{ }": [
+        {
+          col: 40,
+          message: "Empty block statement",
+          hint: "Add code or comment to the empty block",
+        }
+      ],
+      "try { foo(); } catch { }/* outside block */": [
+        {
+          col: 21,
+          message: "Empty block statement",
+          hint: "Add code or comment to the empty block",
+        }
+      ],
+      r#"
+try {
+  foo();
+} catch {
+}// pass
+      "#: [
+        {
+          line: 4,
+          col: 8,
           message: "Empty block statement",
           hint: "Add code or comment to the empty block",
         }

--- a/src/rules/no_empty.rs
+++ b/src/rules/no_empty.rs
@@ -206,6 +206,7 @@ if (foo) {
           return 1;
       }
       "#,
+
       // https://github.com/denoland/deno_lint/issues/469
       "try { foo(); } catch { /* pass */ }",
       r#"
@@ -218,12 +219,8 @@ try {
   }
 
   #[test]
-  fn it_fails_for_an_empty_if_block() {
+  fn no_empty_invalid() {
     assert_lint_err::<NoEmpty>("if (foo) { }", 9);
-  }
-
-  #[test]
-  fn it_fails_for_an_empty_block_with_preceding_comments() {
     assert_lint_err_on_line::<NoEmpty>(
       r#"
 // This is an empty block
@@ -232,88 +229,24 @@ if (foo) { }
       3,
       9,
     );
-  }
-
-  #[test]
-  fn it_fails_for_an_empty_while_block() {
     assert_lint_err::<NoEmpty>("while (foo) { }", 12);
-  }
-
-  #[test]
-  fn it_fails_for_an_empty_do_while_block() {
     assert_lint_err::<NoEmpty>("do { } while (foo);", 3);
-  }
-
-  #[test]
-  fn it_fails_for_an_empty_for_block() {
     assert_lint_err::<NoEmpty>("for(;;) { }", 8);
-  }
-
-  #[test]
-  fn it_fails_for_an_empty_for_in_block() {
     assert_lint_err::<NoEmpty>("for(var foo in bar) { }", 20);
-  }
-
-  #[test]
-  fn it_fails_for_an_empty_for_of_block() {
     assert_lint_err::<NoEmpty>("for(var foo of bar) { }", 20);
-  }
-
-  #[test]
-  fn it_fails_for_an_empty_switch_block() {
     assert_lint_err::<NoEmpty>("switch (foo) { }", 0);
-  }
-
-  #[test]
-  fn it_fails_for_an_empty_try_catch_block() {
     assert_lint_err_n::<NoEmpty>("try { } catch (err) { }", vec![4, 20]);
-  }
-
-  #[test]
-  fn it_fails_for_an_empty_try_catch_finally_block() {
     assert_lint_err_n::<NoEmpty>(
       "try { } catch (err) { } finally { }",
       vec![4, 20, 32],
     );
-  }
-
-  #[test]
-  fn it_fails_for_a_nested_empty_if_block() {
     assert_lint_err::<NoEmpty>("if (foo) { if (bar) { } }", 20);
-  }
-
-  #[test]
-  fn it_fails_for_a_nested_empty_while_block() {
     assert_lint_err::<NoEmpty>("if (foo) { while (bar) { } }", 23);
-  }
-
-  #[test]
-  fn it_fails_for_a_nested_empty_do_while_block() {
     assert_lint_err::<NoEmpty>("if (foo) { do { } while (bar); }", 14);
-  }
-
-  #[test]
-  fn it_fails_for_a_nested_empty_for_block() {
     assert_lint_err::<NoEmpty>("if (foo) { for(;;) { } }", 19);
-  }
-
-  #[test]
-  fn it_fails_for_a_nested_empty_for_in_block() {
     assert_lint_err::<NoEmpty>("if (foo) { for(var bar in foo) { } }", 31);
-  }
-
-  #[test]
-  fn it_fails_for_a_nested_empty_for_of_block() {
     assert_lint_err::<NoEmpty>("if (foo) { for(var bar of foo) { } }", 31);
-  }
-
-  #[test]
-  fn it_fails_for_a_nested_empty_switch() {
     assert_lint_err::<NoEmpty>("if (foo) { switch (foo) { } }", 11);
-  }
-
-  #[test]
-  fn it_fails_for_a_nested_empty_if_block_in_switch_discriminant() {
     assert_lint_err_on_line::<NoEmpty>(
       r#"
 switch (


### PR DESCRIPTION
Fixes #469 

Additionally, switching to `assert_lint_err!` macro is done. #431 