### PR TITLE
doc: add linting hints and docs

### DIFF
--- a/src/rules/no_extra_boolean_cast.rs
+++ b/src/rules/no_extra_boolean_cast.rs
@@ -33,6 +33,31 @@ impl LintRule for NoExtraBooleanCast {
     let mut visitor = NoExtraBooleanCastVisitor::new(context);
     visitor.visit_program(program, program);
   }
+
+  fn docs(&self) -> &'static str {
+    r#"Disallows unnecessary boolean casts 
+
+In certain contexts, such as `if`, `while` or `for` statements, expressions are
+automatically coerced into a boolean.  Therefore, techniques such as double
+negation (`!!foo`) or casting (`Boolean(foo)`) are unnecessary and produce the
+same result as without the negation or casting.
+
+### Invalid:
+```typescript
+if (!!foo) {}
+if (Boolean(foo)) {}
+while(!!foo) {}
+for(;Boolean(foo);) {}
+```
+
+### Valid:
+```typescript
+if (foo) {}
+while(foo) {}
+for(;foo;) {}
+```
+"#
+  }
 }
 
 struct NoExtraBooleanCastVisitor<'c> {
@@ -45,18 +70,20 @@ impl<'c> NoExtraBooleanCastVisitor<'c> {
   }
 
   fn unexpected_call(&mut self, span: Span) {
-    self.context.add_diagnostic(
+    self.context.add_diagnostic_with_hint(
       span,
       "no-extra-boolean-cast",
       "Redundant Boolean call.",
+      "Remove the Boolean call, it is unnecessary",
     );
   }
 
   fn unexpected_negation(&mut self, span: Span) {
-    self.context.add_diagnostic(
+    self.context.add_diagnostic_with_hint(
       span,
       "no-extra-boolean-cast",
       "Redundant double negation.",
+      "Remove the double negation (`!!`), it is unnecessary",
     );
   }
 

--- a/src/rules/no_extra_non_null_assertion.rs
+++ b/src/rules/no_extra_non_null_assertion.rs
@@ -32,6 +32,34 @@ impl LintRule for NoExtraNonNullAssertion {
     let mut visitor = NoExtraNonNullAssertionVisitor::new(context);
     visitor.visit_program(program, program);
   }
+
+  fn docs(&self) -> &'static str {
+    r#"Disallows unnecessary non-null assertions
+
+Non-null assertions are specified with an `!` saying to the compiler that you 
+know this value is not null.  Specifying this operator more than once in a row,
+or in combination with the optional chaining operator (`?`) is confusing and
+unnecessary.
+
+### Invalid:
+```typescript
+const foo: { str: string } | null = null; 
+const bar = foo!!.str;
+
+function myFunc(bar: undefined | string) { return bar!!; }
+function anotherFunc(bar?: { str: string }) { return bar!?.str; }
+```
+
+### Valid:
+```typescript
+const foo: { str: string } | null = null; 
+const bar = foo!.str;
+
+function myFunc(bar: undefined | string) { return bar!; }
+function anotherFunc(bar?: { str: string }) { return bar?.str; }
+```
+"#
+  }
 }
 
 struct NoExtraNonNullAssertionVisitor<'c> {
@@ -44,10 +72,11 @@ impl<'c> NoExtraNonNullAssertionVisitor<'c> {
   }
 
   fn add_diagnostic(&mut self, span: Span) {
-    self.context.add_diagnostic(
+    self.context.add_diagnostic_with_hint(
       span,
       "no-extra-non-null-assertion",
       "Extra non-null assertion is forbidden",
+      "Remove the extra non-null assertion operator (`!`)",
     );
   }
 


### PR DESCRIPTION
This PR contributes to #159  with linting hints and docs on the following rules:
* no-explicit-any
* no-extra-boolean-cast
* no-extra-non-null-assertion