### PR TITLE
fix(camelcase): fix hint for object keys

### DIFF
--- a/src/rules/camelcase.rs
+++ b/src/rules/camelcase.rs
@@ -45,6 +45,7 @@ enforces variable declarations and object property names which you create to be
 in camelCase.  Of note:
 * `_` is allowed at the start or end of a variable
 * All uppercase variable names (e.g. constants) may have `_` in their name
+* If you have to use a snake_case key in an object for some reasons, wrap it in quatations
 * This rule also applies to variables imported or exported via ES modules, but not to object properties of those variables
     
 ### Invalid:
@@ -69,6 +70,7 @@ let firstName = "Ichigo";
 const FIRST_NAME = "Ichigo";
 const __myPrivateVariable = "Hoshimiya";
 const myPrivateVariable_ = "Hoshimiya";
+const obj = { "last_name": "Hoshimiya" }; // if an object key is wrapped in quotations, then it's valid
 const { last_name: lastName } = obj;
 
 function doSomething(){} // function declarations must be camelCase but...
@@ -659,6 +661,12 @@ mod tests {
       r#"({...obj.fo_o.ba_r} = baz);"#,
       r#"({c: {...obj.fo_o }} = baz);"#,
       r#"not_ignored_foo = 0;"#,
+
+      // https://github.com/denoland/deno_lint/issues/475
+      // We are forced to use snake_case keys in object literals in some cases such as an object
+      // representing database schema. In such cases, one is allowed to use snake_case by wrapping
+      // keys in quotation marks.
+      r#"const obj = { "created_at": "2020-10-30T13:16:45+09:00" }"#,
     };
   }
 
@@ -677,14 +685,14 @@ mod tests {
             {
               col: 12,
               message: "Identifier 'bar_baz' is not in camel case.",
-              hint: "Consider renaming `bar_baz` to `barBaz`",
+              hint: r#"Consider renaming `bar_baz` to `barBaz`, or wrapping it in quotation mark like `"bar_baz"`"#,
             }
           ],
     r#"var o = {bar_baz: 1}"#: [
             {
               col: 9,
               message: "Identifier 'bar_baz' is not in camel case.",
-              hint: "Consider renaming `bar_baz` to `barBaz`",
+              hint: r#"Consider renaming `bar_baz` to `barBaz`, or wrapping it in quotation mark like `"bar_baz"`"#,
             }
           ],
     r#"var { category_id: category_alias } = query;"#: [

--- a/src/rules/camelcase.rs
+++ b/src/rules/camelcase.rs
@@ -420,31 +420,10 @@ impl<'c> Visit for CamelcaseVisitor<'c> {
                 Prop::Shorthand(ident) => {
                   self.check_ident(ident, IdentToCheck::object_key(ident, true))
                 }
-                Prop::KeyValue(KeyValueProp { ref key, .. }) => {
-                  if let PropName::Ident(ident) = key {
-                    self.check_ident(
-                      ident,
-                      IdentToCheck::object_key(ident, false),
-                    );
-                  }
-                }
-                Prop::Getter(GetterProp { ref key, .. }) => {
-                  if let PropName::Ident(ident) = key {
-                    self.check_ident(
-                      ident,
-                      IdentToCheck::object_key(ident, false),
-                    );
-                  }
-                }
-                Prop::Setter(SetterProp { ref key, .. }) => {
-                  if let PropName::Ident(ident) = key {
-                    self.check_ident(
-                      ident,
-                      IdentToCheck::object_key(ident, false),
-                    );
-                  }
-                }
-                Prop::Method(MethodProp { ref key, .. }) => {
+                Prop::KeyValue(KeyValueProp { ref key, .. })
+                | Prop::Getter(GetterProp { ref key, .. })
+                | Prop::Setter(SetterProp { ref key, .. })
+                | Prop::Method(MethodProp { ref key, .. }) => {
                   if let PropName::Ident(ident) = key {
                     self.check_ident(
                       ident,

--- a/src/rules/camelcase.rs
+++ b/src/rules/camelcase.rs
@@ -45,7 +45,7 @@ enforces variable declarations and object property names which you create to be
 in camelCase.  Of note:
 * `_` is allowed at the start or end of a variable
 * All uppercase variable names (e.g. constants) may have `_` in their name
-* If you have to use a snake_case key in an object for some reasons, wrap it in quatations
+* If you have to use a snake_case key in an object for some reasons, wrap it in quotation mark
 * This rule also applies to variables imported or exported via ES modules, but not to object properties of those variables
     
 ### Invalid:
@@ -70,7 +70,7 @@ let firstName = "Ichigo";
 const FIRST_NAME = "Ichigo";
 const __myPrivateVariable = "Hoshimiya";
 const myPrivateVariable_ = "Hoshimiya";
-const obj = { "last_name": "Hoshimiya" }; // if an object key is wrapped in quotations, then it's valid
+const obj = { "last_name": "Hoshimiya" }; // if an object key is wrapped in quotation mark, then it's valid
 const { last_name: lastName } = obj;
 
 function doSomething(){} // function declarations must be camelCase but...

--- a/src/rules/camelcase.rs
+++ b/src/rules/camelcase.rs
@@ -51,8 +51,9 @@ in camelCase.  Of note:
 ### Invalid:
 ```typescript
 let first_name = "Ichigo";
-const obj = { last_name: "Hoshimiya" };
-const { last_name } = obj;
+const obj1 = { last_name: "Hoshimiya" };
+const obj2 = { first_name };
+const { last_name } = obj1;
 
 function do_something(){}
 function foo({ snake_case = "default value" }) {}
@@ -70,7 +71,8 @@ let firstName = "Ichigo";
 const FIRST_NAME = "Ichigo";
 const __myPrivateVariable = "Hoshimiya";
 const myPrivateVariable_ = "Hoshimiya";
-const obj = { "last_name": "Hoshimiya" }; // if an object key is wrapped in quotation mark, then it's valid
+const obj1 = { "last_name": "Hoshimiya" }; // if an object key is wrapped in quotation mark, then it's valid
+const obj2 = { "first_name": first_name };
 const { last_name: lastName } = obj;
 
 function doSomething(){} // function declarations must be camelCase but...
@@ -667,6 +669,7 @@ mod tests {
       // representing database schema. In such cases, one is allowed to use snake_case by wrapping
       // keys in quotation marks.
       r#"const obj = { "created_at": "2020-10-30T13:16:45+09:00" }"#,
+      r#"const obj = { "created_at": created_at }"#,
     };
   }
 
@@ -688,11 +691,18 @@ mod tests {
               hint: r#"Consider renaming `bar_baz` to `barBaz`, or wrapping it in quotation mark like `"bar_baz"`"#,
             }
           ],
-    r#"var o = {bar_baz: 1}"#: [
+    r#"var o = { bar_baz: 1 }"#: [
             {
-              col: 9,
+              col: 10,
               message: "Identifier 'bar_baz' is not in camel case.",
               hint: r#"Consider renaming `bar_baz` to `barBaz`, or wrapping it in quotation mark like `"bar_baz"`"#,
+            }
+          ],
+    r#"var o = { bar_baz }"#: [
+            {
+              col: 10,
+              message: "Identifier 'bar_baz' is not in camel case.",
+              hint: r#"Consider writing `barBaz: bar_baz` or `"bar_baz": bar_baz`"#,
             }
           ],
     r#"var { category_id: category_alias } = query;"#: [


### PR DESCRIPTION
Fixes #475 

We are forced to use snake_case keys in object literals in some cases such as an object representing database schema. In such cases, one is allowed to use snake_case by wrapping a key in quotation mark. To tell users this fact, hint message for object keys is fixed.

### valid cases

```typescript
const obj = { "created_at": "2020-10-30T13:16:45+09:00" };
const obj = { "created_at": created_at };
```

### invalid cases

```typescript
var o = { bar_baz: 1 };
// the hint looks like:
// Consider renaming `bar_baz` to `barBaz`, or wrapping it in quotation mark like `"bar_baz"`

var o = { bar_baz };
// the hint looks like:
// Consider writing `barBaz: bar_baz` or `"bar_baz": bar_baz`
```