### PR TITLE
refactor: use parse_program() for parsing

### DIFF
--- a/src/control_flow.rs
+++ b/src/control_flow.rs
@@ -665,8 +665,8 @@ mod tests {
   use crate::test_util::*;
 
   fn analyze_flow(src: &str) -> ControlFlow {
-    let module = parse(src);
-    ControlFlow::analyze(&Program::Module(module))
+    let program = parse(src);
+    ControlFlow::analyze(&program)
   }
 
   macro_rules! assert_flow {

--- a/src/ignore_directives.rs
+++ b/src/ignore_directives.rs
@@ -162,7 +162,7 @@ target: Record<string, any>,
 object | undefined {}
   "#;
     let ast_parser = AstParser::new();
-    let (parse_result, comments) = ast_parser.parse_module(
+    let (parse_result, comments) = ast_parser.parse_program(
       "test.ts",
       swc_util::get_default_ts_config(),
       &source_code,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,11 +38,7 @@ mod lint_tests {
       .build();
 
     linter
-      .lint(
-        "lint_test.ts".to_string(),
-        source.to_string(),
-        FileType::Module,
-      )
+      .lint("lint_test.ts".to_string(), source.to_string())
       .expect("Failed to lint")
   }
 
@@ -80,6 +76,7 @@ mod lint_tests {
       false,
     );
 
+    eprintln!("diagnostics {:#?}", diagnostics);
     assert_eq!(diagnostics.len(), 0);
   }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,7 +76,6 @@ mod lint_tests {
       false,
     );
 
-    eprintln!("diagnostics {:#?}", diagnostics);
     assert_eq!(diagnostics.len(), 0);
   }
 

--- a/src/rules/no_inner_declarations.rs
+++ b/src/rules/no_inner_declarations.rs
@@ -6,7 +6,6 @@ use swc_ecmascript::ast;
 use swc_ecmascript::visit::noop_visit_type;
 use swc_ecmascript::visit::Node;
 use swc_ecmascript::visit::Visit;
-// use swc_ecmascript::visit::VisitAll;
 
 pub struct NoInnerDeclarations;
 

--- a/src/rules/no_inner_declarations.rs
+++ b/src/rules/no_inner_declarations.rs
@@ -6,6 +6,7 @@ use swc_ecmascript::ast;
 use swc_ecmascript::visit::noop_visit_type;
 use swc_ecmascript::visit::Node;
 use swc_ecmascript::visit::Visit;
+// use swc_ecmascript::visit::VisitAll;
 
 pub struct NoInnerDeclarations;
 
@@ -62,6 +63,16 @@ impl ValidDeclsVisitor {
 
 impl Visit for ValidDeclsVisitor {
   noop_visit_type!();
+
+  fn visit_script(&mut self, item: &ast::Script, parent: &dyn Node) {
+    for stmt in &item.body {
+      if let ast::Stmt::Decl(decl) = stmt {
+        self.check_decl(decl)
+      }
+    }
+
+    swc_ecmascript::visit::visit_script(self, item, parent);
+  }
 
   fn visit_module_item(&mut self, item: &ast::ModuleItem, parent: &dyn Node) {
     match item {

--- a/src/rules/prefer_const.rs
+++ b/src/rules/prefer_const.rs
@@ -10,8 +10,8 @@ use swc_common::{Span, Spanned};
 use swc_ecmascript::ast::{
   ArrowExpr, AssignExpr, BlockStmt, BlockStmtOrExpr, CatchClause, Class,
   Constructor, DoWhileStmt, Expr, ExprStmt, ForInStmt, ForOfStmt, ForStmt,
-  Function, Ident, IfStmt, Module, ObjectPatProp, ParamOrTsParamProp, Pat,
-  PatOrExpr, Stmt, TsParamPropParam, UpdateExpr, VarDecl, VarDeclKind,
+  Function, Ident, IfStmt, ObjectPatProp, ParamOrTsParamProp, Pat, PatOrExpr,
+  Program, Stmt, TsParamPropParam, UpdateExpr, VarDecl, VarDeclKind,
   VarDeclOrExpr, VarDeclOrPat, WhileStmt, WithStmt,
 };
 use swc_ecmascript::utils::find_ids;
@@ -222,12 +222,12 @@ impl VariableCollector {
 impl Visit for VariableCollector {
   noop_visit_type!();
 
-  fn visit_module(&mut self, module: &Module, _: &dyn Node) {
+  fn visit_program(&mut self, program: &Program, _: &dyn Node) {
     let scope = RawScope::new(None);
     self
       .scopes
       .insert(ScopeRange::Global, Rc::new(RefCell::new(scope)));
-    module.visit_children_with(self);
+    program.visit_children_with(self);
   }
 
   fn visit_function(&mut self, function: &Function, _: &dyn Node) {
@@ -610,7 +610,7 @@ impl<'c> PreferConstVisitor<'c> {
     false
   }
 
-  fn exit_module(&mut self) {
+  fn exit_program(&mut self) {
     let mut for_init_vars = BTreeMap::new();
     let scopes = self.scopes.clone();
     for scope in scopes.values() {
@@ -647,9 +647,9 @@ impl<'c> PreferConstVisitor<'c> {
 impl<'c> Visit for PreferConstVisitor<'c> {
   noop_visit_type!();
 
-  fn visit_module(&mut self, module: &Module, _: &dyn Node) {
-    module.visit_children_with(self);
-    self.exit_module();
+  fn visit_program(&mut self, program: &Program, _: &dyn Node) {
+    program.visit_children_with(self);
+    self.exit_program();
   }
 
   fn visit_assign_expr(&mut self, assign_expr: &AssignExpr, _: &dyn Node) {
@@ -888,9 +888,9 @@ mod variable_collector_tests {
   use crate::test_util;
 
   fn collect(src: &str) -> VariableCollector {
-    let module = test_util::parse(src);
+    let program = test_util::parse(src);
     let mut v = VariableCollector::new();
-    v.visit_module(&module, &module);
+    v.visit_program(&program, &program);
     v
   }
 

--- a/src/scopes.rs
+++ b/src/scopes.rs
@@ -299,17 +299,16 @@ impl Visit for Analyzer<'_> {
 mod tests {
   use super::{analyze, BindingKind, Scope, ScopeKind, Var};
   use crate::swc_util::{self, AstParser};
-  use swc_ecmascript::ast::Program;
   use swc_ecmascript::utils::Id;
 
   fn test_scope(source_code: &str) -> Scope {
     let ast_parser = AstParser::new();
     let syntax = swc_util::get_default_ts_config();
     let (parse_result, _comments) =
-      ast_parser.parse_module("file_name.ts", syntax, source_code);
-    let module = parse_result.unwrap();
+      ast_parser.parse_program("file_name.ts", syntax, source_code);
+    let program = parse_result.unwrap();
 
-    analyze(&Program::Module(module))
+    analyze(&program)
   }
 
   fn id(scope: &Scope, s: &str) -> Id {

--- a/src/test_util.rs
+++ b/src/test_util.rs
@@ -1,12 +1,11 @@
 // Copyright 2020 the Deno authors. All rights reserved. MIT license.
 
 use crate::diagnostic::LintDiagnostic;
-use crate::linter::FileType;
 use crate::linter::LinterBuilder;
 use crate::rules::LintRule;
 use crate::swc_util;
 use std::marker::PhantomData;
-use swc_ecmascript::ast::Module;
+use swc_ecmascript::ast::Program;
 
 #[macro_export]
 macro_rules! assert_lint_ok {
@@ -154,11 +153,7 @@ fn lint(rule: Box<dyn LintRule>, source: &str) -> Vec<LintDiagnostic> {
     .build();
 
   linter
-    .lint(
-      "deno_lint_test.tsx".to_string(),
-      source.to_string(),
-      FileType::Module,
-    )
+    .lint("deno_lint_test.tsx".to_string(), source.to_string())
     .expect("Failed to lint")
 }
 
@@ -291,10 +286,10 @@ pub fn assert_lint_err_on_line_n<T: LintRule + 'static>(
   }
 }
 
-pub fn parse(source_code: &str) -> Module {
+pub fn parse(source_code: &str) -> Program {
   let ast_parser = swc_util::AstParser::new();
   let syntax = swc_util::get_default_ts_config();
   let (parse_result, _comments) =
-    ast_parser.parse_module("file_name.ts", syntax, source_code);
+    ast_parser.parse_program("file_name.ts", syntax, source_code);
   parse_result.unwrap()
 }


### PR DESCRIPTION
This commit removes "FileType" added in #445. 

This is done by removing "AstParser::parse_script" and "AstParser::parse_module"
in favor of "AstParser::parse_program" which uses new "parse_program"
API provided by SWC.