### PR TITLE
refactor: return SourceFile from Linter::lint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -817,9 +817,9 @@ dependencies = [
 
 [[package]]
 name = "swc_common"
-version = "0.10.4"
+version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2b9362f9d864172dd964c4a213bbf52e48f5b9fcaf3456441da4b279dd41463"
+checksum = "1dd78e25ecc138a4667f5e5ea4d1a1c35d424477882b549d4fc011062eecd50e"
 dependencies = [
  "ast_node",
  "cfg-if",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ log = "0.4.11"
 serde = { version = "1.0.88", features = ["derive"] }
 serde_json = { version = "1.0" }
 swc_atoms = "0.2.5"
-swc_common = "=0.10.4"
+swc_common = "=0.10.5"
 swc_ecmascript = { version = "=0.13.1", features = ["parser", "transforms", "utils", "visit"] }
 regex = "1.3.9"
 once_cell = "1.4.1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,13 +37,14 @@ mod lint_tests {
       .rules(get_recommended_rules())
       .build();
 
-    linter
+    let (_, diagnostics) = linter
       .lint(
         "lint_test.ts".to_string(),
         source.to_string(),
         FileType::Module,
       )
-      .expect("Failed to lint")
+      .expect("Failed to lint");
+    diagnostics
   }
 
   #[test]

--- a/src/linter.rs
+++ b/src/linter.rs
@@ -205,21 +205,18 @@ impl Linter {
     );
     self.has_linted = true;
     let start = Instant::now();
-    let mut diagnostics = vec![];
 
-    if !source_code.is_empty() {
-      let (parse_result, comments) =
-        self
-          .ast_parser
-          .parse_program(&file_name, self.syntax, &source_code);
-      let end_parse_program = Instant::now();
-      debug!(
-        "ast_parser.parse_program took {:#?}",
-        end_parse_program - start
-      );
-      let program = parse_result?;
-      diagnostics = self.lint_program(file_name, program, comments);
-    }
+    let (parse_result, comments) =
+      self
+        .ast_parser
+        .parse_program(&file_name, self.syntax, &source_code);
+    let end_parse_program = Instant::now();
+    debug!(
+      "ast_parser.parse_program took {:#?}",
+      end_parse_program - start
+    );
+    let program = parse_result?;
+    let diagnostics = self.lint_program(file_name.clone(), program, comments);
 
     let source_file = self
       .ast_parser

--- a/src/test_util.rs
+++ b/src/test_util.rs
@@ -153,13 +153,14 @@ fn lint(rule: Box<dyn LintRule>, source: &str) -> Vec<LintDiagnostic> {
     .rules(vec![rule])
     .build();
 
-  linter
+  let (_, diagnostics) = linter
     .lint(
       "deno_lint_test.tsx".to_string(),
       source.to_string(),
       FileType::Module,
     )
-    .expect("Failed to lint")
+    .expect("Failed to lint");
+  diagnostics
 }
 
 pub fn assert_diagnostic(


### PR DESCRIPTION
This commit changes return type of "Linter::lint" to return
instance of "swc_common::SourceFile" alongside diagnostics. 
It allows to leverage meta data stored by SWC when formatting 
(eg. line indexes).

Fixes https://github.com/denoland/deno_lint/issues/393