### PR TITLE
fix(no-eval): catch missing eval cases

### DIFF
--- a/src/rules/no_eval.rs
+++ b/src/rules/no_eval.rs
@@ -142,7 +142,7 @@ mod tests {
       "((eval))('var a = 0');": [{col: 2, message: MESSAGE, hint: HINT}],
       "var foo = eval;": [{col: 4, message: MESSAGE, hint: HINT}],
 
-      // TODO
+      // TODO (see: https://github.com/denoland/deno_lint/pull/490)
       // "this.eval("123");": [{col: 0, message: MESSAGE, hint: HINT}],
       // "var foo = this.eval;": [{col: 0, message: MESSAGE, hint: HINT}],
       // "(function(exe){ exe('foo') })(eval);": [{col: 0, message: MESSAGE, hint: HINT}],

--- a/src/rules/no_eval.rs
+++ b/src/rules/no_eval.rs
@@ -1,7 +1,7 @@
 // Copyright 2020 the Deno authors. All rights reserved. MIT license.
 use super::Context;
 use super::LintRule;
-use crate::swc_util::Key;
+use crate::swc_util::StringRepr;
 use swc_common::Span;
 use swc_ecmascript::ast::CallExpr;
 use swc_ecmascript::ast::Expr;
@@ -85,7 +85,7 @@ impl<'c> Visit for NoEvalVisitor<'c> {
   fn visit_var_declarator(&mut self, v: &VarDeclarator, _: &dyn Node) {
     if let Some(expr) = &v.init {
       if let Expr::Ident(ident) = expr.as_ref() {
-        let ident_name = &ident.get_key().unwrap();
+        let ident_name = &ident.string_repr().unwrap();
         self.maybe_add_diagnostic(ident_name, v.span);
       }
     }
@@ -95,11 +95,11 @@ impl<'c> Visit for NoEvalVisitor<'c> {
     if let ExprOrSuper::Expr(expr) = &call_expr.callee {
       match expr.as_ref() {
         Expr::Ident(ident) => {
-          let ident_name = &ident.get_key().unwrap();
+          let ident_name = &ident.string_repr().unwrap();
           self.maybe_add_diagnostic(ident_name, call_expr.span)
         }
         Expr::Member(member_expr) => {
-          let member_name = &member_expr.get_key().unwrap();
+          let member_name = &member_expr.string_repr().unwrap();
           self.maybe_add_diagnostic(member_name, call_expr.span)
         }
         Expr::Paren(paren) => {


### PR DESCRIPTION
Fixes #466 

Detect `eval` usage in the following situations:

```
this.eval();
var foo = eval;
(0, eval)();
((eval))();
```