### PR TITLE
refactor: drop support for multiple ignore directives and match rule code strictly

### DIFF
--- a/src/ignore_directives.rs
+++ b/src/ignore_directives.rs
@@ -37,9 +37,7 @@ impl IgnoreDirective {
 
     let mut should_ignore = false;
     for code in self.codes.iter() {
-      // `ends_with` allows to skip `@typescript-eslint` prefix - not ideal
-      // but works for now
-      if code.ends_with(&diagnostic.code) {
+      if code == &diagnostic.code {
         should_ignore = true;
         *self.used_codes.get_mut(code).unwrap() = true;
       }

--- a/src/linter.rs
+++ b/src/linter.rs
@@ -90,8 +90,8 @@ impl Context {
 }
 
 pub struct LinterBuilder {
-  ignore_file_directives: Vec<String>,
-  ignore_diagnostic_directives: Vec<String>,
+  ignore_file_directive: String,
+  ignore_diagnostic_directive: String,
   lint_unused_ignore_directives: bool,
   lint_unknown_rules: bool,
   syntax: swc_ecmascript::parser::Syntax,
@@ -101,8 +101,8 @@ pub struct LinterBuilder {
 impl LinterBuilder {
   pub fn default() -> Self {
     Self {
-      ignore_file_directives: vec!["deno-lint-ignore-file".to_string()],
-      ignore_diagnostic_directives: vec!["deno-lint-ignore".to_string()],
+      ignore_file_directive: "deno-lint-ignore-file".to_string(),
+      ignore_diagnostic_directive: "deno-lint-ignore".to_string(),
       lint_unused_ignore_directives: true,
       lint_unknown_rules: true,
       syntax: get_default_ts_config(),
@@ -112,8 +112,8 @@ impl LinterBuilder {
 
   pub fn build(self) -> Linter {
     Linter::new(
-      self.ignore_file_directives,
-      self.ignore_diagnostic_directives,
+      self.ignore_file_directive,
+      self.ignore_diagnostic_directive,
       self.lint_unused_ignore_directives,
       self.lint_unknown_rules,
       self.syntax,
@@ -121,15 +121,13 @@ impl LinterBuilder {
     )
   }
 
-  pub fn ignore_file_directives(mut self, directives: Vec<&str>) -> Self {
-    self.ignore_file_directives =
-      directives.iter().map(|s| s.to_string()).collect();
+  pub fn ignore_file_directive(mut self, directive: &str) -> Self {
+    self.ignore_file_directive = directive.to_owned();
     self
   }
 
-  pub fn ignore_diagnostic_directives(mut self, directives: Vec<&str>) -> Self {
-    self.ignore_diagnostic_directives =
-      directives.iter().map(|s| s.to_string()).collect();
+  pub fn ignore_diagnostic_directive(mut self, directive: &str) -> Self {
+    self.ignore_diagnostic_directive = directive.to_owned();
     self
   }
 
@@ -160,8 +158,8 @@ impl LinterBuilder {
 pub struct Linter {
   has_linted: bool,
   ast_parser: AstParser,
-  ignore_file_directives: Vec<String>,
-  ignore_diagnostic_directives: Vec<String>,
+  ignore_file_directive: String,
+  ignore_diagnostic_directive: String,
   lint_unused_ignore_directives: bool,
   lint_unknown_rules: bool,
   syntax: Syntax,
@@ -170,8 +168,8 @@ pub struct Linter {
 
 impl Linter {
   fn new(
-    ignore_file_directives: Vec<String>,
-    ignore_diagnostic_directives: Vec<String>,
+    ignore_file_directive: String,
+    ignore_diagnostic_directive: String,
     lint_unused_ignore_directives: bool,
     lint_unknown_rules: bool,
     syntax: Syntax,
@@ -180,8 +178,8 @@ impl Linter {
     Linter {
       has_linted: false,
       ast_parser: AstParser::new(),
-      ignore_file_directives,
-      ignore_diagnostic_directives,
+      ignore_file_directive,
+      ignore_diagnostic_directive,
       lint_unused_ignore_directives,
       lint_unknown_rules,
       syntax,
@@ -297,7 +295,7 @@ impl Linter {
       comments.with_leading(program.span().lo(), |c| {
         c.iter().find_map(|comment| {
           parse_ignore_comment(
-            &self.ignore_file_directives,
+            &self.ignore_file_directive,
             &*self.ast_parser.source_map,
             comment,
             true,
@@ -324,7 +322,7 @@ impl Linter {
     let trailing = trailing_coms.into_iter().collect();
 
     let mut ignore_directives = parse_ignore_directives(
-      &self.ignore_diagnostic_directives,
+      &self.ignore_diagnostic_directive,
       &self.ast_parser.source_map,
       &leading,
       &trailing,


### PR DESCRIPTION
This commit drops support for defining multiple ignore directives,
meaning that it's not possible to ignore diagnostics using eg.
"deno-lint-ignore" and "eslint-ignore-next-line" comments.
Only a single such comment is recongnized.

Additionally fixed matching diagnostic code to use 
strict comparison instead of matching suffix. This imples
that it's not longer possible to ignore using "@eslint-typescript/"
prefix.

Fixes https://github.com/denoland/deno_lint/issues/287
Ref https://github.com/denoland/deno/issues/8226