### PR TITLE
feat(example): add `--rule` option to dlint

### DIFF
--- a/examples/dlint/main.rs
+++ b/examples/dlint/main.rs
@@ -132,8 +132,17 @@ fn run_linter(paths: Vec<String>, filter_rule_name: Option<&str>) {
     let source_code =
       std::fs::read_to_string(&file_path).expect("Failed to read file");
 
+    let rules = if let Some(rule_name) = filter_rule_name {
+      get_recommended_rules()
+        .into_iter()
+        .filter(|r| r.code() == rule_name)
+        .collect()
+    } else {
+      get_recommended_rules()
+    };
+
     let mut linter = LinterBuilder::default()
-      .rules(get_recommended_rules())
+      .rules(rules)
       .lint_unknown_rules(true)
       .lint_unused_ignore_directives(true)
       .build();
@@ -141,15 +150,6 @@ fn run_linter(paths: Vec<String>, filter_rule_name: Option<&str>) {
     let (source_file, file_diagnostics) = linter
       .lint(file_path.to_string(), source_code)
       .expect("Failed to lint");
-
-    let file_diagnostics = if let Some(rule_name) = filter_rule_name {
-      file_diagnostics
-        .into_iter()
-        .filter(|d| d.code == rule_name)
-        .collect()
-    } else {
-      file_diagnostics
-    };
 
     error_counts.fetch_add(file_diagnostics.len(), Ordering::Relaxed);
     let _g = output_lock.lock().unwrap();

--- a/examples/dlint/main.rs
+++ b/examples/dlint/main.rs
@@ -145,7 +145,7 @@ fn run_linter(paths: Vec<String>, filter_rule_name: Option<&str>) {
     let file_diagnostics = if let Some(rule_name) = filter_rule_name {
       file_diagnostics
         .into_iter()
-        .filter(|d| &d.code == rule_name)
+        .filter(|d| d.code == rule_name)
         .collect()
     } else {
       file_diagnostics


### PR DESCRIPTION
This PR adds `--rule` option to `dlint run` commandm, which allows us to run __a certain rule__ only.

It is very useful when developers work on fixing a certain rule's bug. For example, I work on `getter-return` and when I think I've done with it, I want to make sure that there's no regression. Of course we have test cases in `deno_lint` for that purpose, but sometimes it is not enough. So I always run a command like this to see a result:

```sh
ls /path/to/deno/**/*.js -1 | grep -v -e 'node_modules' -e 'target' | xargs cargo run --example dlint -- run 2>&1 | less
```

This command produces so many errors that I cannot confirm there's no regression with my fix.
In this case, if we use `--rule` option, we'll be able to get errors we want to see, which should help find any regression easily.