### PR TITLE
Merge codes related to scopes

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,7 @@ mod ignore_directives;
 mod js_regex;
 pub mod linter;
 pub mod rules;
+pub mod scoped_rule;
 mod scopes;
 pub mod swc_util;
 

--- a/src/rules/no_class_assign.rs
+++ b/src/rules/no_class_assign.rs
@@ -136,7 +136,7 @@ class A {}
       "#: [
         {
           line: 3,
-          col: 1,
+          col: 2,
           message: MESSAGE,
           hint: HINT,
         }
@@ -147,7 +147,7 @@ class A {}
       "#: [
         {
           line: 3,
-          col: 1,
+          col: 5,
           message: MESSAGE,
           hint: HINT,
         }

--- a/src/rules/no_class_assign.rs
+++ b/src/rules/no_class_assign.rs
@@ -1,42 +1,33 @@
 // Copyright 2020 the Deno authors. All rights reserved. MIT license.
 use super::Context;
-use super::LintRule;
-use crate::{scopes::BindingKind, swc_util::find_lhs_ids};
-use swc_ecmascript::ast::AssignExpr;
-use swc_ecmascript::visit::noop_visit_type;
-use swc_ecmascript::visit::Node;
-use swc_ecmascript::visit::VisitAll;
-use swc_ecmascript::visit::VisitAllWith;
+use crate::scoped_rule::ScopeRule;
+use crate::scoped_rule::ScopedRule;
+use crate::scopes::BindingKind;
+use swc_ecmascript::ast::Ident;
+use swc_ecmascript::utils::ident::IdentLike;
 
-pub struct NoClassAssign;
+pub type NoClassAssign = ScopedRule<NoClassAssignImpl>;
+
+pub struct NoClassAssignImpl;
 
 const CODE: &str = "no-class-assign";
 const MESSAGE: &str = "Reassigning class declaration is not allowed";
 const HINT: &str = "Do you have the right variable here?";
 
-impl LintRule for NoClassAssign {
-  fn new() -> Box<Self> {
-    Box::new(NoClassAssign)
+impl ScopeRule for NoClassAssignImpl {
+  fn new() -> Self {
+    NoClassAssignImpl
   }
 
-  fn tags(&self) -> &'static [&'static str] {
+  fn tags() -> &'static [&'static str] {
     &["recommended"]
   }
 
-  fn code(&self) -> &'static str {
+  fn code() -> &'static str {
     CODE
   }
 
-  fn lint_program(
-    &self,
-    context: &mut Context,
-    program: &swc_ecmascript::ast::Program,
-  ) {
-    let mut visitor = NoClassAssignVisitor::new(context);
-    program.visit_all_with(program, &mut visitor);
-  }
-
-  fn docs(&self) -> &'static str {
+  fn docs() -> &'static str {
     r#"Disallows modifying variables of class declarations
 
 Declaring a class such as `class A{}`, creates a variable `A`.  Like any variable
@@ -48,7 +39,7 @@ was intended.
 class A {}
 A = 0;  // reassigning the class variable itself
 ```
-    
+
 ### Valid:
 ```typescript
 class A{}
@@ -57,37 +48,17 @@ c = 0;  // reassigning the variable `c`
 ```
 "#
   }
-}
 
-struct NoClassAssignVisitor<'c> {
-  context: &'c mut Context,
-}
-
-impl<'c> NoClassAssignVisitor<'c> {
-  fn new(context: &'c mut Context) -> Self {
-    Self { context }
-  }
-}
-
-impl<'c> VisitAll for NoClassAssignVisitor<'c> {
-  noop_visit_type!();
-
-  fn visit_assign_expr(&mut self, assign_expr: &AssignExpr, _node: &dyn Node) {
-    let ids = find_lhs_ids(&assign_expr.left);
-    for id in ids {
-      let var = self.context.scope.var(&id);
-      if let Some(var) = var {
-        if let BindingKind::Class = var.kind() {
-          self.context.add_diagnostic_with_hint(
-            assign_expr.span,
-            CODE,
-            MESSAGE,
-            HINT,
-          );
-        }
+  fn check_assignment(&mut self, context: &mut Context, i: &Ident) {
+    let var = context.scope.var(&i.to_id());
+    if let Some(var) = var {
+      if let BindingKind::Class = var.kind() {
+        context.add_diagnostic_with_hint(i.span, CODE, MESSAGE, HINT);
       }
     }
   }
+
+  fn check_usage(&mut self, _: &mut Context, _: &Ident) {}
 }
 
 #[cfg(test)]

--- a/src/rules/no_undef.rs
+++ b/src/rules/no_undef.rs
@@ -1,21 +1,15 @@
 // Copyright 2020 the Deno authors. All rights reserved. MIT license.
-use std::collections::HashSet;
 
 use super::Context;
 use crate::globals::GLOBALS;
 use crate::scoped_rule::ScopeRule;
 use crate::scoped_rule::ScopedRule;
-use crate::scopes::BindingKind;
-use swc_ecmascript::utils::Id;
 use swc_ecmascript::{ast::*, utils::ident::IdentLike};
 
 pub type NoUndef = ScopedRule<NoUndefImpl>;
 
 #[derive(Default)]
-pub struct NoUndefImpl {
-  /// declared bindings
-  bindings: HashSet<Id>,
-}
+pub struct NoUndefImpl;
 
 impl ScopeRule for NoUndefImpl {
   fn new() -> Self {
@@ -32,10 +26,6 @@ impl ScopeRule for NoUndefImpl {
 
   fn ignore_typeof() -> bool {
     true
-  }
-
-  fn declare(&mut self, _: &mut Context, i: &Ident, _: BindingKind) {
-    self.bindings.insert(i.to_id());
   }
 
   fn assign(&mut self, context: &mut Context, i: &Ident) {
@@ -58,7 +48,7 @@ impl ScopeRule for NoUndefImpl {
     }
 
     // Ignore top level bindings declared in the file.
-    if self.bindings.contains(&i.to_id()) {
+    if context.scope.var(&i.to_id()).is_some() {
       return;
     }
 

--- a/src/rules/no_undef.rs
+++ b/src/rules/no_undef.rs
@@ -28,7 +28,7 @@ impl ScopeRule for NoUndefImpl {
     true
   }
 
-  fn assign(&mut self, context: &mut Context, i: &Ident) {
+  fn check_assignment(&mut self, context: &mut Context, i: &Ident) {
     self.check_usage(context, i)
   }
 

--- a/src/scoped_rule.rs
+++ b/src/scoped_rule.rs
@@ -1,0 +1,89 @@
+use std::marker::PhantomData;
+
+use crate::linter::Context;
+use crate::rules::LintRule;
+use crate::scopes::BindingKind;
+use swc_common::Span;
+use swc_common::DUMMY_SP;
+use swc_ecmascript::ast::Expr;
+use swc_ecmascript::ast::Invalid;
+use swc_ecmascript::ast::Program;
+use swc_ecmascript::utils::Id;
+use swc_ecmascript::visit::Node;
+use swc_ecmascript::visit::Visit;
+use swc_ecmascript::visit::VisitWith;
+
+pub struct ScopedRule<S>
+where
+  S: ScopeRule,
+{
+  _marker: PhantomData<S>,
+}
+
+impl<S> LintRule for ScopedRule<S>
+where
+  S: ScopeRule,
+{
+  fn new() -> Box<Self>
+  where
+    Self: Sized,
+  {
+    Box::new(ScopedRule {
+      _marker: PhantomData,
+    })
+  }
+
+  fn lint_program(&self, context: &mut Context, program: &Program) {
+    let mut visitor = ScopedRuleVisitor {
+      context,
+      rule: S::new(),
+    };
+
+    program.visit_with(&Invalid { span: DUMMY_SP }, &mut visitor);
+  }
+
+  fn code(&self) -> &'static str {
+    S::new().code()
+  }
+
+  fn tags(&self) -> &'static [&'static str] {
+    S::new().tags()
+  }
+
+  fn docs(&self) -> &'static str {
+    S::new().docs()
+  }
+}
+
+pub trait ScopeRule {
+  fn new() -> Self;
+
+  fn code(&self) -> &'static str;
+  fn tags(&self) -> &'static [&'static str] {
+    &[]
+  }
+  fn docs(&self) -> &'static str {
+    ""
+  }
+
+  fn declare(&mut self, id: Id, kind: BindingKind);
+
+  fn assign(&mut self, id: Id);
+
+  fn lint_usage(&mut self, context: &mut Context, span: Span, id: Id);
+}
+
+struct ScopedRuleVisitor<'a, S>
+where
+  S: ScopeRule,
+{
+  rule: S,
+  context: &'a mut Context,
+}
+
+impl<S> Visit for ScopedRuleVisitor<'_, S>
+where
+  S: ScopeRule,
+{
+  fn visit_expr(&mut self, expr: &Expr, _: &dyn Node) {}
+}

--- a/src/scoped_rule.rs
+++ b/src/scoped_rule.rs
@@ -3,12 +3,23 @@ use std::marker::PhantomData;
 use crate::linter::Context;
 use crate::rules::LintRule;
 use crate::scopes::BindingKind;
-use swc_common::Span;
+use swc_atoms::js_word;
 use swc_common::DUMMY_SP;
+use swc_ecmascript::ast::AssignExpr;
+use swc_ecmascript::ast::CallExpr;
+use swc_ecmascript::ast::ClassProp;
 use swc_ecmascript::ast::Expr;
+use swc_ecmascript::ast::ExprOrSuper;
+use swc_ecmascript::ast::Ident;
 use swc_ecmascript::ast::Invalid;
+use swc_ecmascript::ast::MemberExpr;
+use swc_ecmascript::ast::Pat;
 use swc_ecmascript::ast::Program;
-use swc_ecmascript::utils::Id;
+use swc_ecmascript::ast::Prop;
+use swc_ecmascript::ast::UnaryExpr;
+use swc_ecmascript::ast::UnaryOp;
+use swc_ecmascript::ast::VarDecl;
+use swc_ecmascript::ast::VarDeclKind;
 use swc_ecmascript::visit::Node;
 use swc_ecmascript::visit::Visit;
 use swc_ecmascript::visit::VisitWith;
@@ -35,42 +46,47 @@ where
 
   fn lint_program(&self, context: &mut Context, program: &Program) {
     let mut visitor = ScopedRuleVisitor {
-      context,
       rule: S::new(),
+      context,
+      pat_var_decl_kind: None,
     };
 
     program.visit_with(&Invalid { span: DUMMY_SP }, &mut visitor);
   }
 
   fn code(&self) -> &'static str {
-    S::new().code()
+    S::code()
   }
 
   fn tags(&self) -> &'static [&'static str] {
-    S::new().tags()
+    S::tags()
   }
 
   fn docs(&self) -> &'static str {
-    S::new().docs()
+    S::docs()
   }
 }
 
 pub trait ScopeRule {
   fn new() -> Self;
 
-  fn code(&self) -> &'static str;
-  fn tags(&self) -> &'static [&'static str] {
+  fn ignore_typeof() -> bool {
+    false
+  }
+
+  fn code() -> &'static str;
+  fn tags() -> &'static [&'static str] {
     &[]
   }
-  fn docs(&self) -> &'static str {
+  fn docs() -> &'static str {
     ""
   }
 
-  fn declare(&mut self, id: Id, kind: BindingKind);
+  fn declare(&mut self, context: &mut Context, i: &Ident, kind: BindingKind);
 
-  fn assign(&mut self, id: Id);
+  fn assign(&mut self, context: &mut Context, i: &Ident);
 
-  fn lint_usage(&mut self, context: &mut Context, span: Span, id: Id);
+  fn check_usage(&mut self, context: &mut Context, i: &Ident);
 }
 
 struct ScopedRuleVisitor<'a, S>
@@ -79,11 +95,103 @@ where
 {
   rule: S,
   context: &'a mut Context,
+  /// [Some] while folding patterns of variables,
+  ///  and [None] while folding patterns of an assigment expressions.
+  pat_var_decl_kind: Option<VarDeclKind>,
 }
 
 impl<S> Visit for ScopedRuleVisitor<'_, S>
 where
   S: ScopeRule,
 {
-  fn visit_expr(&mut self, expr: &Expr, _: &dyn Node) {}
+  fn visit_unary_expr(&mut self, expr: &UnaryExpr, _: &dyn Node) {
+    if S::ignore_typeof() && expr.op == UnaryOp::TypeOf {
+      return;
+    }
+
+    expr.visit_children_with(self)
+  }
+
+  fn visit_class_prop(&mut self, p: &ClassProp, _: &dyn Node) {
+    p.value.visit_with(p, self)
+  }
+
+  /// This is required as scoped rules deal with identifiers.
+  fn visit_member_expr(&mut self, expr: &MemberExpr, _: &dyn Node) {
+    expr.obj.visit_with(expr, self);
+
+    if expr.computed {
+      expr.prop.visit_with(expr, self);
+    }
+  }
+
+  /// This method is required because shorthand properties are usage of an identifier.
+  fn visit_prop(&mut self, p: &Prop, _: &dyn Node) {
+    p.visit_children_with(self);
+
+    if let Prop::Shorthand(i) = &p {
+      self.rule.check_usage(self.context, i);
+    }
+  }
+
+  fn visit_expr(&mut self, expr: &Expr, _: &dyn Node) {
+    expr.visit_children_with(self);
+
+    match expr {
+      Expr::Ident(i) => {
+        self.rule.check_usage(self.context, i);
+      }
+      _ => {}
+    }
+  }
+
+  fn visit_pat(&mut self, pat: &Pat, _: &dyn Node) {
+    pat.visit_children_with(self);
+
+    if let Pat::Ident(i) = pat {
+      if let Some(kind) = self.pat_var_decl_kind {
+        self.rule.declare(
+          self.context,
+          i,
+          match kind {
+            VarDeclKind::Var => BindingKind::Var,
+            VarDeclKind::Let => BindingKind::Let,
+            VarDeclKind::Const => BindingKind::Const,
+          },
+        );
+      } else {
+        self.rule.assign(self.context, i);
+      }
+    }
+  }
+
+  fn visit_assign_expr(&mut self, expr: &AssignExpr, _: &dyn Node) {
+    let old_pat_kind = self.pat_var_decl_kind;
+    self.pat_var_decl_kind = None;
+
+    expr.visit_children_with(self);
+
+    self.pat_var_decl_kind = old_pat_kind;
+  }
+
+  fn visit_var_decl(&mut self, var: &VarDecl, _: &dyn Node) {
+    let old_pat_kind = self.pat_var_decl_kind;
+    self.pat_var_decl_kind = Some(var.kind);
+
+    var.visit_children_with(self);
+
+    self.pat_var_decl_kind = old_pat_kind;
+  }
+
+  fn visit_call_expr(&mut self, expr: &CallExpr, _: &dyn Node) {
+    if let ExprOrSuper::Expr(callee) = &expr.callee {
+      if let Expr::Ident(i) = &**callee {
+        if i.sym == js_word!("import") {
+          return;
+        }
+      }
+    }
+
+    expr.visit_children_with(self);
+  }
 }

--- a/src/scoped_rule.rs
+++ b/src/scoped_rule.rs
@@ -2,7 +2,6 @@ use std::marker::PhantomData;
 
 use crate::linter::Context;
 use crate::rules::LintRule;
-use crate::scopes::BindingKind;
 use swc_atoms::js_word;
 use swc_common::DUMMY_SP;
 use swc_ecmascript::ast::AssignExpr;
@@ -82,8 +81,6 @@ pub trait ScopeRule {
     ""
   }
 
-  fn declare(&mut self, context: &mut Context, i: &Ident, kind: BindingKind);
-
   fn assign(&mut self, context: &mut Context, i: &Ident);
 
   fn check_usage(&mut self, context: &mut Context, i: &Ident);
@@ -149,17 +146,7 @@ where
     pat.visit_children_with(self);
 
     if let Pat::Ident(i) = pat {
-      if let Some(kind) = self.pat_var_decl_kind {
-        self.rule.declare(
-          self.context,
-          i,
-          match kind {
-            VarDeclKind::Var => BindingKind::Var,
-            VarDeclKind::Let => BindingKind::Let,
-            VarDeclKind::Const => BindingKind::Const,
-          },
-        );
-      } else {
+      if let None = self.pat_var_decl_kind {
         self.rule.assign(self.context, i);
       }
     }

--- a/src/scoped_rule.rs
+++ b/src/scoped_rule.rs
@@ -5,6 +5,7 @@ use crate::rules::LintRule;
 use swc_atoms::js_word;
 use swc_common::DUMMY_SP;
 use swc_ecmascript::ast::AssignExpr;
+use swc_ecmascript::ast::AssignPatProp;
 use swc_ecmascript::ast::CallExpr;
 use swc_ecmascript::ast::ClassProp;
 use swc_ecmascript::ast::Expr;
@@ -81,7 +82,7 @@ pub trait ScopeRule {
     ""
   }
 
-  fn assign(&mut self, context: &mut Context, i: &Ident);
+  fn check_assignment(&mut self, context: &mut Context, i: &Ident);
 
   fn check_usage(&mut self, context: &mut Context, i: &Ident);
 }
@@ -147,9 +148,14 @@ where
 
     if let Pat::Ident(i) = pat {
       if let None = self.pat_var_decl_kind {
-        self.rule.assign(self.context, i);
+        self.rule.check_assignment(self.context, i);
       }
     }
+  }
+
+  fn visit_assign_pat_prop(&mut self, p: &AssignPatProp, _: &dyn Node) {
+    self.rule.check_assignment(self.context, &p.key);
+    p.value.visit_with(p, self);
   }
 
   fn visit_assign_expr(&mut self, expr: &AssignExpr, _: &dyn Node) {

--- a/src/scoped_rule.rs
+++ b/src/scoped_rule.rs
@@ -7,6 +7,7 @@ use swc_common::DUMMY_SP;
 use swc_ecmascript::ast::AssignExpr;
 use swc_ecmascript::ast::AssignPatProp;
 use swc_ecmascript::ast::CallExpr;
+use swc_ecmascript::ast::CatchClause;
 use swc_ecmascript::ast::ClassProp;
 use swc_ecmascript::ast::Expr;
 use swc_ecmascript::ast::ExprOrSuper;
@@ -186,5 +187,9 @@ where
     }
 
     expr.visit_children_with(self);
+  }
+
+  fn visit_catch_clause(&mut self, cc: &CatchClause, _: &dyn Node) {
+    cc.body.visit_with(cc, self);
   }
 }

--- a/src/scoped_rule.rs
+++ b/src/scoped_rule.rs
@@ -148,7 +148,7 @@ where
     pat.visit_children_with(self);
 
     if let Pat::Ident(i) = pat {
-      if let None = self.pat_var_decl_kind {
+      if self.pat_var_decl_kind.is_none() {
         self.rule.check_assignment(self.context, i);
       }
     }


### PR DESCRIPTION
This is a pr to fix #492.


# Tasks

 - [x] Make no-undef use `scopes.rs`.
 - [ ] Make `no-import-assign` use `scopes.rs`.
 - [ ] Merge rules using `scopes.rs` with a trait.
   - [x] no-undef
   - [ ] no-import-assign
   - [x] no-ex-assign
   - [x] no-func-assign
   - [x] no-class-assign
   - [ ] no-const-assign
   - [ ] no-shadow-restricted-names

