### PR TITLE
refactor(no-dupe-class-members): switch to `asset_lint_err!` macro

### DIFF
--- a/src/rules/no_dupe_class_members.rs
+++ b/src/rules/no_dupe_class_members.rs
@@ -1,6 +1,7 @@
 // Copyright 2020 the Deno authors. All rights reserved. MIT license.
 use super::Context;
 use super::LintRule;
+use derive_more::Display;
 use std::cmp::Ordering;
 use std::collections::BTreeMap;
 use swc_common::Span;
@@ -8,11 +9,23 @@ use swc_ecmascript::ast::{
   BigInt, Bool, Class, ClassMethod, ComputedPropName, Expr, Ident, Lit,
   MethodKind, Null, Number, PropName, Str, Tpl,
 };
-use swc_ecmascript::visit::noop_visit_type;
-use swc_ecmascript::visit::Node;
-use swc_ecmascript::visit::Visit;
+use swc_ecmascript::visit::{noop_visit_type, Node, Visit, VisitWith};
 
 pub struct NoDupeClassMembers;
+
+const CODE: &str = "no-dupe-class-members";
+
+#[derive(Display)]
+enum NoDupeClassMembersMessage {
+  #[display(fmt = "Duplicate name '{}'", _0)]
+  Duplicate(String),
+}
+
+#[derive(Display)]
+enum NoDupeClassMembersHint {
+  #[display(fmt = "Rename or remove the function with the duplicated name")]
+  RenameOrRemove,
+}
 
 impl LintRule for NoDupeClassMembers {
   fn new() -> Box<Self> {
@@ -24,7 +37,7 @@ impl LintRule for NoDupeClassMembers {
   }
 
   fn code(&self) -> &'static str {
-    "no-dupe-class-members"
+    CODE
   }
 
   fn lint_program(
@@ -73,9 +86,9 @@ impl<'c> NoDupeClassMembersVisitor<'c> {
   fn add_diagnostic(&mut self, span: Span, name: &str) {
     self.context.add_diagnostic_with_hint(
       span,
-      "no-dupe-class-members",
-      format!("Duplicate name '{}'", name),
-      "Rename or remove the function with the duplicated name",
+      CODE,
+      NoDupeClassMembersMessage::Duplicate(name.to_string()),
+      NoDupeClassMembersHint::RenameOrRemove,
     );
   }
 }
@@ -83,9 +96,9 @@ impl<'c> NoDupeClassMembersVisitor<'c> {
 impl<'c> Visit for NoDupeClassMembersVisitor<'c> {
   noop_visit_type!();
 
-  fn visit_class(&mut self, class: &Class, parent: &dyn Node) {
+  fn visit_class(&mut self, class: &Class, _: &dyn Node) {
     let mut visitor = ClassVisitor::new(self);
-    visitor.visit_class(class, parent);
+    class.visit_children_with(&mut visitor);
     visitor.aggregate_dupes();
   }
 }
@@ -120,17 +133,13 @@ impl<'a, 'b> ClassVisitor<'a, 'b> {
 impl<'a, 'b> Visit for ClassVisitor<'a, 'b> {
   noop_visit_type!();
 
-  fn visit_class(&mut self, class: &Class, parent: &dyn Node) {
+  fn visit_class(&mut self, class: &Class, _: &dyn Node) {
     let mut visitor = ClassVisitor::new(self.root_visitor);
-    swc_ecmascript::visit::visit_class(&mut visitor, class, parent);
+    class.visit_children_with(&mut visitor);
     visitor.aggregate_dupes();
   }
 
-  fn visit_class_method(
-    &mut self,
-    class_method: &ClassMethod,
-    parent: &dyn Node,
-  ) {
+  fn visit_class_method(&mut self, class_method: &ClassMethod, _: &dyn Node) {
     if class_method.function.body.is_some() {
       if let Some(m) = MethodToCheck::new(
         &class_method.key,
@@ -145,7 +154,7 @@ impl<'a, 'b> Visit for ClassVisitor<'a, 'b> {
           .push((class_method.span, name));
       }
     }
-    swc_ecmascript::visit::visit_class_method(self, class_method, parent);
+    class_method.visit_children_with(self);
   }
 }
 
@@ -234,7 +243,6 @@ impl Ord for MethodToCheck {
 #[cfg(test)]
 mod tests {
   use super::*;
-  use crate::test_util::*;
 
   #[test]
   fn no_dupe_class_members_valid() {
@@ -420,268 +428,509 @@ class Foo {
 
   #[test]
   fn no_dupe_class_members_invalid() {
-    assert_lint_err_on_line_n::<NoDupeClassMembers>(
+    assert_lint_err! {
+      NoDupeClassMembers,
       r#"
 class Foo {
   bar() {}
   bar() {}
 }
-      "#,
-      vec![(3, 2), (4, 2)],
-    );
-
-    assert_lint_err_on_line_n::<NoDupeClassMembers>(
+      "#: [
+        {
+          line: 3,
+          col: 2,
+          message: variant!(NoDupeClassMembersMessage, Duplicate, "bar"),
+          hint: NoDupeClassMembersHint::RenameOrRemove,
+        },
+        {
+          line: 4,
+          col: 2,
+          message: variant!(NoDupeClassMembersMessage, Duplicate, "bar"),
+          hint: NoDupeClassMembersHint::RenameOrRemove,
+        }
+      ],
       r#"
 !class Foo {
   bar() {}
   bar() {}
 };
-      "#,
-      vec![(3, 2), (4, 2)],
-    );
-
-    assert_lint_err_on_line_n::<NoDupeClassMembers>(
+      "#: [
+        {
+          line: 3,
+          col: 2,
+          message: variant!(NoDupeClassMembersMessage, Duplicate, "bar"),
+          hint: NoDupeClassMembersHint::RenameOrRemove,
+        },
+        {
+          line: 4,
+          col: 2,
+          message: variant!(NoDupeClassMembersMessage, Duplicate, "bar"),
+          hint: NoDupeClassMembersHint::RenameOrRemove,
+        }
+      ],
       r#"
 class Foo {
   'bar'() {}
   'bar'() {}
 }
-      "#,
-      vec![(3, 2), (4, 2)],
-    );
-
-    assert_lint_err_on_line_n::<NoDupeClassMembers>(
+      "#: [
+        {
+          line: 3,
+          col: 2,
+          message: variant!(NoDupeClassMembersMessage, Duplicate, "bar"),
+          hint: NoDupeClassMembersHint::RenameOrRemove,
+        },
+        {
+          line: 4,
+          col: 2,
+          message: variant!(NoDupeClassMembersMessage, Duplicate, "bar"),
+          hint: NoDupeClassMembersHint::RenameOrRemove,
+        }
+      ],
       r#"
 class Foo {
   10() {}
   1e1() {}
 }
-      "#,
-      vec![(3, 2), (4, 2)],
-    );
-
-    assert_lint_err_on_line_n::<NoDupeClassMembers>(
+      "#: [
+        {
+          line: 3,
+          col: 2,
+          message: variant!(NoDupeClassMembersMessage, Duplicate, "10"),
+          hint: NoDupeClassMembersHint::RenameOrRemove,
+        },
+        {
+          line: 4,
+          col: 2,
+          message: variant!(NoDupeClassMembersMessage, Duplicate, "10"),
+          hint: NoDupeClassMembersHint::RenameOrRemove,
+        }
+      ],
       r#"
 class Foo {
   ['bar']() {}
   ['bar']() {}
 }
-      "#,
-      vec![(3, 2), (4, 2)],
-    );
-
-    assert_lint_err_on_line_n::<NoDupeClassMembers>(
+      "#: [
+        {
+          line: 3,
+          col: 2,
+          message: variant!(NoDupeClassMembersMessage, Duplicate, "bar"),
+          hint: NoDupeClassMembersHint::RenameOrRemove,
+        },
+        {
+          line: 4,
+          col: 2,
+          message: variant!(NoDupeClassMembersMessage, Duplicate, "bar"),
+          hint: NoDupeClassMembersHint::RenameOrRemove,
+        }
+      ],
       r#"
 class Foo {
   static ['bar']() {}
   static bar() {}
 }
-      "#,
-      vec![(3, 2), (4, 2)],
-    );
-
-    assert_lint_err_on_line_n::<NoDupeClassMembers>(
+      "#: [
+        {
+          line: 3,
+          col: 2,
+          message: variant!(NoDupeClassMembersMessage, Duplicate, "bar"),
+          hint: NoDupeClassMembersHint::RenameOrRemove,
+        },
+        {
+          line: 4,
+          col: 2,
+          message: variant!(NoDupeClassMembersMessage, Duplicate, "bar"),
+          hint: NoDupeClassMembersHint::RenameOrRemove,
+        }
+      ],
       r#"
 class Foo {
   set 'bar'(value: number) {}
   set ['bar'](val: number) {}
 }
-      "#,
-      vec![(3, 2), (4, 2)],
-    );
-
-    assert_lint_err_on_line_n::<NoDupeClassMembers>(
+      "#: [
+        {
+          line: 3,
+          col: 2,
+          message: variant!(NoDupeClassMembersMessage, Duplicate, "bar"),
+          hint: NoDupeClassMembersHint::RenameOrRemove,
+        },
+        {
+          line: 4,
+          col: 2,
+          message: variant!(NoDupeClassMembersMessage, Duplicate, "bar"),
+          hint: NoDupeClassMembersHint::RenameOrRemove,
+        }
+      ],
       r#"
 class Foo {
   ''() {}
   ['']() {}
 }
-      "#,
-      vec![(3, 2), (4, 2)],
-    );
-
-    assert_lint_err_on_line_n::<NoDupeClassMembers>(
+      "#: [
+        {
+          line: 3,
+          col: 2,
+          message: variant!(NoDupeClassMembersMessage, Duplicate, ""),
+          hint: NoDupeClassMembersHint::RenameOrRemove,
+        },
+        {
+          line: 4,
+          col: 2,
+          message: variant!(NoDupeClassMembersMessage, Duplicate, ""),
+          hint: NoDupeClassMembersHint::RenameOrRemove,
+        }
+      ],
       r#"
 class Foo {
   [`bar`]() {}
   [`bar`]() {}
 }
-      "#,
-      vec![(3, 2), (4, 2)],
-    );
-
-    assert_lint_err_on_line_n::<NoDupeClassMembers>(
+      "#: [
+        {
+          line: 3,
+          col: 2,
+          message: variant!(NoDupeClassMembersMessage, Duplicate, "bar"),
+          hint: NoDupeClassMembersHint::RenameOrRemove,
+        },
+        {
+          line: 4,
+          col: 2,
+          message: variant!(NoDupeClassMembersMessage, Duplicate, "bar"),
+          hint: NoDupeClassMembersHint::RenameOrRemove,
+        }
+      ],
       r#"
 class Foo {
   static get [`bar`]() {}
   static get ['bar']() {}
 }
-      "#,
-      vec![(3, 2), (4, 2)],
-    );
-
-    assert_lint_err_on_line_n::<NoDupeClassMembers>(
+      "#: [
+        {
+          line: 3,
+          col: 2,
+          message: variant!(NoDupeClassMembersMessage, Duplicate, "bar"),
+          hint: NoDupeClassMembersHint::RenameOrRemove,
+        },
+        {
+          line: 4,
+          col: 2,
+          message: variant!(NoDupeClassMembersMessage, Duplicate, "bar"),
+          hint: NoDupeClassMembersHint::RenameOrRemove,
+        }
+      ],
       r#"
 class Foo {
   bar() {}
   [`bar`]() {}
 }
-      "#,
-      vec![(3, 2), (4, 2)],
-    );
-
-    assert_lint_err_on_line_n::<NoDupeClassMembers>(
+      "#: [
+        {
+          line: 3,
+          col: 2,
+          message: variant!(NoDupeClassMembersMessage, Duplicate, "bar"),
+          hint: NoDupeClassMembersHint::RenameOrRemove,
+        },
+        {
+          line: 4,
+          col: 2,
+          message: variant!(NoDupeClassMembersMessage, Duplicate, "bar"),
+          hint: NoDupeClassMembersHint::RenameOrRemove,
+        }
+      ],
       r#"
 class Foo {
   get [`bar`]() {}
   'bar'() {}
 }
-      "#,
-      vec![(3, 2), (4, 2)],
-    );
-
-    assert_lint_err_on_line_n::<NoDupeClassMembers>(
+      "#: [
+        {
+          line: 3,
+          col: 2,
+          message: variant!(NoDupeClassMembersMessage, Duplicate, "bar"),
+          hint: NoDupeClassMembersHint::RenameOrRemove,
+        },
+        {
+          line: 4,
+          col: 2,
+          message: variant!(NoDupeClassMembersMessage, Duplicate, "bar"),
+          hint: NoDupeClassMembersHint::RenameOrRemove,
+        }
+      ],
       r#"
 class Foo {
   static 'bar'() {}
   static [`bar`]() {}
 }
-      "#,
-      vec![(3, 2), (4, 2)],
-    );
-
-    assert_lint_err_on_line_n::<NoDupeClassMembers>(
+      "#: [
+        {
+          line: 3,
+          col: 2,
+          message: variant!(NoDupeClassMembersMessage, Duplicate, "bar"),
+          hint: NoDupeClassMembersHint::RenameOrRemove,
+        },
+        {
+          line: 4,
+          col: 2,
+          message: variant!(NoDupeClassMembersMessage, Duplicate, "bar"),
+          hint: NoDupeClassMembersHint::RenameOrRemove,
+        }
+      ],
       r#"
 class Foo {
   ['constructor']() {}
   ['constructor']() {}
 }
-      "#,
-      vec![(3, 2), (4, 2)],
-    );
-
-    assert_lint_err_on_line_n::<NoDupeClassMembers>(
+      "#: [
+        {
+          line: 3,
+          col: 2,
+          message: variant!(NoDupeClassMembersMessage, Duplicate, "constructor"),
+          hint: NoDupeClassMembersHint::RenameOrRemove,
+        },
+        {
+          line: 4,
+          col: 2,
+          message: variant!(NoDupeClassMembersMessage, Duplicate, "constructor"),
+          hint: NoDupeClassMembersHint::RenameOrRemove,
+        }
+      ],
       r#"
 class Foo {
   static [`constructor`]() {}
   static ['constructor']() {}
 }
-      "#,
-      vec![(3, 2), (4, 2)],
-    );
-
-    assert_lint_err_on_line_n::<NoDupeClassMembers>(
+      "#: [
+        {
+          line: 3,
+          col: 2,
+          message: variant!(NoDupeClassMembersMessage, Duplicate, "constructor"),
+          hint: NoDupeClassMembersHint::RenameOrRemove,
+        },
+        {
+          line: 4,
+          col: 2,
+          message: variant!(NoDupeClassMembersMessage, Duplicate, "constructor"),
+          hint: NoDupeClassMembersHint::RenameOrRemove,
+        }
+      ],
       r#"
 class Foo {
   [123]() {}
   [123]() {}
 }
-      "#,
-      vec![(3, 2), (4, 2)],
-    );
-
-    assert_lint_err_on_line_n::<NoDupeClassMembers>(
+      "#: [
+        {
+          line: 3,
+          col: 2,
+          message: variant!(NoDupeClassMembersMessage, Duplicate, "123"),
+          hint: NoDupeClassMembersHint::RenameOrRemove,
+        },
+        {
+          line: 4,
+          col: 2,
+          message: variant!(NoDupeClassMembersMessage, Duplicate, "123"),
+          hint: NoDupeClassMembersHint::RenameOrRemove,
+        }
+      ],
       r#"
 class Foo {
   [0x10]() {}
   16() {}
 }
-      "#,
-      vec![(3, 2), (4, 2)],
-    );
-
-    assert_lint_err_on_line_n::<NoDupeClassMembers>(
+      "#: [
+        {
+          line: 3,
+          col: 2,
+          message: variant!(NoDupeClassMembersMessage, Duplicate, "16"),
+          hint: NoDupeClassMembersHint::RenameOrRemove,
+        },
+        {
+          line: 4,
+          col: 2,
+          message: variant!(NoDupeClassMembersMessage, Duplicate, "16"),
+          hint: NoDupeClassMembersHint::RenameOrRemove,
+        }
+      ],
       r#"
 class Foo {
   [100]() {}
   [1e2]() {}
 }
-      "#,
-      vec![(3, 2), (4, 2)],
-    );
-
-    assert_lint_err_on_line_n::<NoDupeClassMembers>(
+      "#: [
+        {
+          line: 3,
+          col: 2,
+          message: variant!(NoDupeClassMembersMessage, Duplicate, "100"),
+          hint: NoDupeClassMembersHint::RenameOrRemove,
+        },
+        {
+          line: 4,
+          col: 2,
+          message: variant!(NoDupeClassMembersMessage, Duplicate, "100"),
+          hint: NoDupeClassMembersHint::RenameOrRemove,
+        }
+      ],
       r#"
 class Foo {
   [123.00]() {}
   [`123`]() {}
 }
-      "#,
-      vec![(3, 2), (4, 2)],
-    );
-
-    assert_lint_err_on_line_n::<NoDupeClassMembers>(
+      "#: [
+        {
+          line: 3,
+          col: 2,
+          message: variant!(NoDupeClassMembersMessage, Duplicate, "123"),
+          hint: NoDupeClassMembersHint::RenameOrRemove,
+        },
+        {
+          line: 4,
+          col: 2,
+          message: variant!(NoDupeClassMembersMessage, Duplicate, "123"),
+          hint: NoDupeClassMembersHint::RenameOrRemove,
+        }
+      ],
       r#"
 class Foo {
   static '65'() {}
   static [0o101]() {}
 }
-      "#,
-      vec![(3, 2), (4, 2)],
-    );
-
-    assert_lint_err_on_line_n::<NoDupeClassMembers>(
+      "#: [
+        {
+          line: 3,
+          col: 2,
+          message: variant!(NoDupeClassMembersMessage, Duplicate, "65"),
+          hint: NoDupeClassMembersHint::RenameOrRemove,
+        },
+        {
+          line: 4,
+          col: 2,
+          message: variant!(NoDupeClassMembersMessage, Duplicate, "65"),
+          hint: NoDupeClassMembersHint::RenameOrRemove,
+        }
+      ],
       r#"
 class Foo {
   [123n]() {}
   123() {}
 }
-      "#,
-      vec![(3, 2), (4, 2)],
-    );
-
-    assert_lint_err_on_line_n::<NoDupeClassMembers>(
+      "#: [
+        {
+          line: 3,
+          col: 2,
+          message: variant!(NoDupeClassMembersMessage, Duplicate, "123"),
+          hint: NoDupeClassMembersHint::RenameOrRemove,
+        },
+        {
+          line: 4,
+          col: 2,
+          message: variant!(NoDupeClassMembersMessage, Duplicate, "123"),
+          hint: NoDupeClassMembersHint::RenameOrRemove,
+        }
+      ],
       r#"
 class Foo {
   [null]() {}
   'null'() {}
 }
-      "#,
-      vec![(3, 2), (4, 2)],
-    );
-
-    assert_lint_err_on_line_n::<NoDupeClassMembers>(
+      "#: [
+        {
+          line: 3,
+          col: 2,
+          message: variant!(NoDupeClassMembersMessage, Duplicate, "null"),
+          hint: NoDupeClassMembersHint::RenameOrRemove,
+        },
+        {
+          line: 4,
+          col: 2,
+          message: variant!(NoDupeClassMembersMessage, Duplicate, "null"),
+          hint: NoDupeClassMembersHint::RenameOrRemove,
+        }
+      ],
       r#"
 class Foo {
   bar() {}
   get bar() {}
 }
-      "#,
-      vec![(3, 2), (4, 2)],
-    );
-
-    assert_lint_err_on_line_n::<NoDupeClassMembers>(
+      "#: [
+        {
+          line: 3,
+          col: 2,
+          message: variant!(NoDupeClassMembersMessage, Duplicate, "bar"),
+          hint: NoDupeClassMembersHint::RenameOrRemove,
+        },
+        {
+          line: 4,
+          col: 2,
+          message: variant!(NoDupeClassMembersMessage, Duplicate, "bar"),
+          hint: NoDupeClassMembersHint::RenameOrRemove,
+        }
+      ],
       r#"
 class Foo {
   bar() {}
   bar() {}
   get bar() {}
 }
-      "#,
-      vec![(3, 2), (4, 2), (5, 2)],
-    );
-
-    assert_lint_err_on_line_n::<NoDupeClassMembers>(
+      "#: [
+        {
+          line: 3,
+          col: 2,
+          message: variant!(NoDupeClassMembersMessage, Duplicate, "bar"),
+          hint: NoDupeClassMembersHint::RenameOrRemove,
+        },
+        {
+          line: 4,
+          col: 2,
+          message: variant!(NoDupeClassMembersMessage, Duplicate, "bar"),
+          hint: NoDupeClassMembersHint::RenameOrRemove,
+        },
+        {
+          line: 5,
+          col: 2,
+          message: variant!(NoDupeClassMembersMessage, Duplicate, "bar"),
+          hint: NoDupeClassMembersHint::RenameOrRemove,
+        }
+      ],
       r#"
 class Foo {
   static bar() {}
   static bar() {}
 }
-      "#,
-      vec![(3, 2), (4, 2)],
-    );
-
-    assert_lint_err_on_line_n::<NoDupeClassMembers>(
+      "#: [
+        {
+          line: 3,
+          col: 2,
+          message: variant!(NoDupeClassMembersMessage, Duplicate, "bar"),
+          hint: NoDupeClassMembersHint::RenameOrRemove,
+        },
+        {
+          line: 4,
+          col: 2,
+          message: variant!(NoDupeClassMembersMessage, Duplicate, "bar"),
+          hint: NoDupeClassMembersHint::RenameOrRemove,
+        }
+      ],
       r#"
 class Foo {
   set bar(value: number) {}
   bar() {}
 }
-      "#,
-      vec![(3, 2), (4, 2)],
-    );
-
-    assert_lint_err_on_line_n::<NoDupeClassMembers>(
+      "#: [
+        {
+          line: 3,
+          col: 2,
+          message: variant!(NoDupeClassMembersMessage, Duplicate, "bar"),
+          hint: NoDupeClassMembersHint::RenameOrRemove,
+        },
+        {
+          line: 4,
+          col: 2,
+          message: variant!(NoDupeClassMembersMessage, Duplicate, "bar"),
+          hint: NoDupeClassMembersHint::RenameOrRemove,
+        }
+      ],
       r#"
 class Foo {
   foo() {
@@ -691,11 +940,20 @@ class Foo {
     }
   }
 }
-      "#,
-      vec![(5, 6), (6, 6)],
-    );
-
-    assert_lint_err_on_line_n::<NoDupeClassMembers>(
+      "#: [
+        {
+          line: 5,
+          col: 6,
+          message: variant!(NoDupeClassMembersMessage, Duplicate, "bar"),
+          hint: NoDupeClassMembersHint::RenameOrRemove,
+        },
+        {
+          line: 6,
+          col: 6,
+          message: variant!(NoDupeClassMembersMessage, Duplicate, "bar"),
+          hint: NoDupeClassMembersHint::RenameOrRemove,
+        }
+      ],
       r#"
 class Foo {
   bar(v1: number): number;
@@ -703,8 +961,20 @@ class Foo {
   bar(v1: number | string, v2?: boolean): number | string {}
   set bar(value: number) {}
 }
-      "#,
-      vec![(5, 2), (6, 2)],
-    );
+      "#: [
+        {
+          line: 5,
+          col: 2,
+          message: variant!(NoDupeClassMembersMessage, Duplicate, "bar"),
+          hint: NoDupeClassMembersHint::RenameOrRemove,
+        },
+        {
+          line: 6,
+          col: 2,
+          message: variant!(NoDupeClassMembersMessage, Duplicate, "bar"),
+          hint: NoDupeClassMembersHint::RenameOrRemove,
+        }
+      ]
+    };
   }
 }


### PR DESCRIPTION
Part of #431