### PR TITLE
refactor(no-extra-non-null-assertion): switch to `asset_lint_err!` macro

### DIFF
--- a/src/rules/no_extra_non_null_assertion.rs
+++ b/src/rules/no_extra_non_null_assertion.rs
@@ -147,7 +147,6 @@ impl<'c> Visit for NoExtraNonNullAssertionVisitor<'c> {
 #[cfg(test)]
 mod tests {
   use super::*;
-  use crate::test_util::*;
 
   #[test]
   fn no_extra_non_null_assertion_valid() {
@@ -162,33 +161,57 @@ mod tests {
 
   #[test]
   fn no_extra_non_null_assertion_invalid() {
-    assert_lint_err::<NoExtraNonNullAssertion>(
-      r#"const foo: { str: string } | null = null; const bar = foo!!.str;"#,
-      54,
-    );
-    assert_lint_err::<NoExtraNonNullAssertion>(
-      r#"function foo(bar: undefined | string) { return bar!!; }"#,
-      47,
-    );
-    assert_lint_err::<NoExtraNonNullAssertion>(
-      r#"function foo(bar?: { str: string }) { return bar!?.str; }"#,
-      45,
-    );
-    assert_lint_err::<NoExtraNonNullAssertion>(
-      r#"function foo(bar?: { str: string }) { return (bar!)!.str; }"#,
-      45,
-    );
-    assert_lint_err::<NoExtraNonNullAssertion>(
-      r#"function foo(bar?: { str: string }) { return (bar!)?.str; }"#,
-      45,
-    );
-    assert_lint_err::<NoExtraNonNullAssertion>(
-      r#"function foo(bar?: { str: string }) { return bar!?.(); }"#,
-      45,
-    );
-    assert_lint_err::<NoExtraNonNullAssertion>(
-      r#"function foo(bar?: { str: string }) { return (bar!)?.(); }"#,
-      45,
-    );
+    assert_lint_err! {
+      NoExtraNonNullAssertion,
+      r#"const foo: { str: string } | null = null; const bar = foo!!.str;"#: [
+        {
+          col: 54,
+          message: NoExtraNonNullAssertionMessage::Unexpected,
+          hint: NoExtraNonNullAssertionHint::Remove,
+        }
+      ],
+      r#"function foo(bar: undefined | string) { return bar!!; }"#: [
+        {
+          col: 47,
+          message: NoExtraNonNullAssertionMessage::Unexpected,
+          hint: NoExtraNonNullAssertionHint::Remove,
+        }
+      ],
+      r#"function foo(bar?: { str: string }) { return bar!?.str; }"#: [
+        {
+          col: 45,
+          message: NoExtraNonNullAssertionMessage::Unexpected,
+          hint: NoExtraNonNullAssertionHint::Remove,
+        }
+      ],
+      r#"function foo(bar?: { str: string }) { return (bar!)!.str; }"#: [
+        {
+          col: 45,
+          message: NoExtraNonNullAssertionMessage::Unexpected,
+          hint: NoExtraNonNullAssertionHint::Remove,
+        }
+      ],
+      r#"function foo(bar?: { str: string }) { return (bar!)?.str; }"#: [
+        {
+          col: 45,
+          message: NoExtraNonNullAssertionMessage::Unexpected,
+          hint: NoExtraNonNullAssertionHint::Remove,
+        }
+      ],
+      r#"function foo(bar?: { str: string }) { return bar!?.(); }"#: [
+        {
+          col: 45,
+          message: NoExtraNonNullAssertionMessage::Unexpected,
+          hint: NoExtraNonNullAssertionHint::Remove,
+        }
+      ],
+      r#"function foo(bar?: { str: string }) { return (bar!)?.(); }"#: [
+        {
+          col: 45,
+          message: NoExtraNonNullAssertionMessage::Unexpected,
+          hint: NoExtraNonNullAssertionHint::Remove,
+        }
+      ]
+    };
   }
 }

--- a/src/rules/no_extra_non_null_assertion.rs
+++ b/src/rules/no_extra_non_null_assertion.rs
@@ -1,6 +1,7 @@
 // Copyright 2020 the Deno authors. All rights reserved. MIT license.
 use super::Context;
 use super::LintRule;
+use derive_more::Display;
 use swc_common::Span;
 use swc_ecmascript::ast::Expr;
 use swc_ecmascript::ast::ExprOrSuper;
@@ -10,6 +11,20 @@ use swc_ecmascript::visit::Node;
 use swc_ecmascript::visit::Visit;
 
 pub struct NoExtraNonNullAssertion;
+
+const CODE: &str = "no-extra-non-null-assertion";
+
+#[derive(Display)]
+enum NoExtraNonNullAssertionMessage {
+  #[display(fmt = "Extra non-null assertion is forbidden")]
+  Unexpected,
+}
+
+#[derive(Display)]
+enum NoExtraNonNullAssertionHint {
+  #[display(fmt = "Remove the extra non-null assertion operator (`!`)")]
+  Remove,
+}
 
 impl LintRule for NoExtraNonNullAssertion {
   fn new() -> Box<Self> {
@@ -21,7 +36,7 @@ impl LintRule for NoExtraNonNullAssertion {
   }
 
   fn code(&self) -> &'static str {
-    "no-extra-non-null-assertion"
+    CODE
   }
 
   fn lint_program(
@@ -74,9 +89,9 @@ impl<'c> NoExtraNonNullAssertionVisitor<'c> {
   fn add_diagnostic(&mut self, span: Span) {
     self.context.add_diagnostic_with_hint(
       span,
-      "no-extra-non-null-assertion",
-      "Extra non-null assertion is forbidden",
-      "Remove the extra non-null assertion operator (`!`)",
+      CODE,
+      NoExtraNonNullAssertionMessage::Unexpected,
+      NoExtraNonNullAssertionHint::Remove,
     );
   }
 


### PR DESCRIPTION
Part of #431

Additionally replaces Visit with VisitAll