### PR TITLE
fix(no-func-assign): handle FnExpr and nested assignments

### DIFF
--- a/src/rules/no_func_assign.rs
+++ b/src/rules/no_func_assign.rs
@@ -122,6 +122,24 @@ impl<'c> Visit for NoFuncAssignVisitor<'c> {
 mod tests {
   use super::*;
 
+  // Some tests are derived from
+  // https://github.com/eslint/eslint/blob/v7.13.0/tests/lib/rules/no-func-assign.js
+  // MIT Licensed.
+
+  #[test]
+  fn no_func_assign_valid() {
+    assert_lint_ok! {
+      NoFuncAssign,
+      "function foo() { var foo = bar; }",
+      "function foo(foo) { foo = bar; }",
+      "function foo() { var foo; foo = bar; }",
+      "var foo = () => {}; foo = bar;",
+      "var foo = function() {}; foo = bar;",
+      "var foo = function() { foo = bar; };",
+      "import bar from 'bar'; function foo() { var foo = bar; }",
+    };
+  }
+
   #[test]
   fn no_func_assign_invalid() {
     assert_lint_err! {

--- a/src/rules/no_func_assign.rs
+++ b/src/rules/no_func_assign.rs
@@ -144,6 +144,62 @@ mod tests {
   fn no_func_assign_invalid() {
     assert_lint_err! {
       NoFuncAssign,
+      "function foo() {}; foo = bar;": [
+        {
+          col: 19,
+          message: NoFuncAssignMessage::Unexpected,
+          hint: NoFuncAssignHint::RemoveOrRework,
+        }
+      ],
+      "function foo() { foo = bar; }": [
+        {
+          col: 17,
+          message: NoFuncAssignMessage::Unexpected,
+          hint: NoFuncAssignHint::RemoveOrRework,
+        }
+      ],
+      "foo = bar; function foo() { };": [
+        {
+          col: 0,
+          message: NoFuncAssignMessage::Unexpected,
+          hint: NoFuncAssignHint::RemoveOrRework,
+        }
+      ],
+      "[foo] = bar; function foo() { }": [
+        {
+          col: 0,
+          message: NoFuncAssignMessage::Unexpected,
+          hint: NoFuncAssignHint::RemoveOrRework,
+        }
+      ],
+      "({x: foo = 0} = bar); function foo() { };": [
+        {
+          col: 1,
+          message: NoFuncAssignMessage::Unexpected,
+          hint: NoFuncAssignHint::RemoveOrRework,
+        }
+      ],
+      "function foo() { [foo] = bar; }": [
+        {
+          col: 17,
+          message: NoFuncAssignMessage::Unexpected,
+          hint: NoFuncAssignHint::RemoveOrRework,
+        }
+      ],
+      "(function() { ({x: foo = 0} = bar); function foo() { }; })();": [
+        {
+          col: 15,
+          message: NoFuncAssignMessage::Unexpected,
+          hint: NoFuncAssignHint::RemoveOrRework,
+        }
+      ],
+      "var a = function foo() { foo = 123; };": [
+        {
+          col: 25,
+          message: NoFuncAssignMessage::Unexpected,
+          hint: NoFuncAssignHint::RemoveOrRework,
+        }
+      ],
       r#"
 const a = "a";
 const unused = "unused";

--- a/src/scopes.rs
+++ b/src/scopes.rs
@@ -3,9 +3,10 @@ use swc_atoms::JsWord;
 use swc_common::DUMMY_SP;
 use swc_ecmascript::ast::{
   ArrowExpr, BlockStmt, BlockStmtOrExpr, CatchClause, ClassDecl, ClassExpr,
-  DoWhileStmt, Expr, FnDecl, ForInStmt, ForOfStmt, ForStmt, Function, Ident,
-  ImportDefaultSpecifier, ImportNamedSpecifier, ImportStarAsSpecifier, Invalid,
-  Param, Pat, Program, SwitchStmt, VarDecl, VarDeclKind, WhileStmt, WithStmt,
+  DoWhileStmt, Expr, FnDecl, FnExpr, ForInStmt, ForOfStmt, ForStmt, Function,
+  Ident, ImportDefaultSpecifier, ImportNamedSpecifier, ImportStarAsSpecifier,
+  Invalid, Param, Pat, Program, SwitchStmt, VarDecl, VarDeclKind, WhileStmt,
+  WithStmt,
 };
 use swc_ecmascript::utils::find_ids;
 use swc_ecmascript::utils::ident::IdentLike;
@@ -200,6 +201,14 @@ impl Visit for Analyzer<'_> {
 
   fn visit_fn_decl(&mut self, n: &FnDecl, _: &dyn Node) {
     self.declare(BindingKind::Function, &n.ident);
+
+    self.visit_with_path(ScopeKind::Function, &n.function);
+  }
+
+  fn visit_fn_expr(&mut self, n: &FnExpr, _: &dyn Node) {
+    if let Some(ident) = &n.ident {
+      self.declare(BindingKind::Function, ident);
+    }
 
     self.visit_with_path(ScopeKind::Function, &n.function);
   }


### PR DESCRIPTION
Part of #431, #330

What's done in this PR:

- fix scope analyzer to handle `FnExpr` properly
- handle nested assignments using `VisitAll` trait
- switch to `assert_lint_err!` macro
- port tests from ESLint