### PR TITLE
fix(no-dupe-keys): deal with BigInt keys

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,8 +87,8 @@ jobs:
 
       - name: Environment
         run: |
-          echo ::set-env name=GH_ACTIONS::1
-          echo ::set-env name=RUST_BACKTRACE::full
+          echo "GH_ACTIONS=1" >> ${GITHUB_ENV}
+          echo "RUST_BACKTRACE=full" >> ${GITHUB_ENV}
 
       - name: Format
         if: contains(matrix.os, 'ubuntu')

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
           persist-credentials: false
 
       - name: Install rust
-        uses: hecrj/setup-rust-action@v1.3.3
+        uses: hecrj/setup-rust-action@v1.3.4
         with:
           rust-version: "1.47.0"
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -410,9 +410,9 @@ checksum = "dc6f3ad7b9d11a0c00842ff8de1b60ee58661048eb8049ed33c73594f359d7e6"
 
 [[package]]
 name = "jsdoc"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02dd0a45f2fca1d284537158260931c58496103224c3780e40508d0c1e6b9f4e"
+checksum = "18e220ced55f8e93f0a3fb6b6f7c5829235299d818dac283535760a4182b5f0a"
 dependencies = [
  "nom",
  "serde",
@@ -918,9 +918,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_ast"
-version = "0.34.0"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ba29ce355bdfb942c0fb29bd1409197fa1a25ba649f13089129484ad0c83282"
+checksum = "39d14f5b7769eb53a98276475ca72d188f5fa0fbf1819d3e9241b9e295ae0542"
 dependencies = [
  "enum_kind",
  "is-macro",
@@ -933,9 +933,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_parser"
-version = "0.42.0"
+version = "0.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "136f5fddde6d78b5ae532bb0d5a0ce2f1eb1d36caea3e9b9dfcfb70693a7e23d"
+checksum = "a3fed210fea4936fad012d9953d1134302f45c75c647d2734500eac8251ac39f"
 dependencies = [
  "either",
  "enum_kind",
@@ -967,9 +967,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms"
-version = "0.29.3"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0958bbaa69e01a45a2268c398a8814014a029c0b4eaecd42f2545fcd642314e8"
+checksum = "35edb4ae1b59532c5b48fc5035067430bcfccecd84c92bda9ce2edde56c7420f"
 dependencies = [
  "Inflector",
  "arrayvec",
@@ -979,6 +979,7 @@ dependencies = [
  "is-macro",
  "jsdoc",
  "log",
+ "num-bigint",
  "once_cell",
  "ordered-float",
  "phf",
@@ -1013,9 +1014,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_utils"
-version = "0.24.0"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e09463bb646ed5f33608bd60153b604f3a894162d14dba481f1032e7d28e80d"
+checksum = "64fd3d84ee287900f37fd06a1856f57cd0d65b37bb0557abde2c91d8a9b28155"
 dependencies = [
  "once_cell",
  "scoped-tls",
@@ -1028,9 +1029,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_visit"
-version = "0.20.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0175b589eaeb5a8e6458592f82efce759c1fa0fb41dfe14f04b74c498f11f50d"
+checksum = "ee22eeb8c6987f9e740e1867292bd45785408f62ded95e1dc57b9c6c26e85a96"
 dependencies = [
  "num-bigint",
  "swc_atoms",
@@ -1041,9 +1042,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecmascript"
-version = "0.13.3"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f11d30e16321db6eb94b38ec3dd701bc4e7bd5e146aa49451b049817a250b0f1"
+checksum = "60ca662ae5809ed5b61178f797807474a094c43b45ea54f8d47e0542b45f26cf"
 dependencies = [
  "swc_ecma_ast",
  "swc_ecma_parser",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ serde = { version = "1.0.88", features = ["derive"] }
 serde_json = { version = "1.0" }
 swc_atoms = "0.2.5"
 swc_common = "=0.10.5"
-swc_ecmascript = { version = "=0.13.3", features = ["parser", "transforms", "utils", "visit"] }
+swc_ecmascript = { version = "=0.14.0", features = ["parser", "transforms", "utils", "visit"] }
 regex = "1.3.9"
 once_cell = "1.4.1"
 derive_more = { version = "0.99.11", features = ["display"] }

--- a/src/rules/no_dupe_class_members.rs
+++ b/src/rules/no_dupe_class_members.rs
@@ -163,6 +163,7 @@ fn normalize_prop_name(name: &PropName) -> Option<String> {
     PropName::Ident(Ident { ref sym, .. }) => sym.to_string(),
     PropName::Str(Str { ref value, .. }) => value.to_string(),
     PropName::Num(Number { ref value, .. }) => value.to_string(),
+    PropName::BigInt(BigInt { ref value, .. }) => value.to_string(),
     PropName::Computed(ComputedPropName { ref expr, .. }) => match &**expr {
       Expr::Lit(Lit::Str(Str { ref value, .. })) => value.to_string(),
       Expr::Lit(Lit::Bool(Bool { ref value, .. })) => value.to_string(),

--- a/src/rules/no_dupe_keys.rs
+++ b/src/rules/no_dupe_keys.rs
@@ -354,18 +354,13 @@ let x = {
           hint: NoDupeKeysHint::RemoveOrRename,
         }
       ],
-
-      // TODO(magurotuna): this leads to panic due to swc error
-      // It seems like tsc v4.0.2 cannot handle this either
-      // playground: https://www.typescriptlang.org/play?target=99&ts=4.0.2#code/MYewdgzgLgBCBGArGBeGBvAUDGBGMAXDACwBMANJgL4DcQA
-      // r#"var x = { 1n: 1, 1: 2 };"#: [
-      //   {
-      //     col: 8,
-      //     message: variant!(NoDupeKeysMessage, Duplicate, "1"),
-      //     hint: NoDupeKeysHint::RemoveOrRename,
-      //   }
-      // ],
-
+      r#"var x = { 1n: 1, 1: 2 };"#: [
+        {
+          col: 8,
+          message: variant!(NoDupeKeysMessage, Duplicate, "1"),
+          hint: NoDupeKeysHint::RemoveOrRename,
+        }
+      ],
       r#"var x = { 1_0: 1, 10: 2 };"#: [
         {
           col: 8,

--- a/src/swc_util.rs
+++ b/src/swc_util.rs
@@ -114,6 +114,7 @@ impl StringRepr for PropName {
       PropName::Ident(identifier) => Some(identifier.sym.to_string()),
       PropName::Str(str) => Some(str.value.to_string()),
       PropName::Num(num) => Some(num.to_string()),
+      PropName::BigInt(bigint) => Some(bigint.value.to_string()),
       PropName::Computed(ComputedPropName { ref expr, .. }) => match &**expr {
         Expr::Lit(lit) => lit.string_repr(),
         Expr::Tpl(tpl) => tpl.string_repr(),


### PR DESCRIPTION
Thanks to https://github.com/swc-project/swc/pull/1192, BigInt keys can be parsed correctly, which allows us to address a TODO comment in `no-dupe-keys`.

(EDIT) Plus addressed CI issues :)