### PR TITLE
refactor(no-global-assign): switch to `asset_lint_err!` macro

### DIFF
--- a/src/rules/no_global_assign.rs
+++ b/src/rules/no_global_assign.rs
@@ -187,7 +187,6 @@ impl<'c> Visit for NoGlobalAssignVisitor<'c> {
 #[cfg(test)]
 mod tests {
   use super::*;
-  use crate::test_util::*;
 
   #[test]
   fn no_global_assign_valid() {
@@ -203,14 +202,41 @@ mod tests {
 
   #[test]
   fn no_global_assign_invalid() {
-    assert_lint_err::<NoGlobalAssign>("String = 'hello world';", 0);
-
-    assert_lint_err::<NoGlobalAssign>("String++;", 0);
-
-    assert_lint_err_n::<NoGlobalAssign>(
-      "({Object = 0, String = 0} = {});",
-      vec![2, 14],
-    );
-    assert_lint_err::<NoGlobalAssign>("Array = 1;", 0);
+    assert_lint_err! {
+      NoGlobalAssign,
+      "String = 'hello world';": [
+        {
+          col: 0,
+          message: NoGlobalAssignMessage::NotAllowed,
+          hint: NoGlobalAssignHint::Remove,
+        }
+      ],
+      "String++;": [
+        {
+          col: 0,
+          message: NoGlobalAssignMessage::NotAllowed,
+          hint: NoGlobalAssignHint::Remove,
+        }
+      ],
+      "({Object = 0, String = 0} = {});": [
+        {
+          col: 2,
+          message: NoGlobalAssignMessage::NotAllowed,
+          hint: NoGlobalAssignHint::Remove,
+        },
+        {
+          col: 14,
+          message: NoGlobalAssignMessage::NotAllowed,
+          hint: NoGlobalAssignHint::Remove,
+        }
+      ],
+      "Array = 1;": [
+        {
+          col: 0,
+          message: NoGlobalAssignMessage::NotAllowed,
+          hint: NoGlobalAssignHint::Remove,
+        }
+      ],
+    };
   }
 }

--- a/src/rules/no_global_assign.rs
+++ b/src/rules/no_global_assign.rs
@@ -1,5 +1,6 @@
 use super::LintRule;
 use crate::{globals::GLOBALS, linter::Context, swc_util::find_lhs_ids};
+use derive_more::Display;
 use std::collections::HashSet;
 use swc_common::Span;
 use swc_ecmascript::{
@@ -13,6 +14,20 @@ use swc_ecmascript::{
 
 pub struct NoGlobalAssign;
 
+const CODE: &str = "no-global-assign";
+
+#[derive(Display)]
+enum NoGlobalAssignMessage {
+  #[display(fmt = "Assignment to global is not allowed")]
+  NotAllowed,
+}
+
+#[derive(Display)]
+enum NoGlobalAssignHint {
+  #[display(fmt = "Remove the assignment to the global variable")]
+  Remove,
+}
+
 impl LintRule for NoGlobalAssign {
   fn new() -> Box<Self> {
     Box::new(NoGlobalAssign)
@@ -23,7 +38,7 @@ impl LintRule for NoGlobalAssign {
   }
 
   fn code(&self) -> &'static str {
-    "no-global-assign"
+    CODE
   }
 
   fn lint_program(
@@ -140,9 +155,9 @@ impl<'c> NoGlobalAssignVisitor<'c> {
       if !global.1 {
         self.context.add_diagnostic_with_hint(
           span,
-          "no-global-assign",
-          "Assignment to global is not allowed",
-          "Remove the assignment to the global variable",
+          CODE,
+          NoGlobalAssignMessage::NotAllowed,
+          NoGlobalAssignHint::Remove,
         );
       }
     }


### PR DESCRIPTION
Part of #431 