### PR TITLE
refactor(no-inner-declarations): switch to `asset_lint_err!` macro

### DIFF
--- a/src/rules/no_inner_declarations.rs
+++ b/src/rules/no_inner_declarations.rs
@@ -277,7 +277,6 @@ impl<'c> Visit for NoInnerDeclarationsVisitor<'c> {
 #[cfg(test)]
 mod tests {
   use super::*;
-  use crate::test_util::*;
 
   #[test]
   fn no_inner_declarations_valid() {
@@ -311,55 +310,129 @@ mod tests {
 
   #[test]
   fn no_inner_declarations_invalid() {
-    // fn decls
-    assert_lint_err::<NoInnerDeclarations>(
-      "if (test) { function doSomething() { } }",
-      12,
-    );
-    assert_lint_err::<NoInnerDeclarations>("if (foo)  function f(){} ", 10);
-    assert_lint_err::<NoInnerDeclarations>(
-      "function bar() { if (foo) function f(){}; }",
-      26,
-    );
-    assert_lint_err::<NoInnerDeclarations>("function doSomething() { do { function somethingElse() { } } while (test); }", 30);
-    assert_lint_err::<NoInnerDeclarations>(
-      "(function() { if (test) { function doSomething() { } } }());",
-      26,
-    );
+    assert_lint_err! {
+      NoInnerDeclarations,
 
-    // var decls
-    assert_lint_err::<NoInnerDeclarations>("if (foo) var a; ", 9);
-    assert_lint_err::<NoInnerDeclarations>(
-      "if (foo) /* some comments */ var a; ",
-      29,
-    );
-    assert_lint_err::<NoInnerDeclarations>(
-      "function bar() { if (foo) var a; }",
-      26,
-    );
-    assert_lint_err::<NoInnerDeclarations>("if (foo){ var a; }", 10);
-    assert_lint_err::<NoInnerDeclarations>("while (test) { var foo; }", 15);
-    assert_lint_err::<NoInnerDeclarations>(
-      "function doSomething() { if (test) { var foo = 42; } }",
-      37,
-    );
-    assert_lint_err::<NoInnerDeclarations>(
-      "(function() { if (test) { var foo; } }());",
-      26,
-    );
-    assert_lint_err::<NoInnerDeclarations>(
-      "const doSomething = () => { if (test) { var foo = 42; } }",
-      40,
-    );
+      // fn decls
+      "if (test) { function doSomething() { } }": [
+        {
+          col: 12,
+          message: variant!(NoInnerDeclarationsMessage, Move, "function", "module"),
+          hint: NoInnerDeclarationsHint::Move,
+        }
+      ],
+      "if (foo)  function f(){} ": [
+        {
+          col: 10,
+          message: variant!(NoInnerDeclarationsMessage, Move, "function", "module"),
+          hint: NoInnerDeclarationsHint::Move,
+        }
+      ],
+      "function bar() { if (foo) function f(){}; }": [
+        {
+          col: 26,
+          message: variant!(NoInnerDeclarationsMessage, Move, "function", "function"),
+          hint: NoInnerDeclarationsHint::Move,
+        }
+      ],
+      "function doSomething() { do { function somethingElse() { } } while (test); }": [
+        {
+          col: 30,
+          message: variant!(NoInnerDeclarationsMessage, Move, "function", "function"),
+          hint: NoInnerDeclarationsHint::Move,
+        }
+      ],
+      "(function() { if (test) { function doSomething() { } } }());": [
+        {
+          col: 26,
+          message: variant!(NoInnerDeclarationsMessage, Move, "function", "function"),
+          hint: NoInnerDeclarationsHint::Move,
+        }
+      ],
 
-    // both
-    assert_lint_err_n::<NoInnerDeclarations>(
-      "if (foo){ function f(){ if(bar){ var a; } } }",
-      vec![10, 33],
-    );
-    assert_lint_err_n::<NoInnerDeclarations>(
-      "if (foo) function f(){ if(bar) var a; } ",
-      vec![9, 31],
-    );
+      // var decls
+      "if (foo) var a; ": [
+        {
+          col: 9,
+          message: variant!(NoInnerDeclarationsMessage, Move, "variable", "module"),
+          hint: NoInnerDeclarationsHint::Move,
+        }
+      ],
+      "if (foo) /* some comments */ var a; ": [
+        {
+          col: 29,
+          message: variant!(NoInnerDeclarationsMessage, Move, "variable", "module"),
+          hint: NoInnerDeclarationsHint::Move,
+        }
+      ],
+      "function bar() { if (foo) var a; }": [
+        {
+          col: 26,
+          message: variant!(NoInnerDeclarationsMessage, Move, "variable", "function"),
+          hint: NoInnerDeclarationsHint::Move,
+        }
+      ],
+      "if (foo){ var a; }": [
+        {
+          col: 10,
+          message: variant!(NoInnerDeclarationsMessage, Move, "variable", "module"),
+          hint: NoInnerDeclarationsHint::Move,
+        }
+      ],
+      "while (test) { var foo; }": [
+        {
+          col: 15,
+          message: variant!(NoInnerDeclarationsMessage, Move, "variable", "module"),
+          hint: NoInnerDeclarationsHint::Move,
+        }
+      ],
+      "function doSomething() { if (test) { var foo = 42; } }": [
+        {
+          col: 37,
+          message: variant!(NoInnerDeclarationsMessage, Move, "variable", "function"),
+          hint: NoInnerDeclarationsHint::Move,
+        }
+      ],
+      "(function() { if (test) { var foo; } }());": [
+        {
+          col: 26,
+          message: variant!(NoInnerDeclarationsMessage, Move, "variable", "function"),
+          hint: NoInnerDeclarationsHint::Move,
+        }
+      ],
+      "const doSomething = () => { if (test) { var foo = 42; } }": [
+        {
+          col: 40,
+          message: variant!(NoInnerDeclarationsMessage, Move, "variable", "function"),
+          hint: NoInnerDeclarationsHint::Move,
+        }
+      ],
+
+      // both
+      "if (foo){ function f(){ if(bar){ var a; } } }": [
+        {
+          col: 10,
+          message: variant!(NoInnerDeclarationsMessage, Move, "function", "module"),
+          hint: NoInnerDeclarationsHint::Move,
+        },
+        {
+          col: 33,
+          message: variant!(NoInnerDeclarationsMessage, Move, "variable", "function"),
+          hint: NoInnerDeclarationsHint::Move,
+        }
+      ],
+      "if (foo) function f(){ if(bar) var a; } ": [
+        {
+          col: 9,
+          message: variant!(NoInnerDeclarationsMessage, Move, "function", "module"),
+          hint: NoInnerDeclarationsHint::Move,
+        },
+        {
+          col: 31,
+          message: variant!(NoInnerDeclarationsMessage, Move, "variable", "function"),
+          hint: NoInnerDeclarationsHint::Move,
+        }
+      ]
+    };
   }
 }

--- a/src/rules/no_inner_declarations.rs
+++ b/src/rules/no_inner_declarations.rs
@@ -1,5 +1,6 @@
 use super::Context;
 use super::LintRule;
+use derive_more::Display;
 use swc_common::Span;
 use swc_common::Spanned;
 use swc_ecmascript::ast;
@@ -8,6 +9,20 @@ use swc_ecmascript::visit::Node;
 use swc_ecmascript::visit::Visit;
 
 pub struct NoInnerDeclarations;
+
+const CODE: &str = "no-inner-declarations";
+
+#[derive(Display)]
+enum NoInnerDeclarationsMessage {
+  #[display(fmt = "Move {} declaration to {} root", _0, _1)]
+  Move(String, String),
+}
+
+#[derive(Display)]
+enum NoInnerDeclarationsHint {
+  #[display(fmt = "Move the declaration up into the correct scope")]
+  Move,
+}
 
 impl LintRule for NoInnerDeclarations {
   fn new() -> Box<Self> {
@@ -19,7 +34,7 @@ impl LintRule for NoInnerDeclarations {
   }
 
   fn code(&self) -> &'static str {
-    "no-inner-declarations"
+    CODE
   }
 
   fn lint_program(&self, context: &mut Context, program: &ast::Program) {
@@ -214,9 +229,9 @@ impl<'c> NoInnerDeclarationsVisitor<'c> {
 
     self.context.add_diagnostic_with_hint(
       span,
-      "no-inner-declarations",
-      format!("Move {} declaration to {} root", kind, root),
-      "Move the declaration up into the correct scope",
+      CODE,
+      NoInnerDeclarationsMessage::Move(kind.to_string(), root.to_string()),
+      NoInnerDeclarationsHint::Move,
     );
   }
 }


### PR DESCRIPTION
Part of #431 

Additionally, I refactored the following things:

- replace `Vec` with `HashSet` for efficiency
- use `VisitAll` instead of `Visit` in `ValidDeclsVisitor`
- import `swc_ecmascript_ast` items explicitly to be consistent with other rules