### PR TITLE
feat(plugin): expose ControlFlow to JS

### DIFF
--- a/examples/dlint/control-flow.js
+++ b/examples/dlint/control-flow.js
@@ -1,0 +1,18 @@
+class ControlFlow {
+  static isReachable(stmt) {
+    const { isReachable } = Deno.core.jsonOpSync("query_control_flow_by_span", {
+      span: stmt.span,
+    });
+    return isReachable;
+  }
+
+  static stopsExecution(stmt) {
+    const { stopsExectuion } = Deno.core.jsonOpSync(
+      "query_control_flow_by_span",
+      {
+        span: stmt.span,
+      }
+    );
+    return stopsExectuion;
+  }
+}

--- a/examples/dlint/control-flow.js
+++ b/examples/dlint/control-flow.js
@@ -1,14 +1,17 @@
 class ControlFlow {
   static isReachable(stmt) {
-    const { isReachable } = Deno.core.jsonOpSync("query_control_flow_by_span", {
-      span: stmt.span,
-    });
+    const { isReachable } = Deno.core.jsonOpSync(
+      "op_query_control_flow_by_span",
+      {
+        span: stmt.span,
+      }
+    );
     return isReachable;
   }
 
   static stopsExecution(stmt) {
     const { stopsExectuion } = Deno.core.jsonOpSync(
-      "query_control_flow_by_span",
+      "op_query_control_flow_by_span",
       {
         span: stmt.span,
       }

--- a/examples/dlint/js.rs
+++ b/examples/dlint/js.rs
@@ -122,13 +122,15 @@ impl JsRuleRunner {
       .execute("control-flow.js", include_str!("control-flow.js"))
       .unwrap();
     runtime.register_op(
-      "add_diagnostics",
+      "op_add_diagnostics",
       deno_core::json_op_sync(op_add_diagnostics),
     );
-    runtime
-      .register_op("add_rule_code", deno_core::json_op_sync(op_add_rule_code));
     runtime.register_op(
-      "query_control_flow_by_span",
+      "op_add_rule_code",
+      deno_core::json_op_sync(op_add_rule_code),
+    );
+    runtime.register_op(
+      "op_query_control_flow_by_span",
       deno_core::json_op_sync(op_query_control_flow_by_span),
     );
 
@@ -245,7 +247,7 @@ const rules = new Map();
 function registerRule(ruleClass) {
   const code = ruleClass.ruleCode();
   rules.set(code, ruleClass);
-  Deno.core.jsonOpSync('add_rule_code', { code });
+  Deno.core.jsonOpSync('op_add_rule_code', { code });
 }
 globalThis.runPlugins = function(programAst, ruleCodes) {
   for (const code of ruleCodes) {
@@ -254,7 +256,7 @@ globalThis.runPlugins = function(programAst, ruleCodes) {
       continue;
     }
     const diagnostics = new rule().collectDiagnostics(programAst);
-    Deno.core.jsonOpSync('add_diagnostics', { code, diagnostics });
+    Deno.core.jsonOpSync('op_add_diagnostics', { code, diagnostics });
   }
 };
 registerRule(Plugin);
@@ -277,7 +279,7 @@ const rules = new Map();
 function registerRule(ruleClass) {
   const code = ruleClass.ruleCode();
   rules.set(code, ruleClass);
-  Deno.core.jsonOpSync('add_rule_code', { code });
+  Deno.core.jsonOpSync('op_add_rule_code', { code });
 }
 globalThis.runPlugins = function(programAst, ruleCodes) {
   for (const code of ruleCodes) {
@@ -286,7 +288,7 @@ globalThis.runPlugins = function(programAst, ruleCodes) {
       continue;
     }
     const diagnostics = new rule().collectDiagnostics(programAst);
-    Deno.core.jsonOpSync('add_diagnostics', { code, diagnostics });
+    Deno.core.jsonOpSync('op_add_diagnostics', { code, diagnostics });
   }
 };
 registerRule(Plugin);

--- a/examples/dlint/plugins/test_plugin3.js
+++ b/examples/dlint/plugins/test_plugin3.js
@@ -1,0 +1,19 @@
+export default class LintRule extends Visitor {
+  static ruleCode() {
+    return "no-unreachable-return-statement";
+  }
+
+  visitReturnStatement(stmt) {
+    /** @type {(boolean|null)} */
+    const reachable = ControlFlow.isReachable(stmt);
+
+    if (reachable === false) {
+      this.addDiagnostic({
+        span: stmt.span,
+        message: "unreachable return statement detected",
+      });
+    }
+
+    return stmt;
+  }
+}

--- a/src/control_flow.rs
+++ b/src/control_flow.rs
@@ -9,7 +9,7 @@ use swc_ecmascript::{
   visit::{noop_visit_type, Node, Visit, VisitWith},
 };
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct ControlFlow {
   meta: BTreeMap<BytePos, Metadata>,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,9 @@ extern crate log;
 mod test_util;
 
 pub mod ast_parser;
-mod control_flow;
+// TODO(magurotuna): Making control_flow public is just needed for implementing plugin prototype.
+// It will be likely possible to remove `pub` later.
+pub mod control_flow;
 pub mod diagnostic;
 mod globals;
 mod ignore_directives;

--- a/src/linter.rs
+++ b/src/linter.rs
@@ -32,7 +32,9 @@ pub struct Context {
   pub(crate) trailing_comments: HashMap<BytePos, Vec<Comment>>,
   pub ignore_directives: RefCell<Vec<IgnoreDirective>>,
   pub(crate) scope: Scope,
-  pub(crate) control_flow: ControlFlow,
+  // TODO(magurotuna): Making control_flow public is just needed for implementing plugin prototype.
+  // It will be likely possible to revert it to `pub(crate)` later.
+  pub control_flow: ControlFlow,
   pub(crate) top_level_ctxt: SyntaxContext,
 }
 


### PR DESCRIPTION
PoC

Let's say we have `foo.js` with the following content:

```javascript
function f() {
  return 1;
  return "f";
}

function g() {
  throw new Error();
  return "g";
}
```

running `cargo run --example dlint -- run foo.ts --plugin ./examples/dlint/plugins/test_plugin3.js`, then we can see:

![image](https://user-images.githubusercontent.com/23649474/101509096-bc8da880-39bb-11eb-98f5-552158dcc98a.png)
