### PR TITLE
fix(prefer-as-const): handle `var_decl` that has no `decl`

### DIFF
--- a/src/rules/prefer_as_const.rs
+++ b/src/rules/prefer_as_const.rs
@@ -5,8 +5,8 @@ use super::LintRule;
 use derive_more::Display;
 use swc_common::{Span, Spanned};
 use swc_ecmascript::ast::{
-  ArrayPat, Expr, Ident, Lit, ObjectPat, Pat, TsAsExpr, TsLit, TsType,
-  TsTypeAssertion, VarDecl,
+  ArrayPat, Expr, Ident, Lit, ObjectPat, Pat, Program, TsAsExpr, TsLit, TsType,
+  TsTypeAnn, TsTypeAssertion, VarDecl,
 };
 use swc_ecmascript::visit::Node;
 use swc_ecmascript::visit::{VisitAll, VisitAllWith};
@@ -42,11 +42,7 @@ impl LintRule for PreferAsConst {
     CODE
   }
 
-  fn lint_program(
-    &self,
-    context: &mut Context,
-    program: &swc_ecmascript::ast::Program,
-  ) {
+  fn lint_program(&self, context: &mut Context, program: &Program) {
     let mut visitor = PreferAsConstVisitor::new(context);
     program.visit_all_with(program, &mut visitor);
   }
@@ -61,7 +57,7 @@ impl<'c> PreferAsConstVisitor<'c> {
     Self { context }
   }
 
-  fn add_diagnostic_helper(&mut self, span: swc_common::Span) {
+  fn add_diagnostic_helper(&mut self, span: Span) {
     self.context.add_diagnostic_with_hint(
       span,
       CODE,
@@ -116,9 +112,7 @@ impl<'c> VisitAll for PreferAsConstVisitor<'c> {
         | Pat::Object(ObjectPat { type_ann, .. })
         | Pat::Ident(Ident { type_ann, .. }) = &decl.name
         {
-          if let Some(swc_ecmascript::ast::TsTypeAnn { type_ann, .. }) =
-            &type_ann
-          {
+          if let Some(TsTypeAnn { type_ann, .. }) = &type_ann {
             self.compare(type_ann, &init, type_ann.span());
           }
         }

--- a/src/rules/prefer_as_const.rs
+++ b/src/rules/prefer_as_const.rs
@@ -80,8 +80,8 @@ impl<'c> PreferAsConstVisitor<'c> {
             }
           }
           (Lit::Num(value_literal), TsLit::Number(type_literal)) => {
-            let error = 0.01f64;
-            if (value_literal.value - type_literal.value).abs() < error {
+            // `value` of swc_ecma_ast::lit::Number is *never* NaN, according to the doc.
+            if value_literal.value == type_literal.value {
               self.add_diagnostic_helper(span)
             }
           }
@@ -241,6 +241,13 @@ mod tests {
       "let foo = 5 as 5;": [
         {
           col: 15,
+          message: PreferAsConstMessage::ExpectedConstAssertion,
+          hint: PreferAsConstHint::AddAsConst,
+        }
+      ],
+      "let foo: 1.23456 = 1.23456;": [
+        {
+          col: 9,
           message: PreferAsConstMessage::ExpectedConstAssertion,
           hint: PreferAsConstHint::AddAsConst,
         }

--- a/src/rules/prefer_as_const.rs
+++ b/src/rules/prefer_as_const.rs
@@ -76,8 +76,7 @@ impl<'c> PreferAsConstVisitor<'c> {
             }
           }
           (Lit::Num(value_literal), TsLit::Number(type_literal)) => {
-            // `value` of swc_ecma_ast::lit::Number is *never* NaN, according to the doc.
-            if value_literal.value == type_literal.value {
+            if (value_literal.value - type_literal.value).abs() < f64::EPSILON {
               self.add_diagnostic_helper(span)
             }
           }

--- a/src/rules/prefer_as_const.rs
+++ b/src/rules/prefer_as_const.rs
@@ -150,7 +150,6 @@ impl<'c> Visit for PreferAsConstVisitor<'c> {
 #[cfg(test)]
 mod tests {
   use super::*;
-  use crate::test_util::*;
 
   #[test]
   fn prefer_as_const_valid() {
@@ -187,19 +186,85 @@ mod tests {
 
   #[test]
   fn prefer_as_const_invalid() {
-    assert_lint_err::<PreferAsConst>(
-      r#"let foo = { bar: "baz" as "baz" };"#,
-      17,
-    );
-    assert_lint_err::<PreferAsConst>(r#"let foo = { bar: 1 as 1 };"#, 17);
-    assert_lint_err::<PreferAsConst>(r#"let [x]: "bar" = "bar";"#, 0);
-    assert_lint_err::<PreferAsConst>(r#"let {x}: "bar" = "bar";"#, 0);
-    assert_lint_err::<PreferAsConst>(r#"let foo: "bar" = "bar";"#, 0);
-    assert_lint_err::<PreferAsConst>(r#"let foo: 2 = 2;"#, 0);
-    assert_lint_err::<PreferAsConst>(r#"let foo: "bar" = "bar" as "bar";"#, 17);
-    assert_lint_err::<PreferAsConst>(r#"let foo = <"bar">"bar";"#, 10);
-    assert_lint_err::<PreferAsConst>(r#"let foo = <4>4;"#, 10);
-    assert_lint_err::<PreferAsConst>(r#"let foo = "bar" as "bar";"#, 10);
-    assert_lint_err::<PreferAsConst>(r#"let foo = 5 as 5;"#, 10);
+    assert_lint_err! {
+      PreferAsConst,
+      "let foo = { bar: 'baz' as 'baz' };": [
+        {
+          col: 17,
+          message: PreferAsConstMessage::ExpectedConstAssertion,
+          hint: PreferAsConstHint::AddAsConst,
+        }
+      ],
+      "let foo = { bar: 1 as 1 };": [
+        {
+          col: 17,
+          message: PreferAsConstMessage::ExpectedConstAssertion,
+          hint: PreferAsConstHint::AddAsConst,
+        }
+      ],
+      "let [x]: 'bar' = 'bar';": [
+        {
+          col: 0,
+          message: PreferAsConstMessage::ExpectedConstAssertion,
+          hint: PreferAsConstHint::AddAsConst,
+        }
+      ],
+      "let {x}: 'bar' = 'bar';": [
+        {
+          col: 0,
+          message: PreferAsConstMessage::ExpectedConstAssertion,
+          hint: PreferAsConstHint::AddAsConst,
+        }
+      ],
+      "let foo: 'bar' = 'bar';": [
+        {
+          col: 0,
+          message: PreferAsConstMessage::ExpectedConstAssertion,
+          hint: PreferAsConstHint::AddAsConst,
+        }
+      ],
+      "let foo: 2 = 2;": [
+        {
+          col: 0,
+          message: PreferAsConstMessage::ExpectedConstAssertion,
+          hint: PreferAsConstHint::AddAsConst,
+        }
+      ],
+      "let foo: 'bar' = 'bar' as 'bar';": [
+        {
+          col: 17,
+          message: PreferAsConstMessage::ExpectedConstAssertion,
+          hint: PreferAsConstHint::AddAsConst,
+        }
+      ],
+      "let foo = <'bar'>'bar';": [
+        {
+          col: 10,
+          message: PreferAsConstMessage::ExpectedConstAssertion,
+          hint: PreferAsConstHint::AddAsConst,
+        }
+      ],
+      "let foo = <4>4;": [
+        {
+          col: 10,
+          message: PreferAsConstMessage::ExpectedConstAssertion,
+          hint: PreferAsConstHint::AddAsConst,
+        }
+      ],
+      "let foo = 'bar' as 'bar';": [
+        {
+          col: 10,
+          message: PreferAsConstMessage::ExpectedConstAssertion,
+          hint: PreferAsConstHint::AddAsConst,
+        }
+      ],
+      "let foo = 5 as 5;": [
+        {
+          col: 10,
+          message: PreferAsConstMessage::ExpectedConstAssertion,
+          hint: PreferAsConstHint::AddAsConst,
+        }
+      ],
+    };
   }
 }


### PR DESCRIPTION
Fixes #567 

~~I'll undraft it after some more refinement.~~

Refs:
#431 #330 