### PR TITLE
fix(valid-typeof): allow comparison with variables other than undefined, null, Object

### DIFF
--- a/src/rules/valid_typeof.rs
+++ b/src/rules/valid_typeof.rs
@@ -42,7 +42,7 @@ When used with a value the `typeof` operator returns one of the following string
 - `"symbol"`
 - `"bigint"`
 
-This rule disallows comparison with anything other than one of these string literals when using the `typeof` operator, as this likely represents a typing mistake in the string. The rule also disallows comparing the result of a `typeof` operation with any non-string literal value, such as `undefined`, which can represent an inadvertent use of a keyword instead of a string. This includes comparing against string variables even if they contain one of the above values as this cannot be guaranteed. An exception to this is comparing the results of two `typeof` operations as these are both guaranteed to return on of the above strings.
+This rule disallows comparison with anything other than one of these string literals when using the `typeof` operator, as this likely represents a typing mistake in the string. The rule also disallows comparing the result of a `typeof` operation with any non-string literal value i.e. `Object`, `undefined` or `null`, which can represent an inadvertent use of a keyword instead of a string.
 
 ### Invalid:
 ```typescript
@@ -52,19 +52,19 @@ typeof foo === "strnig"
 typeof foo == "undefimed"
 ```
 ```typescript
-typeof bar != "nunber"
+typeof foo != "nunber"
 ```
 ```typescript
-typeof bar !== "fucntion"
+typeof foo !== `fucntion`
+```
+```typescript
+typeof foo == Object
 ```
 ```typescript
 typeof foo === undefined
 ```
 ```typescript
-typeof bar == Object
-```
-```typescript
-typeof baz === anotherVariable
+typeof foo === null
 ```
 ```typescript
 typeof foo == 5
@@ -75,14 +75,24 @@ typeof foo == 5
 typeof foo === "undefined"
 ```
 ```typescript
-typeof bar == "object"
+typeof foo == "object"
 ```
 ```typescript
-typeof baz === "string"
+typeof foo !== "string"
 ```
 ```typescript
-typeof bar === typeof qux
-```"#
+typeof foo != typeof qux
+```
+```typescript
+typeof foo === anotherVariable
+```
+```typescript
+typeof foo === `bigint`
+```
+```typescript
+typeof foo === `object${bar}`
+```
+"#
   }
 }
 

--- a/src/rules/valid_typeof.rs
+++ b/src/rules/valid_typeof.rs
@@ -159,11 +159,34 @@ mod tests {
   fn valid_typeof_valid() {
     assert_lint_ok! {
       ValidTypeof,
-      r#"
-typeof foo === "string"
-typeof bar == "undefined"
-      "#,
-      r#"typeof bar === typeof qux"#,
+        "typeof foo === 'string'",
+        "typeof foo === 'object'",
+        "typeof foo === 'function'",
+        "typeof foo === 'undefined'",
+        "typeof foo === 'boolean'",
+        "typeof foo === 'number'",
+        "typeof foo === 'bigint'",
+        "'string' === typeof foo",
+        "'object' === typeof foo",
+        "'function' === typeof foo",
+        "'undefined' === typeof foo",
+        "'boolean' === typeof foo",
+        "'number' === typeof foo",
+        "typeof foo === typeof bar",
+        "typeof foo === baz",
+        "typeof foo === Object",
+        "typeof foo === undefined",
+        "typeof foo !== someType",
+        "typeof bar != someType",
+        "someType === typeof bar",
+        "someType == typeof bar",
+        "typeof foo == 'string'",
+        "typeof(foo) === 'string'",
+        "typeof(foo) !== 'string'",
+        "typeof(foo) == 'string'",
+        "typeof(foo) != 'string'",
+        "var oddUse = typeof foo + 'thing'",
+        "typeof foo === `str${somethingElse}`",
     };
   }
 
@@ -171,31 +194,71 @@ typeof bar == "undefined"
   fn valid_typeof_invalid() {
     assert_lint_err! {
       ValidTypeof,
-      r#"typeof foo === "strnig""#: [{
+      "typeof foo === 'strnig'": [{
         col: 15,
         message: MESSAGE
       }],
-      r#"typeof foo == "undefimed""#: [{
-        col: 14,
+      "'strnig' === typeof foo": [{
+        col: 0,
         message: MESSAGE
       }],
-      r#"typeof bar != "nunber""#: [{
-        col: 14,
-        message: MESSAGE
-      }],
-      r#"typeof bar !== "fucntion""#: [{
+      "typeof foo !== 'strnig'": [{
         col: 15,
         message: MESSAGE
       }],
-      r#"typeof foo === undefined"#: [{
-        col: 15,
+      "'strnig' !== typeof foo": [{
+        col: 0,
         message: MESSAGE
       }],
-      r#"typeof bar == Object"#: [{
+      "typeof foo == 'undefimed'": [{
         col: 14,
         message: MESSAGE
       }],
-      r#"typeof baz === anotherVariable"#: [{
+      "typeof foo != 'undefimed'": [{
+        col: 14,
+        message: MESSAGE
+      }],
+      "if (typeof foo === 'undefimed') {}": [{
+        col: 19,
+        message: MESSAGE
+      }],
+      "if (typeof foo !== 'undefimed') {}": [{
+        col: 19,
+        message: MESSAGE
+      }],
+      "if ('undefimed' === typeof foo) {}": [{
+        col: 4,
+        message: MESSAGE
+      }],
+      "if ('undefimed' !== typeof foo) {}": [{
+        col: 4,
+        message: MESSAGE
+      }],
+      "if (typeof foo == 'undefimed') {}": [{
+        col: 18,
+        message: MESSAGE
+      }],
+      "if (typeof foo != 'undefimed') {}": [{
+        col: 18,
+        message: MESSAGE
+      }],
+      "if ('undefimed' == typeof foo) {}": [{
+        col: 4,
+        message: MESSAGE
+      }],
+      "if ('undefimed' != typeof foo) {}": [{
+        col: 4,
+        message: MESSAGE
+      }],
+      "typeof foo != 'nunber'": [{
+        col: 14,
+        message: MESSAGE
+      }],
+      "typeof foo !== 'fucntion'": [{
+        col: 15,
+        message: MESSAGE
+      }],
+      "typeof foo !== `bigitn`": [{
         col: 15,
         message: MESSAGE
       }],

--- a/src/rules/valid_typeof.rs
+++ b/src/rules/valid_typeof.rs
@@ -4,7 +4,7 @@ use swc_common::Spanned;
 use swc_ecmascript::ast::{
   BinExpr, BinaryOp, Expr, Ident, Lit, Program, UnaryOp,
 };
-use swc_ecmascript::visit::{noop_visit_type, Node, Visit};
+use swc_ecmascript::visit::{noop_visit_type, Node, VisitAll, VisitAllWith};
 
 pub struct ValidTypeof;
 
@@ -26,7 +26,7 @@ impl LintRule for ValidTypeof {
 
   fn lint_program(&self, context: &mut Context, program: &Program) {
     let mut visitor = ValidTypeofVisitor::new(context);
-    visitor.visit_program(program, program);
+    program.visit_all_with(program, &mut visitor);
   }
 
   fn docs(&self) -> &'static str {
@@ -106,7 +106,7 @@ impl<'c> ValidTypeofVisitor<'c> {
   }
 }
 
-impl<'c> Visit for ValidTypeofVisitor<'c> {
+impl<'c> VisitAll for ValidTypeofVisitor<'c> {
   noop_visit_type!();
 
   fn visit_bin_expr(&mut self, bin_expr: &BinExpr, _parent: &dyn Node) {
@@ -285,6 +285,12 @@ mod tests {
       }],
       "typeof foo === null": [{
         col: 15,
+        message: MESSAGE
+      }],
+
+      // nested
+      "foo === { bar: typeof baz === 'obejct' };": [{
+        col: 30,
         message: MESSAGE
       }],
     }


### PR DESCRIPTION
Fixes #566 

Please see https://github.com/denoland/deno_lint/issues/566#issuecomment-743189703 before reviewing because this fix relaxes the current restriction of `valid-typeof` rule, being against the previous discussion at #38.

In addition, I've done with the following things:
- use `VisitAll` instead of `Visit` to handle nested cases (#330)
- update documentation

