### PR TITLE
chore: delegate FsModuleLoader to deno_core

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -224,9 +224,9 @@ dependencies = [
 
 [[package]]
 name = "deno_core"
-version = "0.70.0"
+version = "0.74.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bd80f07bbc840ec72b96def0a4085a280d48bd20635eb0cc480bc6092d78827"
+checksum = "42ff980f1784abde4c6f0bb383c7bcb443ac8d4d518ea5c64916f8b024af2cdb"
 dependencies = [
  "anyhow",
  "futures",
@@ -234,6 +234,7 @@ dependencies = [
  "lazy_static",
  "libc",
  "log",
+ "pin-project",
  "rusty_v8",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ anyhow = "1.0.35"
 [dev-dependencies]
 annotate-snippets = { version = "0.9.0", features = ["color"] }
 clap = "2.33.3"
-deno_core = "0.70.0"
+deno_core = "0.74.0"
 env_logger = "0.8.2"
 globwalk = "0.8.1"
 rayon = "1.5.0"

--- a/examples/dlint/js.rs
+++ b/examples/dlint/js.rs
@@ -1,11 +1,11 @@
 use anyhow::Context as _;
 use deno_core::error::AnyError;
+use deno_core::FsModuleLoader;
 use deno_core::JsRuntime;
 use deno_core::ModuleSpecifier;
 use deno_core::OpState;
 use deno_core::RuntimeOptions;
 use deno_core::ZeroCopyBuf;
-use deno_core::FsModuleLoader;
 use deno_lint::control_flow::ControlFlow;
 use deno_lint::linter::{Context, Plugin};
 use serde::{Deserialize, Serialize};


### PR DESCRIPTION
This PR bumps `deno_core` to 0.74.0 and removes our own `FsModuleLoader` so that it will be delegated to `deno_core`.

refs:
- #415 
- https://github.com/denoland/deno/pull/8523