### PR TITLE
chore: upgrade rust to 1.49.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Install rust
         uses: hecrj/setup-rust-action@v1.3.4
         with:
-          rust-version: 1.48.0
+          rust-version: 1.49.0
 
       - name: Install clippy and rustfmt
         run: |

--- a/README.md
+++ b/README.md
@@ -130,12 +130,12 @@ For more concrete implementation visit [`deno`](https://github.com/denoland/deno
 
 ## Developing
 
-Make sure to have latest stable version of Rust installed (1.48.0).
+Make sure to have latest stable version of Rust installed (1.49.0).
 
 ```shell
 // check version
 $ rustc --version
-rustc 1.48.0 (7eac88abb 2020-11-16)
+rustc 1.49.0 (e1884a8e3 2020-12-29)
 
 // build all targets
 $ cargo build --all-targets

--- a/src/ast_parser.rs
+++ b/src/ast_parser.rs
@@ -27,25 +27,29 @@ use swc_ecmascript::visit::FoldWith;
 
 #[allow(unused)]
 pub fn get_default_es_config() -> Syntax {
-  let mut config = EsConfig::default();
-  config.num_sep = true;
-  config.class_private_props = false;
-  config.class_private_methods = false;
-  config.class_props = false;
-  config.export_default_from = true;
-  config.export_namespace_from = true;
-  config.dynamic_import = true;
-  config.nullish_coalescing = true;
-  config.optional_chaining = true;
-  config.import_meta = true;
-  config.top_level_await = true;
+  let config = EsConfig {
+    num_sep: true,
+    class_private_props: false,
+    class_private_methods: false,
+    class_props: false,
+    export_default_from: true,
+    export_namespace_from: true,
+    dynamic_import: true,
+    nullish_coalescing: true,
+    optional_chaining: true,
+    import_meta: true,
+    top_level_await: true,
+    ..Default::default()
+  };
   Syntax::Es(config)
 }
 
 pub fn get_default_ts_config() -> Syntax {
-  let mut ts_config = TsConfig::default();
-  ts_config.dynamic_import = true;
-  ts_config.decorators = true;
+  let ts_config = TsConfig {
+    dynamic_import: true,
+    decorators: true,
+    ..Default::default()
+  };
   Syntax::Typescript(ts_config)
 }
 

--- a/src/js_regex/validator.rs
+++ b/src/js_regex/validator.rs
@@ -80,11 +80,11 @@ fn is_valid_unicode(cp: i64) -> bool {
 }
 
 fn is_lead_surrogate(cp: i64) -> bool {
-  cp >= 0xd800 && cp <= 0xdbff
+  (0xd800..=0xdbff).contains(&cp)
 }
 
 fn is_trail_surrogate(cp: i64) -> bool {
-  cp >= 0xdc00 && cp <= 0xdfff
+  (0xdc00..=0xdfff).contains(&cp)
 }
 
 fn combine_surrogate_pair(lead: i64, trail: i64) -> i64 {
@@ -1369,7 +1369,7 @@ impl EcmaRegexValidator {
       self.last_str_value.push(cp);
       self.advance();
     }
-    self.last_str_value != ""
+    !self.last_str_value.is_empty()
   }
 
   /// Eat the next characters as a RegExp `UnicodePropertyValue` production if possible.
@@ -1388,7 +1388,7 @@ impl EcmaRegexValidator {
       self.last_str_value.push(cp);
       self.advance();
     }
-    self.last_str_value != ""
+    !self.last_str_value.is_empty()
   }
 
   /// Eat the next characters as a RegExp `UnicodePropertyValue` production if possible.


### PR DESCRIPTION
This PR upgrades Rust used in CI to v1.49.0.
Also, clippy has got additional rules, so I dealt with those warnings.