### PR TITLE
fix(camelcase): don't check ambient declarations + handle TypeScript things

### DIFF
--- a/src/rules/camelcase.rs
+++ b/src/rules/camelcase.rs
@@ -1042,7 +1042,7 @@ mod tests {
             {
               col: 13,
               message: "Identifier 'snake_case' is not in camel case.",
-              hint: "Consider renaming `snake_case` to `snakeCase`",
+              hint: r#"Consider renaming `snake_case` to `snakeCase`, or wrapping it in quotation mark like `"snake_case"`"#,
             }
           ],
     r#"interface foo_bar { ok: string; };"#: [
@@ -1056,7 +1056,7 @@ mod tests {
             {
               col: 16,
               message: "Identifier 'snake_case' is not in camel case.",
-              hint: "Consider renaming `snake_case` to `snakeCase`",
+              hint: r#"Consider renaming `snake_case` to `snakeCase`, or wrapping it in quotation mark like `"snake_case"`"#,
             }
           ],
     r#"namespace foo_bar {}"#: [

--- a/src/rules/camelcase.rs
+++ b/src/rules/camelcase.rs
@@ -63,6 +63,12 @@ class Also_Not_Valid_Class {}
 
 import { not_camelCased } from "external-module.js";
 export * as not_camelCased from "mod.ts";
+
+enum snake_case_enum { snake_case_variant }
+
+type snake_case_type = { some_property: number; };
+
+interface snake_case_interface { some_property: number; }
 ```
 
 ### Valid:
@@ -83,6 +89,12 @@ class PascalCaseClass {}
 
 import { not_camelCased as camelCased } from "external-module.js";
 export * as camelCased from "mod.ts";
+
+enum PascalCaseEnum { PascalCaseVariant }
+
+type PascalCaseType = { someProperty: number; };
+
+interface PascalCaseInterface { someProperty: number; }
 ```
 "#
   }

--- a/src/rules/camelcase.rs
+++ b/src/rules/camelcase.rs
@@ -1018,7 +1018,63 @@ mod tests {
               message: "Identifier 'no_camelcased' is not in camel case.",
               hint: "Consider renaming `no_camelcased` to `NoCamelcased`",
             }
-          ]
+          ],
+    r#"type foo_bar = string;"#: [
+            {
+              col: 5,
+              message: "Identifier 'foo_bar' is not in camel case.",
+              hint: "Consider renaming `foo_bar` to `FooBar`",
+            }
+          ],
+    r#"type Foo = { snake_case: number; };"#: [
+            {
+              col: 13,
+              message: "Identifier 'snake_case' is not in camel case.",
+              hint: "Consider renaming `snake_case` to `snakeCase`",
+            }
+          ],
+    r#"interface foo_bar { ok: string; };"#: [
+            {
+              col: 10,
+              message: "Identifier 'foo_bar' is not in camel case.",
+              hint: "Consider renaming `foo_bar` to `FooBar`",
+            }
+          ],
+    r#"interface Foo { snake_case: number; };"#: [
+            {
+              col: 16,
+              message: "Identifier 'snake_case' is not in camel case.",
+              hint: "Consider renaming `snake_case` to `snakeCase`",
+            }
+          ],
+    r#"namespace foo_bar {}"#: [
+            {
+              col: 10,
+              message: "Identifier 'foo_bar' is not in camel case.",
+              hint: "Consider renaming `foo_bar` to `FooBar`",
+            }
+          ],
+    r#"namespace FooBar { const snake_case = 42; }"#: [
+            {
+              col: 25,
+              message: "Identifier 'snake_case' is not in camel case.",
+              hint: "Consider renaming `snake_case` to `snakeCase`",
+            }
+          ],
+    r#"enum foo_bar { VariantOne }"#: [
+            {
+              col: 5,
+              message: "Identifier 'foo_bar' is not in camel case.",
+              hint: "Consider renaming `foo_bar` to `FooBar`",
+            }
+          ],
+    r#"enum FooBar { variant_one }"#: [
+            {
+              col: 14,
+              message: "Identifier 'variant_one' is not in camel case.",
+              hint: "Consider renaming `variant_one` to `VariantOne`",
+            }
+          ],
     };
   }
 }

--- a/src/rules/camelcase.rs
+++ b/src/rules/camelcase.rs
@@ -762,6 +762,21 @@ mod tests {
       // keys in quotation marks.
       r#"const obj = { "created_at": "2020-10-30T13:16:45+09:00" }"#,
       r#"const obj = { "created_at": created_at }"#,
+
+      // https://github.com/denoland/deno_lint/issues/587
+      // The rule shouldn't be applied to ambient declarations since the user who writes them is
+      // unable to fix their names.
+      r#"declare function foo_bar(a_b: number): void;"#,
+      r#"declare const foo_bar: number;"#,
+      r#"declare const foo_bar: number, snake_case: string;"#,
+      r#"declare let foo_bar: { some_property: string; };"#,
+      r#"declare var foo_bar: number;"#,
+      r#"declare class foo_bar { some_method(some_param: boolean): string; };"#,
+      r#"export declare const foo_bar: number;"#,
+      r#"declare type foo_bar = { some_var: string; };"#,
+      r#"declare interface foo_bar { some_var: string; }"#,
+      r#"declare namespace foo_bar {}"#,
+      r#"declare enum foo_bar { variant_one, variant_two }"#,
     };
   }
 


### PR DESCRIPTION
Fixes #587, and additionally, lets `camelcase` rule check TypeScript things such as type aliases, interfaces, and so on.