### PR TITLE
feat: add lint_with_ast API

### DIFF
--- a/src/ast_parser.rs
+++ b/src/ast_parser.rs
@@ -162,6 +162,8 @@ impl AstParser {
     syntax: Syntax,
     source_code: &str,
   ) -> Result<(ast::Program, SingleThreadedComments), SwcDiagnosticBuffer> {
+    // NOTE: calling `self.source_map.new_source_file` mutates `source_map`
+    // even though it's of type `Rc`.
     let swc_source_file = self.source_map.new_source_file(
       FileName::Custom(file_name.to_string()),
       source_code.to_string(),

--- a/src/control_flow.rs
+++ b/src/control_flow.rs
@@ -789,7 +789,7 @@ mod tests {
   use crate::test_util;
 
   fn analyze_flow(src: &str) -> ControlFlow {
-    let program = test_util::parse(src);
+    let (program, _) = test_util::parse(src);
     ControlFlow::analyze(&program)
   }
 

--- a/src/control_flow.rs
+++ b/src/control_flow.rs
@@ -789,7 +789,7 @@ mod tests {
   use crate::test_util;
 
   fn analyze_flow(src: &str) -> ControlFlow {
-    let (program, _) = test_util::parse(src);
+    let (program, _, _) = test_util::parse(src);
     ControlFlow::analyze(&program)
   }
 

--- a/src/rules/prefer_const.rs
+++ b/src/rules/prefer_const.rs
@@ -960,7 +960,7 @@ mod variable_collector_tests {
   use crate::test_util;
 
   fn collect(src: &str) -> VariableCollector {
-    let program = test_util::parse(src);
+    let (program, _) = test_util::parse(src);
     let mut v = VariableCollector::new();
     v.visit_program(&program, &program);
     v

--- a/src/rules/prefer_const.rs
+++ b/src/rules/prefer_const.rs
@@ -960,7 +960,7 @@ mod variable_collector_tests {
   use crate::test_util;
 
   fn collect(src: &str) -> VariableCollector {
-    let (program, _) = test_util::parse(src);
+    let (program, _, _) = test_util::parse(src);
     let mut v = VariableCollector::new();
     v.visit_program(&program, &program);
     v

--- a/src/test_util.rs
+++ b/src/test_util.rs
@@ -5,7 +5,9 @@ use crate::diagnostic::LintDiagnostic;
 use crate::linter::LinterBuilder;
 use crate::rules::LintRule;
 use std::marker::PhantomData;
+use std::rc::Rc;
 use swc_common::comments::SingleThreadedComments;
+use swc_common::SourceMap;
 use swc_ecmascript::ast::Program;
 
 #[macro_export]
@@ -302,11 +304,14 @@ pub fn assert_lint_err_on_line_n<T: LintRule + 'static>(
   }
 }
 
-pub fn parse(source_code: &str) -> (Program, SingleThreadedComments) {
+pub fn parse(
+  source_code: &str,
+) -> (Program, SingleThreadedComments, Rc<SourceMap>) {
   let ast_parser = ast_parser::AstParser::new();
   let syntax = ast_parser::get_default_ts_config();
   let (program, comments) = ast_parser
-    .parse_program("file_name.ts", syntax, source_code)
+    .parse_program("lint_test.ts", syntax, source_code)
     .unwrap();
-  (program, comments)
+  let source_map = Rc::clone(&ast_parser.source_map);
+  (program, comments, source_map)
 }

--- a/src/test_util.rs
+++ b/src/test_util.rs
@@ -5,6 +5,7 @@ use crate::diagnostic::LintDiagnostic;
 use crate::linter::LinterBuilder;
 use crate::rules::LintRule;
 use std::marker::PhantomData;
+use swc_common::comments::SingleThreadedComments;
 use swc_ecmascript::ast::Program;
 
 #[macro_export]
@@ -301,11 +302,11 @@ pub fn assert_lint_err_on_line_n<T: LintRule + 'static>(
   }
 }
 
-pub fn parse(source_code: &str) -> Program {
+pub fn parse(source_code: &str) -> (Program, SingleThreadedComments) {
   let ast_parser = ast_parser::AstParser::new();
   let syntax = ast_parser::get_default_ts_config();
-  let (program, _comments) = ast_parser
+  let (program, comments) = ast_parser
     .parse_program("file_name.ts", syntax, source_code)
     .unwrap();
-  program
+  (program, comments)
 }


### PR DESCRIPTION
This PR adds a new public API `lint_with_ast`. Here's its signature:

```rust
pub fn lint_with_ast(
    &mut self,
    file_name: String,
    ast: &swc_ecmascript::ast::Program,
    comments: swc_common::comments::SingleThreadedComments,
    source_map: Rc<SourceMap>,
  ) -> Result<
    (Rc<swc_common::SourceFile>, Vec<LintDiagnostic>),
    SwcDiagnosticBuffer,
  >
```

where `self` is struct of `Linter`.

The proposed API signature in #580 didn't have `comments` and `source_map` as parameters, but it seems they are also required to lint.
I tried to see if it was possible for `comments` to be an immutable reference rather than the value itself, but in vain. Still it works well, though.

Closes #580 