### PR TITLE
doc: Add docs and tests for no_var

### DIFF
--- a/src/rules/no_var.rs
+++ b/src/rules/no_var.rs
@@ -82,4 +82,12 @@ mod tests {
       0,
     );
   }
+
+  #[test]
+  fn no_var_valid() {
+    assert_lint_ok::<NoVar>(
+      r#"let foo = 0; const bar = "bar""#,
+      0
+    );
+  }
 }

--- a/src/rules/no_var.rs
+++ b/src/rules/no_var.rs
@@ -26,6 +26,24 @@ impl LintRule for NoVar {
     let mut visitor = NoVarVisitor::new(context);
     visitor.visit_program(program, program);
   }
+
+  fn docs(&self) -> &'static str {
+    r#"Enforces the use of block scoped variables over more error prone function scoped variables. Block scoped variables are defined using `const` and `let` keywords.
+
+`const` and `let` keywords ensure the variables defined using these keywords are not accessible outside their block scope. On the other hand, variables defined using `var` keyword are only limited by their function scope.
+
+### Invalid:
+```typescript
+var foo = 'bar';
+```
+
+### Valid:
+```typescript
+const foo = 1;
+let bar = 2;
+```
+"#
+  }
 }
 
 struct NoVarVisitor<'c> {

--- a/src/rules/no_var.rs
+++ b/src/rules/no_var.rs
@@ -85,9 +85,6 @@ mod tests {
 
   #[test]
   fn no_var_valid() {
-    assert_lint_ok::<NoVar>(
-      r#"let foo = 0; const bar = "bar""#,
-      0
-    );
+    assert_lint_ok::<NoVar>(r#"let foo = 0; const bar = "bar""#);
   }
 }

--- a/src/rules/no_var.rs
+++ b/src/rules/no_var.rs
@@ -72,11 +72,10 @@ impl<'c> Visit for NoVarVisitor<'c> {
 #[cfg(test)]
 mod tests {
   use super::*;
-  use crate::test_util::*;
 
   #[test]
   fn no_var_valid() {
-    assert_lint_ok::<NoVar>(r#"let foo = 0; const bar = "bar""#);
+    assert_lint_ok!(NoVar, r#"let foo = 0; const bar = 1"#,);
   }
 
   #[test]


### PR DESCRIPTION
This PR contributes to #159 by adding linting docs to `no_var`.

Should I add non-failing tests for `no_var` using `const` and `let` keywords? I'm not sure because `const` and `let` keywords are not even visited by this rules code.