### PR TITLE
Upgrade swc_ecmascript to 0.23.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -46,9 +46,9 @@ checksum = "afddf7f520a80dbf76e6f50a35bca42a2331ef227a28b3b6dc5c2e2338d114b1"
 
 [[package]]
 name = "ast_node"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c701db7f0f212e2e3024a1929cdaf9a21815f329c5ef43be951fc163b3cdc567"
+checksum = "7c84c445d38f7f29c82ed56c2cfae4885e5e6d9fb81b956ab31430757ddad5d7"
 dependencies = [
  "darling",
  "pmutil",
@@ -277,9 +277,9 @@ checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
 name = "enum_kind"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e57153e35187d51f08471d5840459ff29093473e7bedd004a1414985aab92f3"
+checksum = "78b940da354ae81ef0926c5eaa428207b8f4f091d3956c891dfbd124162bed99"
 dependencies = [
  "pmutil",
  "proc-macro2",
@@ -318,9 +318,9 @@ dependencies = [
 
 [[package]]
 name = "from_variant"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "039885ad6579a86b94ad8df696cce8c530da496bf7b07b12fec8d6c4cd654bb9"
+checksum = "0951635027ca477be98f8774abd6f0345233439d63f307e47101acb40c7cc63d"
 dependencies = [
  "pmutil",
  "proc-macro2",
@@ -1019,9 +1019,9 @@ dependencies = [
 
 [[package]]
 name = "string_enum"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94fdb6536756cfd35ee18b9a9972ab2a699d405cc57e0ad0532022960f30d581"
+checksum = "f584cc881e9e5f1fd6bf827b0444aa94c30d8fe6378cf241071b5f5700b2871f"
 dependencies = [
  "pmutil",
  "proc-macro2",
@@ -1054,9 +1054,9 @@ dependencies = [
 
 [[package]]
 name = "swc_common"
-version = "0.10.9"
+version = "0.10.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f8681271be490a61fc0efb2de6897f7a886801b1bd0be021c7d862508bf5147"
+checksum = "d4a358a9bcc475fe8c9bbf323660f37870f64a758a0de9baef6f731814b2d790"
 dependencies = [
  "ast_node",
  "cfg-if 0.1.10",
@@ -1077,9 +1077,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_ast"
-version = "0.39.0"
+version = "0.39.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0875e9eac9d04f4e4fac8bfc8fd17a10249fd73693b99d501a763f18c29bbef1"
+checksum = "1b724414e57a7f795f480b20cbdec5a6d137487afb3fe2d3af1d6f1a539d1214"
 dependencies = [
  "is-macro",
  "num-bigint",
@@ -1091,9 +1091,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_parser"
-version = "0.48.0"
+version = "0.48.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4127964d41da4061b4699d3f0069060f7c52b0b5317ea6b8a52fdd890047a5e"
+checksum = "7c2274bcf79b91920f5691cbe20209f19df413a44004ca451adce29e60be15fb"
 dependencies = [
  "either",
  "enum_kind",
@@ -1111,9 +1111,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms"
-version = "0.37.0"
+version = "0.37.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dadca3e233346eb02e848b39945aef8f0069b1694581da4a27a046473a33aec8"
+checksum = "2df697f35e6be18bb772c4e8f2c4eb6fd56668d4c8ca3280625345944727f562"
 dependencies = [
  "swc_atoms",
  "swc_common",
@@ -1127,9 +1127,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_base"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00ffeb2147d8313816fdabc3f29cf54dfabfb17ba6712cc48aba1a6ecede7abe"
+checksum = "e88c620c7d1695cfd8a3384cb22e2c2ecc15c32307688ed97e85aaf0c9696114"
 dependencies = [
  "fxhash",
  "once_cell",
@@ -1146,9 +1146,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_utils"
-version = "0.29.0"
+version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "598ee798d270a26e14806efc02debe12992a29e5c24a05ef1b12492edb53b695"
+checksum = "0c50420c510fb45fb9ee0324b33d7bdba33e13d0bb5741b4523f655dfd517c45"
 dependencies = [
  "once_cell",
  "scoped-tls",
@@ -1161,9 +1161,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_visit"
-version = "0.25.0"
+version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b17dabc1f4fd1de3cc7662895b3d7f5692dd53bc2b77b4f3c150aa5be314b054"
+checksum = "283213f5129feb31b454d7d0a12c73122329c440cb268b382a8e5d101a48ecf0"
 dependencies = [
  "num-bigint",
  "swc_atoms",
@@ -1174,9 +1174,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecmascript"
-version = "0.23.0"
+version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53684958c3b25d9795e7a305f39d02eaeefee41a85d8bcd59da8f369f6ebc63d"
+checksum = "3277a7d4098728283b991383db918f61871ba44048d50f35e8262e761735e101"
 dependencies = [
  "swc_ecma_ast",
  "swc_ecma_parser",
@@ -1199,9 +1199,9 @@ dependencies = [
 
 [[package]]
 name = "swc_macros_common"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18a9f27d290938370597d363df9a77ba4be8e2bc99f32f69eb5245cdeed3c512"
+checksum = "bf7c68e78ffbcba3d38abe6d0b76a0e1a37888b5c9301db3426537207090ada3"
 dependencies = [
  "pmutil",
  "proc-macro2",
@@ -1211,9 +1211,9 @@ dependencies = [
 
 [[package]]
 name = "swc_visit"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ca9ac0c9177cbc3ae943f7fa1126831b00b68c49c24a0c07f45647e120871d8"
+checksum = "f39cb1989708a0223dcb1ad7e360091b0f7f8e794516c01f6dd8dcb7254cbe5e"
 dependencies = [
  "either",
  "swc_visit_macros",
@@ -1221,9 +1221,9 @@ dependencies = [
 
 [[package]]
 name = "swc_visit_macros"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a544fa1da1a6436b219cb3b47ff3cf140e8eea5b5134d3e21f1c481ca1482186"
+checksum = "e3b2825fee79f10d0166e8e650e79c7a862fb991db275743083f07555d7641f0"
 dependencies = [
  "Inflector",
  "pmutil",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1077,9 +1077,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_ast"
-version = "0.38.0"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efb6a027891bdb66ddddda7bdee43c39be6b7d7861f05fe93177f29183e26738"
+checksum = "0875e9eac9d04f4e4fac8bfc8fd17a10249fd73693b99d501a763f18c29bbef1"
 dependencies = [
  "is-macro",
  "num-bigint",
@@ -1091,9 +1091,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_parser"
-version = "0.46.0"
+version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ed2a23928309960edb769e19235ae345442235c6800fdd2c9b12de35b4ae127"
+checksum = "d4127964d41da4061b4699d3f0069060f7c52b0b5317ea6b8a52fdd890047a5e"
 dependencies = [
  "either",
  "enum_kind",
@@ -1111,9 +1111,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms"
-version = "0.34.0"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca4ef1308184cf7f78ab69e66f2d3f11dc8ab12a26ed400d82a6ddcfa61ab0d3"
+checksum = "dadca3e233346eb02e848b39945aef8f0069b1694581da4a27a046473a33aec8"
 dependencies = [
  "swc_atoms",
  "swc_common",
@@ -1127,9 +1127,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_base"
-version = "0.3.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e243adb8afc4df741a4cfbf265395b4503acbb16f2bb28eaab482a1ca001b25"
+checksum = "00ffeb2147d8313816fdabc3f29cf54dfabfb17ba6712cc48aba1a6ecede7abe"
 dependencies = [
  "fxhash",
  "once_cell",
@@ -1146,9 +1146,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_utils"
-version = "0.28.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eff7a1ec3c9374c3e83f1b21846723573dd41419e27e7204349835f5b599efa8"
+checksum = "598ee798d270a26e14806efc02debe12992a29e5c24a05ef1b12492edb53b695"
 dependencies = [
  "once_cell",
  "scoped-tls",
@@ -1161,9 +1161,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_visit"
-version = "0.24.0"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "169dbafc108be69387475bab48d94e60a786a5959c76e0bd31f6bfb19e81f1b5"
+checksum = "b17dabc1f4fd1de3cc7662895b3d7f5692dd53bc2b77b4f3c150aa5be314b054"
 dependencies = [
  "num-bigint",
  "swc_atoms",
@@ -1174,9 +1174,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecmascript"
-version = "0.20.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f88857fa61bc18ffdb324e8e66300e0af3bb0ad053eb5c490ca4f8bbf7e195b0"
+checksum = "53684958c3b25d9795e7a305f39d02eaeefee41a85d8bcd59da8f369f6ebc63d"
 dependencies = [
  "swc_ecma_ast",
  "swc_ecma_parser",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,8 +20,8 @@ log = "0.4.14"
 serde = { version = "1.0.123", features = ["derive"] }
 serde_json = "1.0.62"
 swc_atoms = "0.2.5"
-swc_common = "0.10.9"
-swc_ecmascript = { version = "0.23.0", features = ["parser", "transforms", "utils", "visit"] }
+swc_common = "0.10.10"
+swc_ecmascript = { version = "0.23.1", features = ["parser", "transforms", "utils", "visit"] }
 regex = "1.4.3"
 once_cell = "1.5.2"
 derive_more = { version = "0.99.11", features = ["display"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ serde = { version = "1.0.123", features = ["derive"] }
 serde_json = "1.0.62"
 swc_atoms = "0.2.5"
 swc_common = "0.10.9"
-swc_ecmascript = { version = "0.20.0", features = ["parser", "transforms", "utils", "visit"] }
+swc_ecmascript = { version = "0.23.0", features = ["parser", "transforms", "utils", "visit"] }
 regex = "1.4.3"
 once_cell = "1.5.2"
 derive_more = { version = "0.99.11", features = ["display"] }

--- a/src/rules/camelcase.rs
+++ b/src/rules/camelcase.rs
@@ -460,7 +460,7 @@ impl<'c> CamelcaseVisitor<'c> {
   fn check_pat(&mut self, pat: &Pat) {
     match pat {
       Pat::Ident(ident) => {
-        self.check_ident(ident, IdentToCheck::variable(ident));
+        self.check_ident(ident, IdentToCheck::variable(&ident.id));
       }
       Pat::Array(ArrayPat { ref elems, .. }) => {
         for elem in elems {
@@ -482,7 +482,7 @@ impl<'c> CamelcaseVisitor<'c> {
                     value_ident,
                     IdentToCheck::object_pat(
                       &key.string_repr().unwrap_or_else(|| "[KEY]".to_string()),
-                      Some(value_ident),
+                      Some(&value_ident.id),
                       false,
                     ),
                   );
@@ -495,7 +495,7 @@ impl<'c> CamelcaseVisitor<'c> {
                         &key
                           .string_repr()
                           .unwrap_or_else(|| "[KEY]".to_string()),
-                        Some(value_ident),
+                        Some(&value_ident.id),
                         true,
                       ),
                     );

--- a/src/rules/explicit_module_boundary_types.rs
+++ b/src/rules/explicit_module_boundary_types.rs
@@ -136,7 +136,7 @@ impl<'c> ExplicitModuleBoundaryTypesVisitor<'c> {
 
   fn check_pat(&mut self, pat: &Pat) {
     match pat {
-      Pat::Ident(ident) => self.check_ann(&ident.type_ann, ident.span),
+      Pat::Ident(ident) => self.check_ann(&ident.type_ann, ident.id.span),
       Pat::Array(array) => self.check_ann(&array.type_ann, array.span),
       Pat::Rest(rest) => self.check_ann(&rest.type_ann, rest.span),
       Pat::Object(object) => self.check_ann(&object.type_ann, object.span),

--- a/src/rules/for_direction.rs
+++ b/src/rules/for_direction.rs
@@ -110,7 +110,7 @@ impl<'c> ForDirectionVisitor<'c> {
         _ => return update_direction,
       },
       PatOrExpr::Pat(boxed_pat) => match &**boxed_pat {
-        Pat::Ident(ident) => ident.sym.as_ref(),
+        Pat::Ident(ident) => ident.id.sym.as_ref(),
         _ => return update_direction,
       },
     };

--- a/src/rules/no_const_assign.rs
+++ b/src/rules/no_const_assign.rs
@@ -70,7 +70,7 @@ impl<'c> NoConstAssignVisitor<'c> {
   fn check_pat(&mut self, pat: &Pat, span: Span) {
     match pat {
       Pat::Ident(ident) => {
-        self.check_scope_for_const(span, ident);
+        self.check_scope_for_const(span, &ident.id);
       }
       Pat::Assign(assign) => {
         self.check_pat(&assign.left, span);

--- a/src/rules/no_dupe_args.rs
+++ b/src/rules/no_dupe_args.rs
@@ -107,7 +107,7 @@ impl<'c> NoDupeArgsVisitor<'c> {
     for pat in pats {
       match &pat {
         Pat::Ident(ident) => {
-          if !seen.insert(ident.as_ref()) {
+          if !seen.insert(ident.id.as_ref()) {
             self.error_spans.insert(span);
           }
         }

--- a/src/rules/no_import_assign.rs
+++ b/src/rules/no_import_assign.rs
@@ -299,7 +299,7 @@ impl<'c> Visit for NoImportAssignVisitor<'c> {
   fn visit_pat(&mut self, n: &Pat, _: &dyn Node) {
     match n {
       Pat::Ident(i) => {
-        self.check(i.span, &i, false);
+        self.check(i.id.span, &i.id, false);
       }
       Pat::Expr(e) => {
         self.check_expr(n.span(), e);

--- a/src/rules/no_redeclare.rs
+++ b/src/rules/no_redeclare.rs
@@ -107,6 +107,9 @@ mod tests {
       class D {
         constructor(a: string) {}
       }",
+
+      // https://github.com/denoland/deno_lint/issues/615
+      "class T { #foo(x) {} #bar(x) {} }",
     };
   }
 

--- a/src/rules/no_self_assign.rs
+++ b/src/rules/no_self_assign.rs
@@ -231,7 +231,7 @@ impl<'c> NoSelfAssignVisitor<'c> {
         self.check_expr_and_expr(&**l_expr, right);
       }
       (Pat::Ident(l_ident), Expr::Ident(r_ident)) => {
-        self.check_same_ident(l_ident, r_ident);
+        self.check_same_ident(&l_ident.id, r_ident);
       }
       (Pat::Array(l_array_pat), Expr::Array(r_array_lit)) => {
         let end =

--- a/src/rules/no_shadow_restricted_names.rs
+++ b/src/rules/no_shadow_restricted_names.rs
@@ -61,14 +61,14 @@ impl<'c> NoShadowRestrictedNamesVisitor<'c> {
       Pat::Ident(ident) => {
         // trying to assign `undefined`
         // Check is scope is valid for current pattern
-        if &ident.sym == "undefined" && check_scope {
+        if &ident.id.sym == "undefined" && check_scope {
           if let Some(_binding) = self.context.scope.var(&ident.to_id()) {
-            self.report_shadowing(&ident);
+            self.report_shadowing(&ident.id);
           }
           return;
         }
 
-        self.check_shadowing(ident);
+        self.check_shadowing(&ident.id);
       }
       Pat::Expr(expr) => {
         if let Expr::Ident(ident) = expr.as_ref() {
@@ -124,7 +124,7 @@ impl<'c> VisitAll for NoShadowRestrictedNamesVisitor<'c> {
     for decl in &node.decls {
       if let Pat::Ident(ident) = &decl.name {
         // `undefined` variable declaration without init is have same meaning
-        if decl.init.is_none() && &ident.sym == "undefined" {
+        if decl.init.is_none() && &ident.id.sym == "undefined" {
           continue;
         }
       }

--- a/src/rules/no_undef.rs
+++ b/src/rules/no_undef.rs
@@ -218,7 +218,7 @@ impl<'c> Visit for NoUndefVisitor<'c> {
 
   fn visit_pat(&mut self, p: &Pat, _: &dyn Node) {
     if let Pat::Ident(i) = p {
-      self.check(i);
+      self.check(&i.id);
     } else {
       p.visit_children_with(self);
     }

--- a/src/rules/no_unused_vars.rs
+++ b/src/rules/no_unused_vars.rs
@@ -68,7 +68,6 @@ struct Collector {
 
 impl Collector {
   fn mark_as_usage(&mut self, i: &Ident) {
-    i.type_ann.visit_with(i, self);
     let id = i.to_id();
 
     // Recursive calls are not usage
@@ -412,7 +411,7 @@ impl<'c> Visit for NoUnusedVarVisitor<'c> {
     match params.first() {
       Some(Param {
         pat: Pat::Ident(i), ..
-      }) if i.sym == *"this" => params
+      }) if i.id.sym == *"this" => params
         .iter()
         .skip(1)
         .for_each(|param| param.visit_with(parent, self)),

--- a/src/rules/prefer_as_const.rs
+++ b/src/rules/prefer_as_const.rs
@@ -5,8 +5,8 @@ use super::LintRule;
 use derive_more::Display;
 use swc_common::{Span, Spanned};
 use swc_ecmascript::ast::{
-  ArrayPat, Expr, Ident, Lit, ObjectPat, Pat, Program, TsAsExpr, TsLit, TsType,
-  TsTypeAnn, TsTypeAssertion, VarDecl,
+  ArrayPat, BindingIdent, Expr, Lit, ObjectPat, Pat, Program, TsAsExpr, TsLit,
+  TsType, TsTypeAnn, TsTypeAssertion, VarDecl,
 };
 use swc_ecmascript::visit::Node;
 use swc_ecmascript::visit::{VisitAll, VisitAllWith};
@@ -109,7 +109,7 @@ impl<'c> VisitAll for PreferAsConstVisitor<'c> {
       if let Some(init) = &decl.init {
         if let Pat::Array(ArrayPat { type_ann, .. })
         | Pat::Object(ObjectPat { type_ann, .. })
-        | Pat::Ident(Ident { type_ann, .. }) = &decl.name
+        | Pat::Ident(BindingIdent { type_ann, .. }) = &decl.name
         {
           if let Some(TsTypeAnn { type_ann, .. }) = &type_ann {
             self.compare(type_ann, &init, type_ann.span());

--- a/src/rules/prefer_const.rs
+++ b/src/rules/prefer_const.rs
@@ -533,7 +533,7 @@ impl Visit for VariableCollector {
             }
             match &ts_param_prop.param {
               TsParamPropParam::Ident(ident) => {
-                a.insert_var(ident, VarStatus::Reassigned);
+                a.insert_var(&ident.id, VarStatus::Reassigned);
               }
               TsParamPropParam::Assign(assign_pat) => {
                 assign_pat.visit_children_with(a);
@@ -597,7 +597,7 @@ where
   F: FnMut(ExtractIdentsArgs<'a>),
 {
   match pat {
-    Pat::Ident(ident) => op(ExtractIdentsArgs::Ident(ident)),
+    Pat::Ident(ident) => op(ExtractIdentsArgs::Ident(&ident.id)),
     Pat::Array(array_pat) => {
       for elem in &array_pat.elems {
         if let Some(elem_pat) = elem {

--- a/src/scopes.rs
+++ b/src/scopes.rs
@@ -169,7 +169,7 @@ impl Visit for Analyzer<'_> {
         }) = &**expr
         {
           if let Pat::Ident(var_name) = &v.name {
-            if var_name.sym == class_name.sym {
+            if var_name.id.sym == class_name.sym {
               self.declare(BindingKind::Class, class_name);
               return;
             }


### PR DESCRIPTION
This PR upgrades swc_ecmascript to v0.23.1 which has a breaking change on `Ident`.
It consequently resolves #615, so I have added a new test case to make sure deno_lint doesn't complain the following code:

```ts
class T {
  #foo(x) {}
  #bar(x) {}
}
```