### PR TITLE
fix(no-unreachable): do not ignore TsEnum. Ignore TsModuleDecl.

### DIFF
--- a/src/rules/no_unreachable.rs
+++ b/src/rules/no_unreachable.rs
@@ -57,7 +57,7 @@ impl<'c> Visit for NoUnreachableVisitor<'c> {
       // Ignore type declarations.
       Stmt::Decl(Decl::TsInterface(..)) => return,
       Stmt::Decl(Decl::TsTypeAlias(..)) => return,
-      Stmt::Decl(Decl::TsEnum(..)) => return,
+      Stmt::Decl(Decl::TsModule(..)) => return,
       Stmt::Decl(Decl::Var(VarDecl {
         kind: VarDeclKind::Var,
         decls,
@@ -383,6 +383,12 @@ interface I<V> {
 throw new Error();
 type S = string;
 type X<T> = T;
+      "#,
+      r#"
+throw new Error();
+declare module "SomeModule" {
+  export function fn(): void;
+}
       "#,
     };
   }


### PR DESCRIPTION
This PR:

1. Let's the rule apply on `enum`s.
Enums transform to runtime objects. Therefore, they can be unreachable. 

2. Ignore `module` declarations.
```typescript
throw new Error(); // <-- will throw at runtime

declare module "SomeModule" {
  export function fn(): void;
} // <-- types can be imported.

let a = 1; // <-- this is rather unreachable.
```

My bad for not testing it thoroughly in #618 