### PR TITLE
refactor(no-this-alias): switch to `assert_lint_err!` macro and cleanup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -247,6 +247,7 @@ dependencies = [
  "derive_more",
  "env_logger",
  "globwalk",
+ "if_chain",
  "log",
  "once_cell",
  "rayon",
@@ -514,6 +515,12 @@ dependencies = [
  "unicode-bidi",
  "unicode-normalization",
 ]
+
+[[package]]
+name = "if_chain"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f7280c75fb2e2fc47080ec80ccc481376923acb04501957fc38f935c3de5088"
 
 [[package]]
 name = "ignore"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ regex = "1.4.3"
 once_cell = "1.5.2"
 derive_more = { version = "0.99.11", features = ["display"] }
 anyhow = "1.0.38"
+if_chain = "1.0.1"
 
 [dev-dependencies]
 annotate-snippets = { version = "0.9.0", features = ["color"] }

--- a/src/rules/no_this_alias.rs
+++ b/src/rules/no_this_alias.rs
@@ -1,6 +1,7 @@
 // Copyright 2020-2021 the Deno authors. All rights reserved. MIT license.
 use super::Context;
 use super::LintRule;
+use if_chain::if_chain;
 use swc_ecmascript::ast::{Expr, Pat, VarDecl};
 use swc_ecmascript::visit::noop_visit_type;
 use swc_ecmascript::visit::Node;
@@ -49,11 +50,12 @@ impl<'c> VisitAll for NoThisAliasVisitor<'c> {
 
   fn visit_var_decl(&mut self, var_decl: &VarDecl, _parent: &dyn Node) {
     for decl in &var_decl.decls {
-      if let Some(init) = &decl.init {
-        if matches!(&**init, Expr::This(_)) {
-          if matches!(&decl.name, Pat::Ident(_)) {
-            self.context.add_diagnostic(var_decl.span, CODE, MESSAGE);
-          }
+      if_chain! {
+        if let Some(init) = &decl.init;
+        if matches!(&**init, Expr::This(_));
+        if matches!(&decl.name, Pat::Ident(_));
+        then {
+          self.context.add_diagnostic(var_decl.span, CODE, MESSAGE);
         }
       }
     }


### PR DESCRIPTION
Part of #431, #330

- switch to `assert_lint_err!` macro
- replace `Visit` with `VisitAll` to deal with nested cases
- introduce [`if_chain`](https://docs.rs/if_chain/1.0.1/if_chain/) crate so that chained `if` and `if let` won't have redundant indentations. `if_chain!` macro is simple but so useful that even clippy use it.