### PR TITLE
feat(no-unused-vars): add recommended tag to `no-unused-vars` and refine it

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -114,9 +114,9 @@ mod lint_tests {
   fn warn_unknown_rules() {
     let src = r#"
  // deno-lint-ignore some-rule
- function foo() {
+ function _foo() {
    // deno-lint-ignore some-rule-2 some-rule-3
-   let bar_foo = true
+   let _bar_foo = true
  }
       "#;
     let diagnostics = lint_recommended_rules(src, true, false);
@@ -130,7 +130,7 @@ mod lint_tests {
     let diagnostics = lint_recommended_rules(
       r#"
  // deno-lint-ignore some-rule
- function foo() {
+ function _foo() {
    // pass
  }
       "#,
@@ -160,9 +160,9 @@ const fooBar: any = 42;
   fn warn_unused_dir() {
     let src = r#"
  // deno-lint-ignore no-explicit-any
- function bar(p: boolean) {
+ function _bar(_p: boolean) {
    // deno-lint-ignore no-misused-new eqeqeq
-   const foo = false
+   const _foo = false
  }
       "#;
     let diagnostics = lint_recommended_rules(src, false, true);
@@ -177,7 +177,7 @@ const fooBar: any = 42;
     let diagnostics = lint_recommended_rules(
       r#"
  // deno-lint-ignore no-explicit-any
- function bar(p: boolean) {
+ function _bar(_p: boolean) {
    // pass
  }
       "#,
@@ -194,7 +194,7 @@ const fooBar: any = 42;
     let diagnostics = lint_specified_rule::<Camelcase>(
       r#"
 // deno-lint-ignore no-explicit-any
-const fooBar = 42;
+const _fooBar = 42;
       "#,
       false,
       true,
@@ -209,7 +209,7 @@ const fooBar = 42;
       r#"
  // deno-lint-ignore-file no-explicit-any
 
- function bar(p: any) {
+ function _bar(_p: any) {
    // pass
  }
       "#,
@@ -225,7 +225,7 @@ const fooBar = 42;
     let src = r#"
  // deno-lint-ignore-file no-explicit-any no-empty
 
- function bar(p: any) {
+ function _bar(_p: any) {
    // pass
  }
       "#;
@@ -241,12 +241,13 @@ const fooBar = 42;
  // deno-lint-ignore-file no-explicit-any
 
  // deno-lint-ignore no-explicit-any
- function bar(p: any) {
+ function _bar(_p: any) {
    // pass
  }
       "#;
     let diagnostics = lint_recommended_rules(src, false, true);
 
+    dbg!(&diagnostics);
     assert_eq!(diagnostics.len(), 1);
     assert_diagnostic(&diagnostics[0], "ban-unused-ignore", 4, 1, src);
   }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -247,7 +247,6 @@ const _fooBar = 42;
       "#;
     let diagnostics = lint_recommended_rules(src, false, true);
 
-    dbg!(&diagnostics);
     assert_eq!(diagnostics.len(), 1);
     assert_diagnostic(&diagnostics[0], "ban-unused-ignore", 4, 1, src);
   }

--- a/src/rules/no_unused_vars.rs
+++ b/src/rules/no_unused_vars.rs
@@ -1,27 +1,23 @@
 // Copyright 2020-2021 the Deno authors. All rights reserved. MIT license.
 use super::Context;
 use super::LintRule;
-use swc_ecmascript::utils::find_ids;
-use swc_ecmascript::utils::ident::IdentLike;
-use swc_ecmascript::utils::Id;
-use swc_ecmascript::visit::Node;
-use swc_ecmascript::visit::Visit;
-use swc_ecmascript::{
-  ast::{
-    ArrowExpr, CatchClause, ClassDecl, ClassMethod, ClassProp, Constructor,
-    Decl, ExportDecl, ExportNamedSpecifier, Expr, FnDecl, FnExpr, Ident,
-    ImportDefaultSpecifier, ImportNamedSpecifier, ImportStarAsSpecifier,
-    KeyValueProp, MemberExpr, MethodKind, NamedExport, Param, Pat, Program,
-    Prop, SetterProp, TsEntityName, TsEnumDecl, TsExprWithTypeArgs,
-    TsModuleDecl, TsNamespaceDecl, TsPropertySignature, TsTypeRef, VarDecl,
-    VarDeclOrPat, VarDeclarator,
-  },
-  visit::VisitWith,
-};
-
 use std::collections::HashSet;
+use swc_ecmascript::ast::{
+  ArrowExpr, CatchClause, ClassDecl, ClassMethod, ClassProp, Constructor, Decl,
+  ExportDecl, ExportNamedSpecifier, Expr, FnDecl, FnExpr, Ident,
+  ImportDefaultSpecifier, ImportNamedSpecifier, ImportStarAsSpecifier,
+  KeyValueProp, MemberExpr, MethodKind, NamedExport, Param, Pat, Program, Prop,
+  SetterProp, TsEntityName, TsEnumDecl, TsExprWithTypeArgs, TsModuleDecl,
+  TsNamespaceDecl, TsPropertySignature, TsTypeRef, VarDecl, VarDeclOrPat,
+  VarDeclarator,
+};
+use swc_ecmascript::utils::ident::IdentLike;
+use swc_ecmascript::utils::{find_ids, Id};
+use swc_ecmascript::visit::{Node, Visit, VisitWith};
 
 pub struct NoUnusedVars;
+
+const CODE: &str = "no-unused-vars";
 
 impl LintRule for NoUnusedVars {
   fn new() -> Box<Self> {
@@ -29,7 +25,7 @@ impl LintRule for NoUnusedVars {
   }
 
   fn code(&self) -> &'static str {
-    "no-unused-vars"
+    CODE
   }
 
   fn lint_program(&self, context: &mut Context, program: &Program) {
@@ -267,7 +263,7 @@ impl<'c> NoUnusedVarVisitor<'c> {
       // The variable is not used.
       self.context.add_diagnostic(
         ident.span,
-        "no-unused-vars",
+        CODE,
         format!("\"{}\" is never used", ident.sym),
       );
     }

--- a/src/rules/no_unused_vars.rs
+++ b/src/rules/no_unused_vars.rs
@@ -348,10 +348,10 @@ impl<'c> Visit for NoUnusedVarVisitor<'c> {
     method.function.decorators.visit_with(method, self);
     method.key.visit_with(method, self);
 
-    match method.kind {
-      MethodKind::Method => method.function.params.visit_children_with(self),
-      MethodKind::Getter => {}
-      MethodKind::Setter => {}
+    // If method body is not present, it's an overload definition
+    if matches!(method.kind, MethodKind::Method if method.function.body.is_some())
+    {
+      method.function.params.visit_children_with(self)
     }
 
     method.function.body.visit_with(method, self);
@@ -1089,6 +1089,7 @@ export default class Foo {
       "export function foo(msg: string): void",
       "function _foo(msg?: string): void",
       "const key = 0; export const obj = { [key]: true };",
+      "export class Foo { bar(msg: string): void; }",
     };
   }
 

--- a/src/rules/no_unused_vars.rs
+++ b/src/rules/no_unused_vars.rs
@@ -292,8 +292,13 @@ impl<'c> Visit for NoUnusedVarVisitor<'c> {
     if decl.declare {
       return;
     }
+
     self.handle_id(&decl.ident);
-    decl.function.visit_with(decl, self);
+
+    // If function body is not present, it's an overload definition
+    if decl.function.body.is_some() {
+      decl.function.visit_with(decl, self);
+    }
   }
 
   fn visit_var_decl(&mut self, n: &VarDecl, _: &dyn Node) {
@@ -399,7 +404,10 @@ impl<'c> Visit for NoUnusedVarVisitor<'c> {
         c.class.visit_with(c, self);
       }
       Decl::Fn(f) => {
-        f.function.visit_with(f, self);
+        // If function body is not present, it's an overload definition
+        if f.function.body.is_some() {
+          f.function.visit_with(f, self);
+        }
       }
       Decl::Var(v) => {
         for decl in &v.decls {
@@ -1076,6 +1084,8 @@ export default class Foo {
   }
 }
       ",
+      "export function foo(msg: string): void",
+      "function _foo(msg?: string): void",
     };
   }
 

--- a/src/rules/no_unused_vars.rs
+++ b/src/rules/no_unused_vars.rs
@@ -455,7 +455,6 @@ impl<'c> Visit for NoUnusedVarVisitor<'c> {
 #[cfg(test)]
 mod tests {
   use super::*;
-  use crate::test_util::*;
 
   #[test]
   fn no_unused_vars_valid() {
@@ -1707,103 +1706,191 @@ export interface Bar extends baz.test {}
   #[test]
   #[ignore = "control flow analysis is not implemented yet"]
   fn no_unused_vars_err_for_loop_control_flow() {
-    assert_lint_err::<NoUnusedVars>(
-      "(function(obj) { var name; for ( name in obj ) { i(); return; } })({});",
-      0,
-    );
-    assert_lint_err::<NoUnusedVars>(
-      "(function(obj) { var name; for ( name in obj ) { } })({});",
-      0,
-    );
-    assert_lint_err::<NoUnusedVars>(
-      "(function(obj) { for ( var name in obj ) { } })({});",
-      0,
-    );
+    assert_lint_err! {
+      NoUnusedVars,
+      "(function(obj) { var name; for ( name in obj ) { i(); return; } })({});": [
+        {
+          col: 21,
+          message: variant!(NoUnusedVarsMessage, NeverUsed, "name"),
+        }
+      ],
+      "(function(obj) { var name; for ( name in obj ) { } })({});": [
+        {
+          col: 21,
+          message: variant!(NoUnusedVarsMessage, NeverUsed, "name"),
+        }
+      ],
+      "(function(obj) { for ( var name in obj ) { } })({});": [
+        {
+          col: 37,
+          message: variant!(NoUnusedVarsMessage, NeverUsed, "name"),
+        }
+      ]
+    };
   }
 
   // TODO(magurotuna): deals with this using ControlFlow
   #[test]
   #[ignore = "control flow analysis is not implemented yet"]
   fn no_unused_vars_err_assign_expr() {
-    assert_lint_err::<NoUnusedVars>("var a = 0; a = a + 1;", 0);
-    assert_lint_err::<NoUnusedVars>("var a = 0; a = a + a;", 0);
-    assert_lint_err::<NoUnusedVars>("var a = 0; a += a + 1", 0);
-    assert_lint_err::<NoUnusedVars>("var a = 0; a++;", 0);
-    assert_lint_err::<NoUnusedVars>("function foo(a) { a = a + 1 } foo();", 0);
-    assert_lint_err::<NoUnusedVars>("function foo(a) { a += a + 1 } foo();", 0);
-    assert_lint_err::<NoUnusedVars>("function foo(a) { a++ } foo();", 0);
-    assert_lint_err::<NoUnusedVars>("var a = 3; a = a * 5 + 6;", 0);
-    assert_lint_err::<NoUnusedVars>("var a = 2, b = 4; a = a * 2 + b;", 0);
-
-    assert_lint_err::<NoUnusedVars>("const a = 1; a += 1;", 6);
+    assert_lint_err! {
+      NoUnusedVars,
+      "var a = 0; a = a + 1;": [
+        {
+          col: 4,
+          message: variant!(NoUnusedVarsMessage, NeverUsed, "a"),
+        }
+      ],
+      "var a = 0; a = a + a;": [
+        {
+          col: 4,
+          message: variant!(NoUnusedVarsMessage, NeverUsed, "a"),
+        }
+      ],
+      "var a = 0; a += a + 1": [
+        {
+          col: 4,
+          message: variant!(NoUnusedVarsMessage, NeverUsed, "a"),
+        }
+      ],
+      "var a = 0; a++;": [
+        {
+          col: 4,
+          message: variant!(NoUnusedVarsMessage, NeverUsed, "a"),
+        }
+      ],
+      "function foo(a) { a = a + 1 } foo();": [
+        {
+          col: 13,
+          message: variant!(NoUnusedVarsMessage, NeverUsed, "a"),
+        }
+      ],
+      "function foo(a) { a += a + 1 } foo();": [
+        {
+          col: 13,
+          message: variant!(NoUnusedVarsMessage, NeverUsed, "a"),
+        }
+      ],
+      "function foo(a) { a++ } foo();": [
+        {
+          col: 13,
+          message: variant!(NoUnusedVarsMessage, NeverUsed, "a"),
+        }
+      ],
+      "var a = 3; a = a * 5 + 6;": [
+        {
+          col: 4,
+          message: variant!(NoUnusedVarsMessage, NeverUsed, "a"),
+        }
+      ],
+      "var a = 2, b = 4; a = a * 2 + b;": [
+        {
+          col: 4,
+          message: variant!(NoUnusedVarsMessage, NeverUsed, "a"),
+        }
+      ],
+      "const a = 1; a += 1;": [
+        {
+          col: 6,
+          message: variant!(NoUnusedVarsMessage, NeverUsed, "a"),
+        }
+      ]
+    };
   }
 
   // TODO(magurotuna): deals with this using ControlFlow
   #[test]
   #[ignore = "control flow analysis is not implemented yet"]
   fn no_unused_vars_err_assign_to_self() {
-    assert_lint_err::<NoUnusedVars>("function foo(cb) { cb = function(a) { cb(1 + a); }; bar(not_cb); } foo();", 0);
-    assert_lint_err::<NoUnusedVars>(
-      "function foo(cb) { cb = function(a) { return cb(1 + a); }(); } foo();",
-      0,
-    );
-    assert_lint_err::<NoUnusedVars>(
-      "function foo(cb) { cb = (function(a) { cb(1 + a); }, cb); } foo();",
-      0,
-    );
-    assert_lint_err::<NoUnusedVars>(
-      "function foo(cb) { cb = (0, function(a) { cb(1 + a); }); } foo();",
-      0,
-    );
+    assert_lint_err! {
+      NoUnusedVars,
+      "function foo(cb) { cb = function(a) { cb(1 + a); }; bar(not_cb); } foo();": [
+        {
+          col: 13,
+          message: variant!(NoUnusedVarsMessage, NeverUsed, "cb"),
+        }
+      ],
+      "function foo(cb) { cb = function(a) { return cb(1 + a); }(); } foo();": [
+        {
+          col: 13,
+          message: variant!(NoUnusedVarsMessage, NeverUsed, "cb"),
+        }
+      ],
+      "function foo(cb) { cb = (function(a) { cb(1 + a); }, cb); } foo();": [
+        {
+          col: 13,
+          message: variant!(NoUnusedVarsMessage, NeverUsed, "cb"),
+        }
+      ],
+      "function foo(cb) { cb = (0, function(a) { cb(1 + a); }); } foo();": [
+        {
+          col: 13,
+          message: variant!(NoUnusedVarsMessage, NeverUsed, "cb"),
+        }
+      ]
+    };
   }
 
   #[test]
   #[ignore = "pure method analysis is not implemented yet"]
   fn no_unused_vars_err_array_methods() {
-    assert_lint_err::<NoUnusedVars>(
-      "let myArray = [1,2,3,4].filter((x) => x == 0); myArray = myArray.filter((x) => x == 1);",
-      4,
-    );
+    assert_lint_err! {
+      NoUnusedVars,
+      "let myArray = [1,2,3,4].filter((x) => x == 0); myArray = myArray.filter((x) => x == 1);": [
+        {
+          col: 4,
+          message: variant!(NoUnusedVarsMessage, NeverUsed, "myArray"),
+        }
+      ]
+    };
   }
 
   #[test]
   #[ignore = "swc cannot parse this at the moment"]
   fn no_unused_vars_ts_err_06() {
-    assert_lint_err_on_line::<NoUnusedVars>(
+    assert_lint_err! {
+      NoUnusedVars,
       "
 import test from 'test';
 import baz from 'baz';
 export interface Bar extends baz().test {}
-      ",
-      0,
-      0,
-    );
-
-    assert_lint_err_on_line::<NoUnusedVars>(
+      ": [
+        {
+          line: 2,
+          col: 7,
+          message: variant!(NoUnusedVarsMessage, NeverUsed, "test"),
+        }
+      ],
       "
 import test from 'test';
 import baz from 'baz';
 export class Bar implements baz.test {}
-      ",
-      0,
-      0,
-    );
-
-    assert_lint_err_on_line::<NoUnusedVars>(
+      ": [
+        {
+          line: 2,
+          col: 7,
+          message: variant!(NoUnusedVarsMessage, NeverUsed, "test"),
+        }
+      ],
       "
 import test from 'test';
 import baz from 'baz';
 export class Bar implements baz().test {}
-      ",
-      0,
-      0,
-    );
+      ": [
+        {
+          line: 2,
+          col: 7,
+          message: variant!(NoUnusedVarsMessage, NeverUsed, "test"),
+        }
+      ]
+    };
   }
 
   #[test]
   #[ignore = "typescript property analysis is not implemented yet"]
   fn no_unused_vars_ts_ok_12() {
-    assert_lint_ok::<NoUnusedVars>(
+    assert_lint_ok! {
+      NoUnusedVars,
       "
 export class App {
   constructor(private logger: Logger) {
@@ -1811,9 +1898,6 @@ export class App {
   }
 }
       ",
-    );
-
-    assert_lint_ok::<NoUnusedVars>(
       "
 export class App {
   constructor(bar: string);
@@ -1822,9 +1906,6 @@ export class App {
   }
 }
       ",
-    );
-
-    assert_lint_ok::<NoUnusedVars>(
       "
 export class App {
   constructor(baz: string, private logger: Logger) {
@@ -1833,9 +1914,6 @@ export class App {
   }
 }
       ",
-    );
-
-    assert_lint_ok::<NoUnusedVars>(
       "
 export class App {
   constructor(baz: string, private logger: Logger, private bar: () => void) {
@@ -1844,9 +1922,6 @@ export class App {
   }
 }
       ",
-    );
-
-    assert_lint_ok::<NoUnusedVars>(
       "
 export class App {
   constructor(private logger: Logger) {}
@@ -1855,6 +1930,6 @@ export class App {
   }
 }
       ",
-    );
+    };
   }
 }

--- a/src/rules/no_unused_vars.rs
+++ b/src/rules/no_unused_vars.rs
@@ -31,6 +31,10 @@ impl LintRule for NoUnusedVars {
     Box::new(NoUnusedVars)
   }
 
+  fn tags(&self) -> &'static [&'static str] {
+    &["recommended"]
+  }
+
   fn code(&self) -> &'static str {
     CODE
   }


### PR DESCRIPTION
This PR adds `no-unused-vars` to the recommended set to enable it by default, and refines the rule so that it can work fine for deno_std.

Applying this rule to the current deno_std, we get 37 errors. It seems like there are no false positives.
I will soon open another PR to the deno_std repo to address these errors.

Part of #431 
Resolves #598 