### PR TITLE
fix(no-undef):  Handle bindings of arrow expressions.

### DIFF
--- a/src/rules/no_undef.rs
+++ b/src/rules/no_undef.rs
@@ -374,6 +374,13 @@ mod tests {
       r#"type Foo = string | number; export default Foo;"#,
       r#"type Foo<T> = { bar: T }; export default Foo;"#,
       r#"type Foo = string | undefined; export type { Foo };"#,
+      // https://github.com/denoland/deno_lint/issues/596
+      r#"
+      const f = (
+        { a }: Foo,
+        b: boolean,
+      ) => {};
+      "#,
     };
   }
 

--- a/src/rules/no_undef.rs
+++ b/src/rules/no_undef.rs
@@ -133,6 +133,14 @@ impl VisitAll for BindingCollector {
       }
     }
   }
+
+  /// See https://github.com/denoland/deno_lint/issues/596
+  fn visit_arrow_expr(&mut self, e: &ArrowExpr, _: &dyn Node) {
+    let ids: Vec<Id> = find_ids(&e.params);
+    for id in ids {
+      self.declare(id);
+    }
+  }
 }
 
 struct NoUndefVisitor<'c> {


### PR DESCRIPTION
Closes #596.