### PR TITLE
refactor(no-this-before-super): rewrite with ast-view and assert macro

### DIFF
--- a/src/handler.rs
+++ b/src/handler.rs
@@ -10,7 +10,12 @@ pub trait Handler {
   fn arrow_expr(&mut self, _n: &AstView::ArrowExpr, _ctx: &mut Context) {}
   fn assign_expr(&mut self, _n: &AstView::AssignExpr, _ctx: &mut Context) {}
   fn assign_pat(&mut self, _n: &AstView::AssignPat, _ctx: &mut Context) {}
-  fn assign_pat_prop(&mut self, _n: &AstView::AssignPatProp, _ctx: &mut Context) {}
+  fn assign_pat_prop(
+    &mut self,
+    _n: &AstView::AssignPatProp,
+    _ctx: &mut Context,
+  ) {
+  }
   fn assign_prop(&mut self, _n: &AstView::AssignProp, _ctx: &mut Context) {}
   fn await_expr(&mut self, _n: &AstView::AwaitExpr, _ctx: &mut Context) {}
   fn big_int(&mut self, _n: &AstView::BigInt, _ctx: &mut Context) {}
@@ -71,7 +76,8 @@ pub trait Handler {
     _ctx: &mut Context,
   ) {
   }
-  fn expr_or_spread(&mut self, _n: &AstView::ExprOrSpread, _ctx: &mut Context) {}
+  fn expr_or_spread(&mut self, _n: &AstView::ExprOrSpread, _ctx: &mut Context) {
+  }
   fn expr_stmt(&mut self, _n: &AstView::ExprStmt, _ctx: &mut Context) {}
   fn fn_decl(&mut self, _n: &AstView::FnDecl, _ctx: &mut Context) {}
   fn fn_expr(&mut self, _n: &AstView::FnExpr, _ctx: &mut Context) {}
@@ -116,7 +122,8 @@ pub trait Handler {
   ) {
   }
   fn jsx_element(&mut self, _n: &AstView::JSXElement, _ctx: &mut Context) {}
-  fn jsx_empty_expr(&mut self, _n: &AstView::JSXEmptyExpr, _ctx: &mut Context) {}
+  fn jsx_empty_expr(&mut self, _n: &AstView::JSXEmptyExpr, _ctx: &mut Context) {
+  }
   fn jsx_expr_container(
     &mut self,
     _n: &AstView::JSXExprContainer,
@@ -124,7 +131,12 @@ pub trait Handler {
   ) {
   }
   fn jsx_fragment(&mut self, _n: &AstView::JSXFragment, _ctx: &mut Context) {}
-  fn jsx_member_expr(&mut self, _n: &AstView::JSXMemberExpr, _ctx: &mut Context) {}
+  fn jsx_member_expr(
+    &mut self,
+    _n: &AstView::JSXMemberExpr,
+    _ctx: &mut Context,
+  ) {
+  }
   fn jsx_namespaced_name(
     &mut self,
     _n: &AstView::JSXNamespacedName,
@@ -143,7 +155,11 @@ pub trait Handler {
     _ctx: &mut Context,
   ) {
   }
-  fn jsx_spread_child(&mut self, _n: &AstView::JSXSpreadChild, _ctx: &mut Context) {
+  fn jsx_spread_child(
+    &mut self,
+    _n: &AstView::JSXSpreadChild,
+    _ctx: &mut Context,
+  ) {
   }
   fn jsx_text(&mut self, _n: &AstView::JSXText, _ctx: &mut Context) {}
   fn key_value_pat_prop(
@@ -152,10 +168,12 @@ pub trait Handler {
     _ctx: &mut Context,
   ) {
   }
-  fn key_value_prop(&mut self, _n: &AstView::KeyValueProp, _ctx: &mut Context) {}
+  fn key_value_prop(&mut self, _n: &AstView::KeyValueProp, _ctx: &mut Context) {
+  }
   fn labeled_stmt(&mut self, _n: &AstView::LabeledStmt, _ctx: &mut Context) {}
   fn member_expr(&mut self, _n: &AstView::MemberExpr, _ctx: &mut Context) {}
-  fn meta_prop_expr(&mut self, _n: &AstView::MetaPropExpr, _ctx: &mut Context) {}
+  fn meta_prop_expr(&mut self, _n: &AstView::MetaPropExpr, _ctx: &mut Context) {
+  }
   fn method_prop(&mut self, _n: &AstView::MethodProp, _ctx: &mut Context) {}
   fn module(&mut self, _n: &AstView::Module, _ctx: &mut Context) {}
   fn named_export(&mut self, _n: &AstView::NamedExport, _ctx: &mut Context) {}
@@ -164,10 +182,16 @@ pub trait Handler {
   fn number(&mut self, _n: &AstView::Number, _ctx: &mut Context) {}
   fn object_lit(&mut self, _n: &AstView::ObjectLit, _ctx: &mut Context) {}
   fn object_pat(&mut self, _n: &AstView::ObjectPat, _ctx: &mut Context) {}
-  fn opt_chain_expr(&mut self, _n: &AstView::OptChainExpr, _ctx: &mut Context) {}
+  fn opt_chain_expr(&mut self, _n: &AstView::OptChainExpr, _ctx: &mut Context) {
+  }
   fn param(&mut self, _n: &AstView::Param, _ctx: &mut Context) {}
   fn paren_expr(&mut self, _n: &AstView::ParenExpr, _ctx: &mut Context) {}
-  fn private_method(&mut self, _n: &AstView::PrivateMethod, _ctx: &mut Context) {}
+  fn private_method(
+    &mut self,
+    _n: &AstView::PrivateMethod,
+    _ctx: &mut Context,
+  ) {
+  }
   fn private_name(&mut self, _n: &AstView::PrivateName, _ctx: &mut Context) {}
   fn private_prop(&mut self, _n: &AstView::PrivateProp, _ctx: &mut Context) {}
   fn regex(&mut self, _n: &AstView::Regex, _ctx: &mut Context) {}
@@ -176,7 +200,12 @@ pub trait Handler {
   fn script(&mut self, _n: &AstView::Script, _ctx: &mut Context) {}
   fn seq_expr(&mut self, _n: &AstView::SeqExpr, _ctx: &mut Context) {}
   fn setter_prop(&mut self, _n: &AstView::SetterProp, _ctx: &mut Context) {}
-  fn spread_element(&mut self, _n: &AstView::SpreadElement, _ctx: &mut Context) {}
+  fn spread_element(
+    &mut self,
+    _n: &AstView::SpreadElement,
+    _ctx: &mut Context,
+  ) {
+  }
   fn str(&mut self, _n: &AstView::Str, _ctx: &mut Context) {}
   // Neither `super` or `r#super` can be used here, so we use `super_` reluctantly
   fn super_(&mut self, _n: &AstView::Super, _ctx: &mut Context) {}
@@ -221,7 +250,8 @@ pub trait Handler {
   ) {
   }
   fn ts_enum_decl(&mut self, _n: &AstView::TsEnumDecl, _ctx: &mut Context) {}
-  fn ts_enum_member(&mut self, _n: &AstView::TsEnumMember, _ctx: &mut Context) {}
+  fn ts_enum_member(&mut self, _n: &AstView::TsEnumMember, _ctx: &mut Context) {
+  }
   fn ts_export_assignment(
     &mut self,
     _n: &AstView::TsExportAssignment,
@@ -247,7 +277,8 @@ pub trait Handler {
     _ctx: &mut Context,
   ) {
   }
-  fn ts_import_type(&mut self, _n: &AstView::TsImportType, _ctx: &mut Context) {}
+  fn ts_import_type(&mut self, _n: &AstView::TsImportType, _ctx: &mut Context) {
+  }
   fn ts_index_signature(
     &mut self,
     _n: &AstView::TsIndexSignature,
@@ -279,17 +310,29 @@ pub trait Handler {
     _ctx: &mut Context,
   ) {
   }
-  fn ts_keyword_type(&mut self, _n: &AstView::TsKeywordType, _ctx: &mut Context) {}
+  fn ts_keyword_type(
+    &mut self,
+    _n: &AstView::TsKeywordType,
+    _ctx: &mut Context,
+  ) {
+  }
   fn ts_lit_type(&mut self, _n: &AstView::TsLitType, _ctx: &mut Context) {}
-  fn ts_mapped_type(&mut self, _n: &AstView::TsMappedType, _ctx: &mut Context) {}
+  fn ts_mapped_type(&mut self, _n: &AstView::TsMappedType, _ctx: &mut Context) {
+  }
   fn ts_method_signature(
     &mut self,
     _n: &AstView::TsMethodSignature,
     _ctx: &mut Context,
   ) {
   }
-  fn ts_module_block(&mut self, _n: &AstView::TsModuleBlock, _ctx: &mut Context) {}
-  fn ts_module_decl(&mut self, _n: &AstView::TsModuleDecl, _ctx: &mut Context) {}
+  fn ts_module_block(
+    &mut self,
+    _n: &AstView::TsModuleBlock,
+    _ctx: &mut Context,
+  ) {
+  }
+  fn ts_module_decl(&mut self, _n: &AstView::TsModuleDecl, _ctx: &mut Context) {
+  }
   fn ts_namespace_decl(
     &mut self,
     _n: &AstView::TsNamespaceDecl,
@@ -302,8 +345,17 @@ pub trait Handler {
     _ctx: &mut Context,
   ) {
   }
-  fn ts_non_null_expr(&mut self, _n: &AstView::TsNonNullExpr, _ctx: &mut Context) {}
-  fn ts_optional_type(&mut self, _n: &AstView::TsOptionalType, _ctx: &mut Context) {
+  fn ts_non_null_expr(
+    &mut self,
+    _n: &AstView::TsNonNullExpr,
+    _ctx: &mut Context,
+  ) {
+  }
+  fn ts_optional_type(
+    &mut self,
+    _n: &AstView::TsOptionalType,
+    _ctx: &mut Context,
+  ) {
   }
   fn ts_param_prop(&mut self, _n: &AstView::TsParamProp, _ctx: &mut Context) {}
   fn ts_parenthesized_type(
@@ -326,8 +378,17 @@ pub trait Handler {
   }
   fn ts_rest_type(&mut self, _n: &AstView::TsRestType, _ctx: &mut Context) {}
   fn ts_this_type(&mut self, _n: &AstView::TsThisType, _ctx: &mut Context) {}
-  fn ts_tpl_lit_type(&mut self, _n: &AstView::TsTplLitType, _ctx: &mut Context) {}
-  fn ts_tuple_element(&mut self, _n: &AstView::TsTupleElement, _ctx: &mut Context) {
+  fn ts_tpl_lit_type(
+    &mut self,
+    _n: &AstView::TsTplLitType,
+    _ctx: &mut Context,
+  ) {
+  }
+  fn ts_tuple_element(
+    &mut self,
+    _n: &AstView::TsTupleElement,
+    _ctx: &mut Context,
+  ) {
   }
   fn ts_tuple_type(&mut self, _n: &AstView::TsTupleType, _ctx: &mut Context) {}
   fn ts_type_alias_decl(
@@ -344,7 +405,11 @@ pub trait Handler {
   ) {
   }
   fn ts_type_lit(&mut self, _n: &AstView::TsTypeLit, _ctx: &mut Context) {}
-  fn ts_type_operator(&mut self, _n: &AstView::TsTypeOperator, _ctx: &mut Context) {
+  fn ts_type_operator(
+    &mut self,
+    _n: &AstView::TsTypeOperator,
+    _ctx: &mut Context,
+  ) {
   }
   fn ts_type_param(&mut self, _n: &AstView::TsTypeParam, _ctx: &mut Context) {}
   fn ts_type_param_decl(
@@ -371,7 +436,12 @@ pub trait Handler {
   fn unary_expr(&mut self, _n: &AstView::UnaryExpr, _ctx: &mut Context) {}
   fn update_expr(&mut self, _n: &AstView::UpdateExpr, _ctx: &mut Context) {}
   fn var_decl(&mut self, _n: &AstView::VarDecl, _ctx: &mut Context) {}
-  fn var_declarator(&mut self, _n: &AstView::VarDeclarator, _ctx: &mut Context) {}
+  fn var_declarator(
+    &mut self,
+    _n: &AstView::VarDeclarator,
+    _ctx: &mut Context,
+  ) {
+  }
   fn while_stmt(&mut self, _n: &AstView::WhileStmt, _ctx: &mut Context) {}
   fn with_stmt(&mut self, _n: &AstView::WithStmt, _ctx: &mut Context) {}
   fn yield_expr(&mut self, _n: &AstView::YieldExpr, _ctx: &mut Context) {}

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -2,380 +2,380 @@ use crate::linter::Context;
 use dprint_swc_ecma_ast_view::{self as AstView, NodeTrait};
 
 pub trait Handler {
-  fn array_lit(&self, _n: &AstView::ArrayLit, _ctx: &mut Context) {}
-  fn array_pat(&self, _n: &AstView::ArrayPat, _ctx: &mut Context) {}
-  fn arrow_expr(&self, _n: &AstView::ArrowExpr, _ctx: &mut Context) {}
-  fn assign_expr(&self, _n: &AstView::AssignExpr, _ctx: &mut Context) {}
-  fn assign_pat(&self, _n: &AstView::AssignPat, _ctx: &mut Context) {}
-  fn assign_pat_prop(&self, _n: &AstView::AssignPatProp, _ctx: &mut Context) {}
-  fn assign_prop(&self, _n: &AstView::AssignProp, _ctx: &mut Context) {}
-  fn await_expr(&self, _n: &AstView::AwaitExpr, _ctx: &mut Context) {}
-  fn big_int(&self, _n: &AstView::BigInt, _ctx: &mut Context) {}
-  fn bin_expr(&self, _n: &AstView::BinExpr, _ctx: &mut Context) {}
-  fn binding_ident(&self, _n: &AstView::BindingIdent, _ctx: &mut Context) {}
-  fn block_stmt(&self, _n: &AstView::BlockStmt, _ctx: &mut Context) {}
-  fn bool(&self, _n: &AstView::Bool, _ctx: &mut Context) {}
-  fn break_stmt(&self, _n: &AstView::BreakStmt, _ctx: &mut Context) {}
-  fn call_expr(&self, _n: &AstView::CallExpr, _ctx: &mut Context) {}
-  fn catch_clause(&self, _n: &AstView::CatchClause, _ctx: &mut Context) {}
-  fn class(&self, _n: &AstView::Class, _ctx: &mut Context) {}
-  fn class_decl(&self, _n: &AstView::ClassDecl, _ctx: &mut Context) {}
-  fn class_expr(&self, _n: &AstView::ClassExpr, _ctx: &mut Context) {}
-  fn class_method(&self, _n: &AstView::ClassMethod, _ctx: &mut Context) {}
-  fn class_prop(&self, _n: &AstView::ClassProp, _ctx: &mut Context) {}
+  fn array_lit(&mut self, _n: &AstView::ArrayLit, _ctx: &mut Context) {}
+  fn array_pat(&mut self, _n: &AstView::ArrayPat, _ctx: &mut Context) {}
+  fn arrow_expr(&mut self, _n: &AstView::ArrowExpr, _ctx: &mut Context) {}
+  fn assign_expr(&mut self, _n: &AstView::AssignExpr, _ctx: &mut Context) {}
+  fn assign_pat(&mut self, _n: &AstView::AssignPat, _ctx: &mut Context) {}
+  fn assign_pat_prop(&mut self, _n: &AstView::AssignPatProp, _ctx: &mut Context) {}
+  fn assign_prop(&mut self, _n: &AstView::AssignProp, _ctx: &mut Context) {}
+  fn await_expr(&mut self, _n: &AstView::AwaitExpr, _ctx: &mut Context) {}
+  fn big_int(&mut self, _n: &AstView::BigInt, _ctx: &mut Context) {}
+  fn bin_expr(&mut self, _n: &AstView::BinExpr, _ctx: &mut Context) {}
+  fn binding_ident(&mut self, _n: &AstView::BindingIdent, _ctx: &mut Context) {}
+  fn block_stmt(&mut self, _n: &AstView::BlockStmt, _ctx: &mut Context) {}
+  fn bool(&mut self, _n: &AstView::Bool, _ctx: &mut Context) {}
+  fn break_stmt(&mut self, _n: &AstView::BreakStmt, _ctx: &mut Context) {}
+  fn call_expr(&mut self, _n: &AstView::CallExpr, _ctx: &mut Context) {}
+  fn catch_clause(&mut self, _n: &AstView::CatchClause, _ctx: &mut Context) {}
+  fn class(&mut self, _n: &AstView::Class, _ctx: &mut Context) {}
+  fn class_decl(&mut self, _n: &AstView::ClassDecl, _ctx: &mut Context) {}
+  fn class_expr(&mut self, _n: &AstView::ClassExpr, _ctx: &mut Context) {}
+  fn class_method(&mut self, _n: &AstView::ClassMethod, _ctx: &mut Context) {}
+  fn class_prop(&mut self, _n: &AstView::ClassProp, _ctx: &mut Context) {}
   fn computed_prop_name(
-    &self,
+    &mut self,
     _n: &AstView::ComputedPropName,
     _ctx: &mut Context,
   ) {
   }
-  fn cond_expr(&self, _n: &AstView::CondExpr, _ctx: &mut Context) {}
-  fn constructor(&self, _n: &AstView::Constructor, _ctx: &mut Context) {}
-  fn continue_stmt(&self, _n: &AstView::ContinueStmt, _ctx: &mut Context) {}
-  fn debugger_stmt(&self, _n: &AstView::DebuggerStmt, _ctx: &mut Context) {}
-  fn decorator(&self, _n: &AstView::Decorator, _ctx: &mut Context) {}
-  fn do_while_stmt(&self, _n: &AstView::DoWhileStmt, _ctx: &mut Context) {}
-  fn empty_stmt(&self, _n: &AstView::EmptyStmt, _ctx: &mut Context) {}
-  fn export_all(&self, _n: &AstView::ExportAll, _ctx: &mut Context) {}
-  fn export_decl(&self, _n: &AstView::ExportDecl, _ctx: &mut Context) {}
+  fn cond_expr(&mut self, _n: &AstView::CondExpr, _ctx: &mut Context) {}
+  fn constructor(&mut self, _n: &AstView::Constructor, _ctx: &mut Context) {}
+  fn continue_stmt(&mut self, _n: &AstView::ContinueStmt, _ctx: &mut Context) {}
+  fn debugger_stmt(&mut self, _n: &AstView::DebuggerStmt, _ctx: &mut Context) {}
+  fn decorator(&mut self, _n: &AstView::Decorator, _ctx: &mut Context) {}
+  fn do_while_stmt(&mut self, _n: &AstView::DoWhileStmt, _ctx: &mut Context) {}
+  fn empty_stmt(&mut self, _n: &AstView::EmptyStmt, _ctx: &mut Context) {}
+  fn export_all(&mut self, _n: &AstView::ExportAll, _ctx: &mut Context) {}
+  fn export_decl(&mut self, _n: &AstView::ExportDecl, _ctx: &mut Context) {}
   fn export_default_decl(
-    &self,
+    &mut self,
     _n: &AstView::ExportDefaultDecl,
     _ctx: &mut Context,
   ) {
   }
   fn export_default_expr(
-    &self,
+    &mut self,
     _n: &AstView::ExportDefaultExpr,
     _ctx: &mut Context,
   ) {
   }
   fn export_default_specifier(
-    &self,
+    &mut self,
     _n: &AstView::ExportDefaultSpecifier,
     _ctx: &mut Context,
   ) {
   }
   fn export_named_specifier(
-    &self,
+    &mut self,
     _n: &AstView::ExportNamedSpecifier,
     _ctx: &mut Context,
   ) {
   }
   fn export_namespace_specifier(
-    &self,
+    &mut self,
     _n: &AstView::ExportNamespaceSpecifier,
     _ctx: &mut Context,
   ) {
   }
-  fn expr_or_spread(&self, _n: &AstView::ExprOrSpread, _ctx: &mut Context) {}
-  fn expr_stmt(&self, _n: &AstView::ExprStmt, _ctx: &mut Context) {}
-  fn fn_decl(&self, _n: &AstView::FnDecl, _ctx: &mut Context) {}
-  fn fn_expr(&self, _n: &AstView::FnExpr, _ctx: &mut Context) {}
-  fn for_in_stmt(&self, _n: &AstView::ForInStmt, _ctx: &mut Context) {}
-  fn for_of_stmt(&self, _n: &AstView::ForOfStmt, _ctx: &mut Context) {}
-  fn for_stmt(&self, _n: &AstView::ForStmt, _ctx: &mut Context) {}
-  fn function(&self, _n: &AstView::Function, _ctx: &mut Context) {}
-  fn getter_prop(&self, _n: &AstView::GetterProp, _ctx: &mut Context) {}
-  fn ident(&self, _n: &AstView::Ident, _ctx: &mut Context) {}
-  fn if_stmt(&self, _n: &AstView::IfStmt, _ctx: &mut Context) {}
-  fn import_decl(&self, _n: &AstView::ImportDecl, _ctx: &mut Context) {}
+  fn expr_or_spread(&mut self, _n: &AstView::ExprOrSpread, _ctx: &mut Context) {}
+  fn expr_stmt(&mut self, _n: &AstView::ExprStmt, _ctx: &mut Context) {}
+  fn fn_decl(&mut self, _n: &AstView::FnDecl, _ctx: &mut Context) {}
+  fn fn_expr(&mut self, _n: &AstView::FnExpr, _ctx: &mut Context) {}
+  fn for_in_stmt(&mut self, _n: &AstView::ForInStmt, _ctx: &mut Context) {}
+  fn for_of_stmt(&mut self, _n: &AstView::ForOfStmt, _ctx: &mut Context) {}
+  fn for_stmt(&mut self, _n: &AstView::ForStmt, _ctx: &mut Context) {}
+  fn function(&mut self, _n: &AstView::Function, _ctx: &mut Context) {}
+  fn getter_prop(&mut self, _n: &AstView::GetterProp, _ctx: &mut Context) {}
+  fn ident(&mut self, _n: &AstView::Ident, _ctx: &mut Context) {}
+  fn if_stmt(&mut self, _n: &AstView::IfStmt, _ctx: &mut Context) {}
+  fn import_decl(&mut self, _n: &AstView::ImportDecl, _ctx: &mut Context) {}
   fn import_default_specifier(
-    &self,
+    &mut self,
     _n: &AstView::ImportDefaultSpecifier,
     _ctx: &mut Context,
   ) {
   }
   fn import_named_specifier(
-    &self,
+    &mut self,
     _n: &AstView::ImportNamedSpecifier,
     _ctx: &mut Context,
   ) {
   }
   fn import_star_as_specifier(
-    &self,
+    &mut self,
     _n: &AstView::ImportStarAsSpecifier,
     _ctx: &mut Context,
   ) {
   }
-  fn invalid(&self, _n: &AstView::Invalid, _ctx: &mut Context) {}
-  fn jsx_attr(&self, _n: &AstView::JSXAttr, _ctx: &mut Context) {}
+  fn invalid(&mut self, _n: &AstView::Invalid, _ctx: &mut Context) {}
+  fn jsx_attr(&mut self, _n: &AstView::JSXAttr, _ctx: &mut Context) {}
   fn jsx_closing_element(
-    &self,
+    &mut self,
     _n: &AstView::JSXClosingElement,
     _ctx: &mut Context,
   ) {
   }
   fn jsx_closing_fragment(
-    &self,
+    &mut self,
     _n: &AstView::JSXClosingFragment,
     _ctx: &mut Context,
   ) {
   }
-  fn jsx_element(&self, _n: &AstView::JSXElement, _ctx: &mut Context) {}
-  fn jsx_empty_expr(&self, _n: &AstView::JSXEmptyExpr, _ctx: &mut Context) {}
+  fn jsx_element(&mut self, _n: &AstView::JSXElement, _ctx: &mut Context) {}
+  fn jsx_empty_expr(&mut self, _n: &AstView::JSXEmptyExpr, _ctx: &mut Context) {}
   fn jsx_expr_container(
-    &self,
+    &mut self,
     _n: &AstView::JSXExprContainer,
     _ctx: &mut Context,
   ) {
   }
-  fn jsx_fragment(&self, _n: &AstView::JSXFragment, _ctx: &mut Context) {}
-  fn jsx_member_expr(&self, _n: &AstView::JSXMemberExpr, _ctx: &mut Context) {}
+  fn jsx_fragment(&mut self, _n: &AstView::JSXFragment, _ctx: &mut Context) {}
+  fn jsx_member_expr(&mut self, _n: &AstView::JSXMemberExpr, _ctx: &mut Context) {}
   fn jsx_namespaced_name(
-    &self,
+    &mut self,
     _n: &AstView::JSXNamespacedName,
     _ctx: &mut Context,
   ) {
   }
   fn jsx_opening_element(
-    &self,
+    &mut self,
     _n: &AstView::JSXOpeningElement,
     _ctx: &mut Context,
   ) {
   }
   fn jsx_opening_fragment(
-    &self,
+    &mut self,
     _n: &AstView::JSXOpeningFragment,
     _ctx: &mut Context,
   ) {
   }
-  fn jsx_spread_child(&self, _n: &AstView::JSXSpreadChild, _ctx: &mut Context) {
+  fn jsx_spread_child(&mut self, _n: &AstView::JSXSpreadChild, _ctx: &mut Context) {
   }
-  fn jsx_text(&self, _n: &AstView::JSXText, _ctx: &mut Context) {}
+  fn jsx_text(&mut self, _n: &AstView::JSXText, _ctx: &mut Context) {}
   fn key_value_pat_prop(
-    &self,
+    &mut self,
     _n: &AstView::KeyValuePatProp,
     _ctx: &mut Context,
   ) {
   }
-  fn key_value_prop(&self, _n: &AstView::KeyValueProp, _ctx: &mut Context) {}
-  fn labeled_stmt(&self, _n: &AstView::LabeledStmt, _ctx: &mut Context) {}
-  fn member_expr(&self, _n: &AstView::MemberExpr, _ctx: &mut Context) {}
-  fn meta_prop_expr(&self, _n: &AstView::MetaPropExpr, _ctx: &mut Context) {}
-  fn method_prop(&self, _n: &AstView::MethodProp, _ctx: &mut Context) {}
-  fn module(&self, _n: &AstView::Module, _ctx: &mut Context) {}
-  fn named_export(&self, _n: &AstView::NamedExport, _ctx: &mut Context) {}
-  fn new_expr(&self, _n: &AstView::NewExpr, _ctx: &mut Context) {}
-  fn null(&self, _n: &AstView::Null, _ctx: &mut Context) {}
-  fn number(&self, _n: &AstView::Number, _ctx: &mut Context) {}
-  fn object_lit(&self, _n: &AstView::ObjectLit, _ctx: &mut Context) {}
-  fn object_pat(&self, _n: &AstView::ObjectPat, _ctx: &mut Context) {}
-  fn opt_chain_expr(&self, _n: &AstView::OptChainExpr, _ctx: &mut Context) {}
-  fn param(&self, _n: &AstView::Param, _ctx: &mut Context) {}
-  fn paren_expr(&self, _n: &AstView::ParenExpr, _ctx: &mut Context) {}
-  fn private_method(&self, _n: &AstView::PrivateMethod, _ctx: &mut Context) {}
-  fn private_name(&self, _n: &AstView::PrivateName, _ctx: &mut Context) {}
-  fn private_prop(&self, _n: &AstView::PrivateProp, _ctx: &mut Context) {}
-  fn regex(&self, _n: &AstView::Regex, _ctx: &mut Context) {}
-  fn rest_pat(&self, _n: &AstView::RestPat, _ctx: &mut Context) {}
-  fn return_stmt(&self, _n: &AstView::ReturnStmt, _ctx: &mut Context) {}
-  fn script(&self, _n: &AstView::Script, _ctx: &mut Context) {}
-  fn seq_expr(&self, _n: &AstView::SeqExpr, _ctx: &mut Context) {}
-  fn setter_prop(&self, _n: &AstView::SetterProp, _ctx: &mut Context) {}
-  fn spread_element(&self, _n: &AstView::SpreadElement, _ctx: &mut Context) {}
-  fn str(&self, _n: &AstView::Str, _ctx: &mut Context) {}
+  fn key_value_prop(&mut self, _n: &AstView::KeyValueProp, _ctx: &mut Context) {}
+  fn labeled_stmt(&mut self, _n: &AstView::LabeledStmt, _ctx: &mut Context) {}
+  fn member_expr(&mut self, _n: &AstView::MemberExpr, _ctx: &mut Context) {}
+  fn meta_prop_expr(&mut self, _n: &AstView::MetaPropExpr, _ctx: &mut Context) {}
+  fn method_prop(&mut self, _n: &AstView::MethodProp, _ctx: &mut Context) {}
+  fn module(&mut self, _n: &AstView::Module, _ctx: &mut Context) {}
+  fn named_export(&mut self, _n: &AstView::NamedExport, _ctx: &mut Context) {}
+  fn new_expr(&mut self, _n: &AstView::NewExpr, _ctx: &mut Context) {}
+  fn null(&mut self, _n: &AstView::Null, _ctx: &mut Context) {}
+  fn number(&mut self, _n: &AstView::Number, _ctx: &mut Context) {}
+  fn object_lit(&mut self, _n: &AstView::ObjectLit, _ctx: &mut Context) {}
+  fn object_pat(&mut self, _n: &AstView::ObjectPat, _ctx: &mut Context) {}
+  fn opt_chain_expr(&mut self, _n: &AstView::OptChainExpr, _ctx: &mut Context) {}
+  fn param(&mut self, _n: &AstView::Param, _ctx: &mut Context) {}
+  fn paren_expr(&mut self, _n: &AstView::ParenExpr, _ctx: &mut Context) {}
+  fn private_method(&mut self, _n: &AstView::PrivateMethod, _ctx: &mut Context) {}
+  fn private_name(&mut self, _n: &AstView::PrivateName, _ctx: &mut Context) {}
+  fn private_prop(&mut self, _n: &AstView::PrivateProp, _ctx: &mut Context) {}
+  fn regex(&mut self, _n: &AstView::Regex, _ctx: &mut Context) {}
+  fn rest_pat(&mut self, _n: &AstView::RestPat, _ctx: &mut Context) {}
+  fn return_stmt(&mut self, _n: &AstView::ReturnStmt, _ctx: &mut Context) {}
+  fn script(&mut self, _n: &AstView::Script, _ctx: &mut Context) {}
+  fn seq_expr(&mut self, _n: &AstView::SeqExpr, _ctx: &mut Context) {}
+  fn setter_prop(&mut self, _n: &AstView::SetterProp, _ctx: &mut Context) {}
+  fn spread_element(&mut self, _n: &AstView::SpreadElement, _ctx: &mut Context) {}
+  fn str(&mut self, _n: &AstView::Str, _ctx: &mut Context) {}
   // Neither `super` or `r#super` can be used here, so we use `super_` reluctantly
-  fn super_(&self, _n: &AstView::Super, _ctx: &mut Context) {}
-  fn switch_case(&self, _n: &AstView::SwitchCase, _ctx: &mut Context) {}
-  fn switch_stmt(&self, _n: &AstView::SwitchStmt, _ctx: &mut Context) {}
-  fn tagged_tpl(&self, _n: &AstView::TaggedTpl, _ctx: &mut Context) {}
-  fn this_expr(&self, _n: &AstView::ThisExpr, _ctx: &mut Context) {}
-  fn throw_stmt(&self, _n: &AstView::ThrowStmt, _ctx: &mut Context) {}
-  fn tpl(&self, _n: &AstView::Tpl, _ctx: &mut Context) {}
-  fn tpl_element(&self, _n: &AstView::TplElement, _ctx: &mut Context) {}
-  fn try_stmt(&self, _n: &AstView::TryStmt, _ctx: &mut Context) {}
-  fn ts_array_type(&self, _n: &AstView::TsArrayType, _ctx: &mut Context) {}
-  fn ts_as_expr(&self, _n: &AstView::TsAsExpr, _ctx: &mut Context) {}
+  fn super_(&mut self, _n: &AstView::Super, _ctx: &mut Context) {}
+  fn switch_case(&mut self, _n: &AstView::SwitchCase, _ctx: &mut Context) {}
+  fn switch_stmt(&mut self, _n: &AstView::SwitchStmt, _ctx: &mut Context) {}
+  fn tagged_tpl(&mut self, _n: &AstView::TaggedTpl, _ctx: &mut Context) {}
+  fn this_expr(&mut self, _n: &AstView::ThisExpr, _ctx: &mut Context) {}
+  fn throw_stmt(&mut self, _n: &AstView::ThrowStmt, _ctx: &mut Context) {}
+  fn tpl(&mut self, _n: &AstView::Tpl, _ctx: &mut Context) {}
+  fn tpl_element(&mut self, _n: &AstView::TplElement, _ctx: &mut Context) {}
+  fn try_stmt(&mut self, _n: &AstView::TryStmt, _ctx: &mut Context) {}
+  fn ts_array_type(&mut self, _n: &AstView::TsArrayType, _ctx: &mut Context) {}
+  fn ts_as_expr(&mut self, _n: &AstView::TsAsExpr, _ctx: &mut Context) {}
   fn ts_call_signature_decl(
-    &self,
+    &mut self,
     _n: &AstView::TsCallSignatureDecl,
     _ctx: &mut Context,
   ) {
   }
   fn ts_conditional_type(
-    &self,
+    &mut self,
     _n: &AstView::TsConditionalType,
     _ctx: &mut Context,
   ) {
   }
   fn ts_const_assertion(
-    &self,
+    &mut self,
     _n: &AstView::TsConstAssertion,
     _ctx: &mut Context,
   ) {
   }
   fn ts_construct_signature_decl(
-    &self,
+    &mut self,
     _n: &AstView::TsConstructSignatureDecl,
     _ctx: &mut Context,
   ) {
   }
   fn ts_constructor_type(
-    &self,
+    &mut self,
     _n: &AstView::TsConstructorType,
     _ctx: &mut Context,
   ) {
   }
-  fn ts_enum_decl(&self, _n: &AstView::TsEnumDecl, _ctx: &mut Context) {}
-  fn ts_enum_member(&self, _n: &AstView::TsEnumMember, _ctx: &mut Context) {}
+  fn ts_enum_decl(&mut self, _n: &AstView::TsEnumDecl, _ctx: &mut Context) {}
+  fn ts_enum_member(&mut self, _n: &AstView::TsEnumMember, _ctx: &mut Context) {}
   fn ts_export_assignment(
-    &self,
+    &mut self,
     _n: &AstView::TsExportAssignment,
     _ctx: &mut Context,
   ) {
   }
   fn ts_expr_with_type_args(
-    &self,
+    &mut self,
     _n: &AstView::TsExprWithTypeArgs,
     _ctx: &mut Context,
   ) {
   }
   fn ts_external_module_ref(
-    &self,
+    &mut self,
     _n: &AstView::TsExternalModuleRef,
     _ctx: &mut Context,
   ) {
   }
-  fn ts_fn_type(&self, _n: &AstView::TsFnType, _ctx: &mut Context) {}
+  fn ts_fn_type(&mut self, _n: &AstView::TsFnType, _ctx: &mut Context) {}
   fn ts_import_equal_decl(
-    &self,
+    &mut self,
     _n: &AstView::TsImportEqualsDecl,
     _ctx: &mut Context,
   ) {
   }
-  fn ts_import_type(&self, _n: &AstView::TsImportType, _ctx: &mut Context) {}
+  fn ts_import_type(&mut self, _n: &AstView::TsImportType, _ctx: &mut Context) {}
   fn ts_index_signature(
-    &self,
+    &mut self,
     _n: &AstView::TsIndexSignature,
     _ctx: &mut Context,
   ) {
   }
   fn ts_indexed_access_type(
-    &self,
+    &mut self,
     _n: &AstView::TsIndexedAccessType,
     _ctx: &mut Context,
   ) {
   }
-  fn ts_infer_type(&self, _n: &AstView::TsInferType, _ctx: &mut Context) {}
+  fn ts_infer_type(&mut self, _n: &AstView::TsInferType, _ctx: &mut Context) {}
   fn ts_interface_body(
-    &self,
+    &mut self,
     _n: &AstView::TsInterfaceBody,
     _ctx: &mut Context,
   ) {
   }
   fn ts_interface_decl(
-    &self,
+    &mut self,
     _n: &AstView::TsInterfaceDecl,
     _ctx: &mut Context,
   ) {
   }
   fn ts_intersection_type(
-    &self,
+    &mut self,
     _n: &AstView::TsIntersectionType,
     _ctx: &mut Context,
   ) {
   }
-  fn ts_keyword_type(&self, _n: &AstView::TsKeywordType, _ctx: &mut Context) {}
-  fn ts_lit_type(&self, _n: &AstView::TsLitType, _ctx: &mut Context) {}
-  fn ts_mapped_type(&self, _n: &AstView::TsMappedType, _ctx: &mut Context) {}
+  fn ts_keyword_type(&mut self, _n: &AstView::TsKeywordType, _ctx: &mut Context) {}
+  fn ts_lit_type(&mut self, _n: &AstView::TsLitType, _ctx: &mut Context) {}
+  fn ts_mapped_type(&mut self, _n: &AstView::TsMappedType, _ctx: &mut Context) {}
   fn ts_method_signature(
-    &self,
+    &mut self,
     _n: &AstView::TsMethodSignature,
     _ctx: &mut Context,
   ) {
   }
-  fn ts_module_block(&self, _n: &AstView::TsModuleBlock, _ctx: &mut Context) {}
-  fn ts_module_decl(&self, _n: &AstView::TsModuleDecl, _ctx: &mut Context) {}
+  fn ts_module_block(&mut self, _n: &AstView::TsModuleBlock, _ctx: &mut Context) {}
+  fn ts_module_decl(&mut self, _n: &AstView::TsModuleDecl, _ctx: &mut Context) {}
   fn ts_namespace_decl(
-    &self,
+    &mut self,
     _n: &AstView::TsNamespaceDecl,
     _ctx: &mut Context,
   ) {
   }
   fn ts_namespace_export_decl(
-    &self,
+    &mut self,
     _n: &AstView::TsNamespaceExportDecl,
     _ctx: &mut Context,
   ) {
   }
-  fn ts_non_null_expr(&self, _n: &AstView::TsNonNullExpr, _ctx: &mut Context) {}
-  fn ts_optional_type(&self, _n: &AstView::TsOptionalType, _ctx: &mut Context) {
+  fn ts_non_null_expr(&mut self, _n: &AstView::TsNonNullExpr, _ctx: &mut Context) {}
+  fn ts_optional_type(&mut self, _n: &AstView::TsOptionalType, _ctx: &mut Context) {
   }
-  fn ts_param_prop(&self, _n: &AstView::TsParamProp, _ctx: &mut Context) {}
+  fn ts_param_prop(&mut self, _n: &AstView::TsParamProp, _ctx: &mut Context) {}
   fn ts_parenthesized_type(
-    &self,
+    &mut self,
     _n: &AstView::TsParenthesizedType,
     _ctx: &mut Context,
   ) {
   }
   fn ts_property_signature(
-    &self,
+    &mut self,
     _n: &AstView::TsPropertySignature,
     _ctx: &mut Context,
   ) {
   }
   fn ts_qualified_name(
-    &self,
+    &mut self,
     _n: &AstView::TsQualifiedName,
     _ctx: &mut Context,
   ) {
   }
-  fn ts_rest_type(&self, _n: &AstView::TsRestType, _ctx: &mut Context) {}
-  fn ts_this_type(&self, _n: &AstView::TsThisType, _ctx: &mut Context) {}
-  fn ts_tpl_lit_type(&self, _n: &AstView::TsTplLitType, _ctx: &mut Context) {}
-  fn ts_tuple_element(&self, _n: &AstView::TsTupleElement, _ctx: &mut Context) {
+  fn ts_rest_type(&mut self, _n: &AstView::TsRestType, _ctx: &mut Context) {}
+  fn ts_this_type(&mut self, _n: &AstView::TsThisType, _ctx: &mut Context) {}
+  fn ts_tpl_lit_type(&mut self, _n: &AstView::TsTplLitType, _ctx: &mut Context) {}
+  fn ts_tuple_element(&mut self, _n: &AstView::TsTupleElement, _ctx: &mut Context) {
   }
-  fn ts_tuple_type(&self, _n: &AstView::TsTupleType, _ctx: &mut Context) {}
+  fn ts_tuple_type(&mut self, _n: &AstView::TsTupleType, _ctx: &mut Context) {}
   fn ts_type_alias_decl(
-    &self,
+    &mut self,
     _n: &AstView::TsTypeAliasDecl,
     _ctx: &mut Context,
   ) {
   }
-  fn ts_type_ann(&self, _n: &AstView::TsTypeAnn, _ctx: &mut Context) {}
+  fn ts_type_ann(&mut self, _n: &AstView::TsTypeAnn, _ctx: &mut Context) {}
   fn ts_type_assertion(
-    &self,
+    &mut self,
     _n: &AstView::TsTypeAssertion,
     _ctx: &mut Context,
   ) {
   }
-  fn ts_type_lit(&self, _n: &AstView::TsTypeLit, _ctx: &mut Context) {}
-  fn ts_type_operator(&self, _n: &AstView::TsTypeOperator, _ctx: &mut Context) {
+  fn ts_type_lit(&mut self, _n: &AstView::TsTypeLit, _ctx: &mut Context) {}
+  fn ts_type_operator(&mut self, _n: &AstView::TsTypeOperator, _ctx: &mut Context) {
   }
-  fn ts_type_param(&self, _n: &AstView::TsTypeParam, _ctx: &mut Context) {}
+  fn ts_type_param(&mut self, _n: &AstView::TsTypeParam, _ctx: &mut Context) {}
   fn ts_type_param_decl(
-    &self,
+    &mut self,
     _n: &AstView::TsTypeParamDecl,
     _ctx: &mut Context,
   ) {
   }
   fn ts_type_param_instantiation(
-    &self,
+    &mut self,
     _n: &AstView::TsTypeParamInstantiation,
     _ctx: &mut Context,
   ) {
   }
   fn ts_type_predicate(
-    &self,
+    &mut self,
     _n: &AstView::TsTypePredicate,
     _ctx: &mut Context,
   ) {
   }
-  fn ts_type_query(&self, _n: &AstView::TsTypeQuery, _ctx: &mut Context) {}
-  fn ts_type_ref(&self, _n: &AstView::TsTypeRef, _ctx: &mut Context) {}
-  fn ts_union_type(&self, _n: &AstView::TsUnionType, _ctx: &mut Context) {}
-  fn unary_expr(&self, _n: &AstView::UnaryExpr, _ctx: &mut Context) {}
-  fn update_expr(&self, _n: &AstView::UpdateExpr, _ctx: &mut Context) {}
-  fn var_decl(&self, _n: &AstView::VarDecl, _ctx: &mut Context) {}
-  fn var_declarator(&self, _n: &AstView::VarDeclarator, _ctx: &mut Context) {}
-  fn while_stmt(&self, _n: &AstView::WhileStmt, _ctx: &mut Context) {}
-  fn with_stmt(&self, _n: &AstView::WithStmt, _ctx: &mut Context) {}
-  fn yield_expr(&self, _n: &AstView::YieldExpr, _ctx: &mut Context) {}
+  fn ts_type_query(&mut self, _n: &AstView::TsTypeQuery, _ctx: &mut Context) {}
+  fn ts_type_ref(&mut self, _n: &AstView::TsTypeRef, _ctx: &mut Context) {}
+  fn ts_union_type(&mut self, _n: &AstView::TsUnionType, _ctx: &mut Context) {}
+  fn unary_expr(&mut self, _n: &AstView::UnaryExpr, _ctx: &mut Context) {}
+  fn update_expr(&mut self, _n: &AstView::UpdateExpr, _ctx: &mut Context) {}
+  fn var_decl(&mut self, _n: &AstView::VarDecl, _ctx: &mut Context) {}
+  fn var_declarator(&mut self, _n: &AstView::VarDeclarator, _ctx: &mut Context) {}
+  fn while_stmt(&mut self, _n: &AstView::WhileStmt, _ctx: &mut Context) {}
+  fn with_stmt(&mut self, _n: &AstView::WithStmt, _ctx: &mut Context) {}
+  fn yield_expr(&mut self, _n: &AstView::YieldExpr, _ctx: &mut Context) {}
 }
 
 pub trait Traverse: Handler {
-  fn traverse<'a, N>(&self, node: N, ctx: &mut Context)
+  fn traverse<'a, N>(&mut self, node: N, ctx: &mut Context)
   where
     N: NodeTrait<'a>,
   {

--- a/src/rules/no_await_in_loop.rs
+++ b/src/rules/no_await_in_loop.rs
@@ -74,7 +74,7 @@ async function doSomething(items) {
 struct NoAwaitInLoopHandler;
 
 impl Handler for NoAwaitInLoopHandler {
-  fn await_expr(&self, await_expr: &AstView::AwaitExpr, ctx: &mut Context) {
+  fn await_expr(&mut self, await_expr: &AstView::AwaitExpr, ctx: &mut Context) {
     fn inside_loop(
       await_expr: &AstView::AwaitExpr,
       node: AstView::Node,

--- a/src/rules/no_this_before_super.rs
+++ b/src/rules/no_this_before_super.rs
@@ -144,7 +144,6 @@ impl<'a> Visit for ConstructorVisitor<'a> {
 #[cfg(test)]
 mod tests {
   use super::*;
-  use crate::test_util::*;
 
   #[test]
   fn no_this_before_super_valid() {
@@ -172,12 +171,46 @@ class A extends B {
   }
 }
       "#,
+
+      // inline super class
+      r#"
+class A extends class extends B {
+  constructor() {
+    super();
+    this.a = 0;
+  }
+} {
+    constructor() {
+      super();
+      this.a = 0;
+    }
+}
+      "#,
+
+      // nested class
+      r#"
+class A extends B {
+  constructor() {
+    super();
+    this.a = 0;
+  }
+  foo() {
+    class C extends D {
+      constructor() {
+        super();
+        this.c = 1;
+      }
+    }
+  }
+}
+      "#,
     };
   }
 
   #[test]
   fn no_this_before_super_invalid() {
-    assert_lint_err_on_line::<NoThisBeforeSuper>(
+    assert_lint_err! {
+      NoThisBeforeSuper,
       r#"
 class A extends B {
   constructor() {
@@ -185,12 +218,14 @@ class A extends B {
     super();
   }
 }
-      "#,
-      4,
-      4,
-    );
-
-    assert_lint_err_on_line::<NoThisBeforeSuper>(
+      "#: [
+        {
+          line: 4,
+          col: 4,
+          message: MESSAGE,
+          hint: HINT,
+        }
+      ],
       r#"
 class A extends B {
   constructor() {
@@ -198,12 +233,14 @@ class A extends B {
     super();
   }
 }
-      "#,
-      4,
-      4,
-    );
-
-    assert_lint_err_on_line::<NoThisBeforeSuper>(
+      "#: [
+        {
+          line: 4,
+          col: 4,
+          message: MESSAGE,
+          hint: HINT,
+        }
+      ],
       r#"
 class A extends B {
   constructor() {
@@ -211,24 +248,28 @@ class A extends B {
     super();
   }
 }
-    "#,
-      4,
-      4,
-    );
-
-    assert_lint_err_on_line::<NoThisBeforeSuper>(
+    "#: [
+        {
+          line: 4,
+          col: 4,
+          message: MESSAGE,
+          hint: HINT,
+        }
+      ],
       r#"
 class A extends B {
   constructor() {
     super(this.foo());
   }
 }
-    "#,
-      4,
-      10,
-    );
-
-    assert_lint_err_on_line::<NoThisBeforeSuper>(
+    "#: [
+        {
+          line: 4,
+          col: 10,
+          message: MESSAGE,
+          hint: HINT,
+        }
+      ],
       r#"
 class A extends B {
   constructor() {
@@ -241,29 +282,14 @@ class C extends D {
     super();
   }
 }
-    "#,
-      9,
-      4,
-    );
-
-    // inline super class
-    assert_lint_ok::<NoThisBeforeSuper>(
-      r#"
-class A extends class extends B {
-  constructor() {
-    super();
-    this.a = 0;
-  }
-} {
-    constructor() {
-      super();
-      this.a = 0;
-    }
-}
-      "#,
-    );
-
-    assert_lint_err_on_line::<NoThisBeforeSuper>(
+    "#: [
+        {
+          line: 9,
+          col: 4,
+          message: MESSAGE,
+          hint: HINT,
+        }
+      ],
       r#"
 class A extends class extends B {
   constructor() {
@@ -276,12 +302,14 @@ class A extends class extends B {
       this.a = 0;
     }
 }
-      "#,
-      4,
-      4,
-    );
-
-    assert_lint_err_on_line::<NoThisBeforeSuper>(
+      "#: [
+        {
+          line: 4,
+          col: 4,
+          message: MESSAGE,
+          hint: HINT,
+        }
+      ],
       r#"
 class A extends class extends B {
   constructor() {
@@ -294,34 +322,14 @@ class A extends class extends B {
       super();
     }
 }
-      "#,
-      9,
-      6,
-    );
-  }
-
-  #[test]
-  fn no_this_before_super_nested_class() {
-    assert_lint_ok::<NoThisBeforeSuper>(
-      r#"
-class A extends B {
-  constructor() {
-    super();
-    this.a = 0;
-  }
-  foo() {
-    class C extends D {
-      constructor() {
-        super();
-        this.c = 1;
-      }
-    }
-  }
-}
-      "#,
-    );
-
-    assert_lint_err_on_line::<NoThisBeforeSuper>(
+      "#: [
+        {
+          line: 9,
+          col: 6,
+          message: MESSAGE,
+          hint: HINT,
+        }
+      ],
       r#"
 class A extends B {
   constructor() {
@@ -336,12 +344,14 @@ class A extends B {
     }
   }
 }
-      "#,
-      10,
-      8,
-    );
-
-    assert_lint_err_on_line::<NoThisBeforeSuper>(
+      "#: [
+        {
+          line: 10,
+          col: 8,
+          message: MESSAGE,
+          hint: HINT,
+        }
+      ],
       r#"
 class A extends B {
   constructor() {
@@ -357,12 +367,14 @@ class A extends B {
     }
   }
 }
-      "#,
-      4,
-      4,
-    );
-
-    assert_lint_err_on_line::<NoThisBeforeSuper>(
+      "#: [
+        {
+          line: 4,
+          col: 4,
+          message: MESSAGE,
+          hint: HINT,
+        }
+      ],
       r#"
 class A {
   constructor() {
@@ -376,12 +388,14 @@ class A {
     }
   }
 }
-      "#,
-      9,
-      8,
-    );
-
-    assert_lint_err_on_line::<NoThisBeforeSuper>(
+      "#: [
+        {
+          line: 9,
+          col: 8,
+          message: MESSAGE,
+          hint: HINT,
+        }
+      ],
       r#"
 class A extends B {
   constructor() {
@@ -395,12 +409,14 @@ class A extends B {
     }
   }
 }
-      "#,
-      4,
-      4,
-    );
-
-    assert_lint_err_on_line::<NoThisBeforeSuper>(
+      "#: [
+        {
+          line: 4,
+          col: 4,
+          message: MESSAGE,
+          hint: HINT,
+        }
+      ],
       r#"
 class A extends B {
   constructor() {
@@ -413,9 +429,14 @@ class A extends B {
     }
   }
 }
-      "#,
-      8,
-      8,
-    );
+      "#: [
+        {
+          line: 8,
+          col: 8,
+          message: MESSAGE,
+          hint: HINT,
+        }
+      ]
+    };
   }
 }

--- a/src/rules/no_this_before_super.rs
+++ b/src/rules/no_this_before_super.rs
@@ -7,6 +7,10 @@ use swc_ecmascript::visit::{noop_visit_type, Node, Visit};
 
 pub struct NoThisBeforeSuper;
 
+const CODE: &str = "no-this-before-super";
+const MESSAGE: &str = "In the constructor of derived classes, `this` / `super` are not allowed before calling to `super()`.";
+const HINT: &str = "Call `super()` before using `this` or `super` keyword.";
+
 impl LintRule for NoThisBeforeSuper {
   fn new() -> Box<Self> {
     Box::new(NoThisBeforeSuper)
@@ -17,7 +21,7 @@ impl LintRule for NoThisBeforeSuper {
   }
 
   fn code(&self) -> &'static str {
-    "no-this-before-super"
+      CODE
   }
 
   fn lint_program(&self, context: &mut Context, program: ProgramRef<'_>) {
@@ -116,20 +120,22 @@ impl<'a> Visit for ConstructorVisitor<'a> {
 
   fn visit_this_expr(&mut self, this_expr: &ThisExpr, _parent: &dyn Node) {
     if !self.super_called {
-      self.context.add_diagnostic(
+      self.context.add_diagnostic_with_hint(
         this_expr.span,
-        "no-this-before-super",
-        "'this' / 'super' are not allowed before 'super()'.",
+        CODE,
+        MESSAGE,
+        HINT,
       );
     }
   }
 
   fn visit_super(&mut self, sup: &Super, _parent: &dyn Node) {
     if !self.super_called {
-      self.context.add_diagnostic(
+      self.context.add_diagnostic_with_hint(
         sup.span,
-        "no-this-before-super",
-        "'this' / 'super' are not allowed before 'super()'.",
+        CODE,
+        MESSAGE,
+        HINT,
       );
     }
   }

--- a/src/rules/no_with.rs
+++ b/src/rules/no_with.rs
@@ -37,7 +37,7 @@ struct NoWithHandler;
 
 impl Handler for NoWithHandler {
   fn with_stmt(
-    &self,
+    &mut self,
     with_stmt: &dprint_swc_ecma_ast_view::WithStmt,
     ctx: &mut Context,
   ) {


### PR DESCRIPTION
This PR does the following:

- modify `Handler` signatures to take a mutable reference so that implementors can store states while traversing
- add special handler methods `on_enter_node` and `on_exit_node`
- rewrite `no-this-before-super` with dprint-swc-ecma-ast-view
- switch to `assert_lint_err!` macro
- add some test cases to ensure that functions inside a constructor are processed correctly

Part of #431 