### PR TITLE
fix(no-unsafe-finally): deal with if-statements or functions in finally blocks, etc.

### DIFF
--- a/src/rules/no_unsafe_finally.rs
+++ b/src/rules/no_unsafe_finally.rs
@@ -156,7 +156,6 @@ fn add_diagnostic_with_hint(ctx: &mut Context, span: Span, stmt_type: &str) {
 #[cfg(test)]
 mod tests {
   use super::*;
-  use crate::test_util::*;
 
   #[test]
   fn no_unsafe_finally_valid() {
@@ -207,7 +206,8 @@ let foo = function(a) {
 
   #[test]
   fn no_unsafe_finally_invalid() {
-    assert_lint_err_on_line::<NoUnsafeFinally>(
+    assert_lint_err! {
+      NoUnsafeFinally,
       r#"
 let foo = function() {
   try {
@@ -218,11 +218,14 @@ let foo = function() {
     break;
   }
 };
-     "#,
-      8,
-      4,
-    );
-    assert_lint_err_on_line::<NoUnsafeFinally>(
+     "#: [
+        {
+          line: 8,
+          col: 4,
+          message: variant!(NoUnsafeFinallyMessage, UnsafeUsage, "break"),
+          hint: HINT,
+        }
+      ],
       r#"
 let foo = function() {
   try {
@@ -233,11 +236,14 @@ let foo = function() {
     continue;
   }
 };
-     "#,
-      8,
-      4,
-    );
-    assert_lint_err_on_line::<NoUnsafeFinally>(
+     "#: [
+        {
+          line: 8,
+          col: 4,
+          message: variant!(NoUnsafeFinallyMessage, UnsafeUsage, "continue"),
+          hint: HINT,
+        }
+      ],
       r#"
 let foo = function() {
   try {
@@ -248,11 +254,14 @@ let foo = function() {
     return 3;
   }
 };
-          "#,
-      8,
-      4,
-    );
-    assert_lint_err_on_line::<NoUnsafeFinally>(
+          "#: [
+        {
+          line: 8,
+          col: 4,
+          message: variant!(NoUnsafeFinallyMessage, UnsafeUsage, "return"),
+          hint: HINT,
+        }
+      ],
       r#"
 let foo = function() {
   try {
@@ -263,11 +272,14 @@ let foo = function() {
     throw new Error;
   }
 };
-     "#,
-      8,
-      4,
-    );
-    assert_lint_err_on_line::<NoUnsafeFinally>(
+     "#: [
+        {
+          line: 8,
+          col: 4,
+          message: variant!(NoUnsafeFinallyMessage, UnsafeUsage, "throw"),
+          hint: HINT,
+        }
+      ],
       r#"
 try {}
 finally {
@@ -276,9 +288,14 @@ finally {
     throw new Error;
   }
 }
-     "#,
-      6,
-      4,
-    );
+     "#: [
+        {
+          line: 6,
+          col: 4,
+          message: variant!(NoUnsafeFinallyMessage, UnsafeUsage, "throw"),
+          hint: HINT,
+        }
+      ]
+    };
   }
 }

--- a/src/rules/no_unsafe_finally.rs
+++ b/src/rules/no_unsafe_finally.rs
@@ -513,7 +513,178 @@ finally {
           message: variant!(NoUnsafeFinallyMessage, UnsafeUsage, "throw"),
           hint: HINT,
         }
-      ]
+      ],
+      r#"
+function foo() {
+  try {}
+  finally {
+    if (x) {
+      return 0;
+    } else {
+      return 1;
+    }
+  }
+}
+     "#: [
+        {
+          line: 6,
+          col: 6,
+          message: variant!(NoUnsafeFinallyMessage, UnsafeUsage, "return"),
+          hint: HINT,
+        },
+        {
+          line: 8,
+          col: 6,
+          message: variant!(NoUnsafeFinallyMessage, UnsafeUsage, "return"),
+          hint: HINT,
+        },
+      ],
+      r#"
+function foo() {
+  try {}
+  finally {
+    return () => {
+      return 0;
+    };
+  }
+}
+     "#: [
+        {
+          line: 5,
+          col: 4,
+          message: variant!(NoUnsafeFinallyMessage, UnsafeUsage, "return"),
+          hint: HINT,
+        }
+      ],
+      r#"
+function foo() {
+  label: try {
+    return 0;
+  } finally {
+    break label;
+  }
+}
+     "#: [
+        {
+          line: 6,
+          col: 4,
+          message: variant!(NoUnsafeFinallyMessage, UnsafeUsage, "break"),
+          hint: HINT,
+        }
+      ],
+      r#"
+function foo() {
+  while (x) {
+    try {}
+    finally {
+      break;
+    }
+  }
+}
+     "#: [
+        {
+          line: 6,
+          col: 6,
+          message: variant!(NoUnsafeFinallyMessage, UnsafeUsage, "break"),
+          hint: HINT,
+        }
+      ],
+      r#"
+function foo() {
+  while (x) {
+    try {}
+    finally {
+      continue;
+    }
+  }
+}
+     "#: [
+        {
+          line: 6,
+          col: 6,
+          message: variant!(NoUnsafeFinallyMessage, UnsafeUsage, "continue"),
+          hint: HINT,
+        }
+      ],
+      r#"
+function foo() {
+  switch (x) {
+    case 0:
+      try {}
+      finally {
+        break;
+      }
+  }
+}
+     "#: [
+        {
+          line: 7,
+          col: 8,
+          message: variant!(NoUnsafeFinallyMessage, UnsafeUsage, "break"),
+          hint: HINT,
+        }
+      ],
+      r#"
+function foo() {
+  a: while (x) {
+    try {}
+    finally {
+      switch (y) {
+        case 0:
+          break a;
+      }
+    }
+  }
+}
+     "#: [
+        {
+          line: 8,
+          col: 10,
+          message: variant!(NoUnsafeFinallyMessage, UnsafeUsage, "break"),
+          hint: HINT,
+        }
+      ],
+      r#"
+function foo() {
+  while (x) {
+    try {}
+    finally {
+      switch (y) {
+        case 0:
+          continue;
+      }
+    }
+  }
+}
+     "#: [
+        {
+          line: 8,
+          col: 10,
+          message: variant!(NoUnsafeFinallyMessage, UnsafeUsage, "continue"),
+          hint: HINT,
+        }
+      ],
+      r#"
+function foo() {
+  a: switch (x) {
+    case 0:
+      try {}
+      finally {
+        switch (y) {
+          case 1:
+            break a;
+        }
+      }
+  }
+}
+     "#: [
+        {
+          line: 9,
+          col: 12,
+          message: variant!(NoUnsafeFinallyMessage, UnsafeUsage, "break"),
+          hint: HINT,
+        }
+      ],
     };
   }
 }

--- a/src/rules/no_unsafe_finally.rs
+++ b/src/rules/no_unsafe_finally.rs
@@ -8,7 +8,8 @@ use swc_common::{Span, Spanned};
 pub struct NoUnsafeFinally;
 
 const CODE: &str = "no-unsafe-finally";
-const HINT: &str = "Use of the control flow statements (`return`, `throw`, `break` and `continue`) in a `finally` block will most likely lead to undesired behavior. It's recommended to take a second look.";
+const HINT: &str = "Use of the control flow statements (`return`, `throw`, `break` and `continue`) in a `finally` block\
+will most likely lead to undesired behavior.";
 
 #[derive(Display)]
 enum NoUnsafeFinallyMessage {


### PR DESCRIPTION
Part of #330, #431

- rewrite the implementation with dprint-swc-ecma-ast-view
- add hint message
- refine the implementation so it can properly work for a) if-statements or functions in finally blocks, b) labeled statements
- add/port more tests referring to [ESLint](https://github.com/eslint/eslint/blob/master/tests/lib/rules/no-unsafe-finally.js)