### PR TITLE
0.2.20

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -238,7 +238,7 @@ dependencies = [
 
 [[package]]
 name = "deno_lint"
-version = "0.2.19"
+version = "0.2.20"
 dependencies = [
  "annotate-snippets",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deno_lint"
-version = "0.2.19"
+version = "0.2.20"
 edition = "2018"
 description = "lint for deno"
 authors = ["the Deno authors"]
@@ -22,7 +22,7 @@ serde_json = "1.0.62"
 swc_atoms = "0.2.5"
 swc_common = "0.10.12"
 swc_ecmascript = { version = "0.24.1", features = ["parser", "transforms", "utils", "visit"] }
-regex = "1.4.3"
+regex = "=1.4.3"
 once_cell = "1.5.2"
 derive_more = { version = "0.99.11", features = ["display"] }
 anyhow = "1.0.38"


### PR DESCRIPTION
This is a patch release forked from 0.2.19 that locks regex crate to `=1.4.3`.﻿
