### PR TITLE
chore: upgrade dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -92,9 +92,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.6.0"
+version = "3.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "099e596ef14349721d9016f6b80dd3419ea1bf289ab9b44df8e4dfd3a005d5d9"
+checksum = "63396b8a4b9de3f4fdfb320ab6080762242f66a8ef174c49d8e19b674db4cdbe"
 
 [[package]]
 name = "byteorder"
@@ -279,9 +279,9 @@ dependencies = [
 
 [[package]]
 name = "dprint-swc-ecma-ast-view"
-version = "0.10.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b495385633bb59f360775a5278327c294c42484e5256288c80e591db334227e"
+checksum = "ecf692a2ee5c5f699ed0e95f21686cf6367f3a591e5d8e7bd3041bbf184651f9"
 dependencies = [
  "bumpalo",
  "fnv",
@@ -1082,9 +1082,9 @@ dependencies = [
 
 [[package]]
 name = "swc_common"
-version = "0.10.12"
+version = "0.10.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "570f4343486251030e61186c144952d1bcc1dc4ac8b334ce450264788603b4e3"
+checksum = "1c46e9d1414d5a361a4eb548e3f76bee3e2d9f8f4333907881fe681a59a829aa"
 dependencies = [
  "ast_node",
  "cfg-if 0.1.10",
@@ -1105,9 +1105,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_ast"
-version = "0.40.0"
+version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b73b90f45238ac4b29e264591cfb34b0df32fb336f74a12a369678c7d5e906b"
+checksum = "83eb6a73820660a5af3c24ae1d436e84e4d4c13822021140011361e678df247b"
 dependencies = [
  "is-macro",
  "num-bigint",
@@ -1119,9 +1119,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_parser"
-version = "0.49.0"
+version = "0.52.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9070f184ca5724d67325dbc4a9d6e8e18c27a0439c95e088e246a3404ef2f05f"
+checksum = "c03250697857164f16fa98f8e1726f566652d13e52ea3f0c3ecea9deb63ee327"
 dependencies = [
  "either",
  "enum_kind",
@@ -1139,9 +1139,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms"
-version = "0.38.1"
+version = "0.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2fa7fa6a8ab3b65767e01efae34d5079c7e964826074ce7b1f10cb66175d9d3"
+checksum = "fb55368ba3185781373a120060e6cbc4f058c947e29a03c9f82fa492d76f2082"
 dependencies = [
  "swc_atoms",
  "swc_common",
@@ -1155,9 +1155,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_base"
-version = "0.6.2"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21db046d7e79ba05a42292c905740a47b1da241e71d55c5adc75a0a5418576b6"
+checksum = "9e255452f3ce0a34bc8e31e098c4d74fb53fa5fa01127d7c1dc01a4e6d299e05"
 dependencies = [
  "fxhash",
  "once_cell",
@@ -1174,9 +1174,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_utils"
-version = "0.30.0"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80d1e28b7c0c0a463c0b565af98cd1d241313990568e657bb2f1bd4468892d93"
+checksum = "c0178053286bfdde5cfc53f68fb76c3741e2a2a848d5f47327559dff01beb34a"
 dependencies = [
  "once_cell",
  "scoped-tls",
@@ -1189,9 +1189,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_visit"
-version = "0.26.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd01a0c58d20627f2fa29f44c5c6f68ae7d2ca6e2de0447429f2db65e4482a4e"
+checksum = "fd3d60b9dc97ae4f181d4d60f43142d8ac9669953db410bcedefb29a14627e19"
 dependencies = [
  "num-bigint",
  "swc_atoms",
@@ -1202,9 +1202,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecmascript"
-version = "0.24.1"
+version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e54da8566eb8035ea784b7297e16db45525242a7c955d8b9b3a5895d5694abbe"
+checksum = "3ffb53afe008c15d4dc4957e80148c4b457659f93e4d4e8736eaeae352e48ec8"
 dependencies = [
  "swc_ecma_ast",
  "swc_ecma_parser",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -279,9 +279,9 @@ dependencies = [
 
 [[package]]
 name = "dprint-swc-ecma-ast-view"
-version = "0.13.1"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecf692a2ee5c5f699ed0e95f21686cf6367f3a591e5d8e7bd3041bbf184651f9"
+checksum = "1a58a42bc0f1fe40953a1dd865ee739bf71758c00420a1274bf679681e0e2f5a"
 dependencies = [
  "bumpalo",
  "fnv",
@@ -1072,9 +1072,9 @@ checksum = "6446ced80d6c486436db5c078dde11a9f73d42b57fb273121e160b84f63d894c"
 
 [[package]]
 name = "swc_atoms"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "762f5c66bf70e6f96db67808b5ad783c33a72cc3e0022cd04b41349231cdbe6c"
+checksum = "7bcdb70cb6ecee568e5acfda1a8c6e851ecf49443e5fb51f1b13613b5d04d2b0"
 dependencies = [
  "string_cache",
  "string_cache_codegen",
@@ -1082,9 +1082,9 @@ dependencies = [
 
 [[package]]
 name = "swc_common"
-version = "0.10.13"
+version = "0.10.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c46e9d1414d5a361a4eb548e3f76bee3e2d9f8f4333907881fe681a59a829aa"
+checksum = "83d405e6dc4cdde5122631268c749c7d1ddb2258be318d8d68b5d0c76f70ff6c"
 dependencies = [
  "ast_node",
  "cfg-if 0.1.10",
@@ -1105,9 +1105,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_ast"
-version = "0.42.0"
+version = "0.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83eb6a73820660a5af3c24ae1d436e84e4d4c13822021140011361e678df247b"
+checksum = "12bc9116a900cf73b81d5aca412a8a988c4935967bcbd0b7e94bfb1f906209bb"
 dependencies = [
  "is-macro",
  "num-bigint",
@@ -1119,9 +1119,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_parser"
-version = "0.52.2"
+version = "0.54.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c03250697857164f16fa98f8e1726f566652d13e52ea3f0c3ecea9deb63ee327"
+checksum = "a2259963223076f0e14ebdca0c3ea91cf7bf632b86bcbcd20d06f3e99467e442"
 dependencies = [
  "either",
  "enum_kind",
@@ -1139,9 +1139,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms"
-version = "0.43.0"
+version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb55368ba3185781373a120060e6cbc4f058c947e29a03c9f82fa492d76f2082"
+checksum = "de54db3535bc7fb7eb9c64b9ba87e246ee19d4cece8ca238fb15df5a82452214"
 dependencies = [
  "swc_atoms",
  "swc_common",
@@ -1155,9 +1155,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_base"
-version = "0.10.1"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e255452f3ce0a34bc8e31e098c4d74fb53fa5fa01127d7c1dc01a4e6d299e05"
+checksum = "228118dce83fcc2dcb9542476b2f419446fc73f0d83391e81c5b6430e0b1ab5f"
 dependencies = [
  "fxhash",
  "once_cell",
@@ -1174,9 +1174,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_utils"
-version = "0.33.0"
+version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0178053286bfdde5cfc53f68fb76c3741e2a2a848d5f47327559dff01beb34a"
+checksum = "de8d88b09ee9726ba431ebb14a60a304ff37f6b4c4ea56b59f6fc5d527a577c4"
 dependencies = [
  "once_cell",
  "scoped-tls",
@@ -1189,9 +1189,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_visit"
-version = "0.28.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd3d60b9dc97ae4f181d4d60f43142d8ac9669953db410bcedefb29a14627e19"
+checksum = "1ea12f9daba61bedf9ef548493403a02ac3109db477ec863c806ddb80089c40c"
 dependencies = [
  "num-bigint",
  "swc_atoms",
@@ -1202,9 +1202,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecmascript"
-version = "0.29.1"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ffb53afe008c15d4dc4957e80148c4b457659f93e4d4e8736eaeae352e48ec8"
+checksum = "d35c0d2519155e1a4a9b9bcd6c869c75f0fe2db5a65ca4af6a36c42c18d302d7"
 dependencies = [
  "swc_ecma_ast",
  "swc_ecma_parser",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,14 +19,14 @@ name = "dlint"
 log = "0.4.14"
 serde = { version = "1.0.123", features = ["derive"] }
 serde_json = "1.0.62"
-swc_atoms = "0.2.5"
-swc_common = "0.10.13"
-swc_ecmascript = { version = "0.29.1", features = ["parser", "transforms", "utils", "visit"] }
+swc_atoms = "0.2.6"
+swc_common = "0.10.15"
+swc_ecmascript = { version = "0.31.0", features = ["parser", "transforms", "utils", "visit"] }
 regex = "=1.4.3"
 once_cell = "1.5.2"
 derive_more = { version = "0.99.11", features = ["display"] }
 anyhow = "1.0.38"
-dprint-swc-ecma-ast-view = "0.13.1"
+dprint-swc-ecma-ast-view = "0.15.0"
 if_chain = "1.0.1"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,13 +20,13 @@ log = "0.4.14"
 serde = { version = "1.0.123", features = ["derive"] }
 serde_json = "1.0.62"
 swc_atoms = "0.2.5"
-swc_common = "0.10.12"
-swc_ecmascript = { version = "0.24.1", features = ["parser", "transforms", "utils", "visit"] }
+swc_common = "0.10.13"
+swc_ecmascript = { version = "0.29.1", features = ["parser", "transforms", "utils", "visit"] }
 regex = "=1.4.3"
 once_cell = "1.5.2"
 derive_more = { version = "0.99.11", features = ["display"] }
 anyhow = "1.0.38"
-dprint-swc-ecma-ast-view = "0.10.0"
+dprint-swc-ecma-ast-view = "0.13.1"
 if_chain = "1.0.1"
 
 [dev-dependencies]

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -272,6 +272,12 @@ pub trait Handler {
   ) {
   }
   fn ts_fn_type(&mut self, _n: &AstView::TsFnType, _ctx: &mut Context) {}
+  fn ts_getter_signature(
+    &mut self,
+    _n: &AstView::TsGetterSignature,
+    _ctx: &mut Context,
+  ) {
+  }
   fn ts_import_equal_decl(
     &mut self,
     _n: &AstView::TsImportEqualsDecl,
@@ -378,6 +384,12 @@ pub trait Handler {
   ) {
   }
   fn ts_rest_type(&mut self, _n: &AstView::TsRestType, _ctx: &mut Context) {}
+  fn ts_setter_signature(
+    &mut self,
+    _n: &AstView::TsSetterSignature,
+    _ctx: &mut Context,
+  ) {
+  }
   fn ts_this_type(&mut self, _n: &AstView::TsThisType, _ctx: &mut Context) {}
   fn ts_tpl_lit_type(
     &mut self,
@@ -803,6 +815,9 @@ pub trait Traverse: Handler {
       TsFnType(n) => {
         self.ts_fn_type(n, ctx);
       }
+      TsGetterSignature(n) => {
+        self.ts_getter_signature(n, ctx);
+      }
       TsImportEqualsDecl(n) => {
         self.ts_import_equal_decl(n, ctx);
       }
@@ -871,6 +886,9 @@ pub trait Traverse: Handler {
       }
       TsRestType(n) => {
         self.ts_rest_type(n, ctx);
+      }
+      TsSetterSignature(n) => {
+        self.ts_setter_signature(n, ctx);
       }
       TsThisType(n) => {
         self.ts_this_type(n, ctx);

--- a/src/rules/camelcase.rs
+++ b/src/rules/camelcase.rs
@@ -452,6 +452,19 @@ impl<'c> CamelcaseVisitor<'c> {
           self.check_ts_type(&*type_ann.type_ann);
         }
       }
+      TsGetterSignature(getter_sig) => {
+        if let Expr::Ident(ident) = &*getter_sig.key {
+          self.check_ident(ident, IdentToCheck::function(ident));
+        }
+        if let Some(type_ann) = &getter_sig.type_ann {
+          self.check_ts_type(&*type_ann.type_ann);
+        }
+      }
+      TsSetterSignature(setter_sig) => {
+        if let Expr::Ident(ident) = &*setter_sig.key {
+          self.check_ident(ident, IdentToCheck::function(ident));
+        }
+      }
       TsIndexSignature(_)
       | TsCallSignatureDecl(_)
       | TsConstructSignatureDecl(_) => {}

--- a/src/rules/no_setter_return.rs
+++ b/src/rules/no_setter_return.rs
@@ -51,7 +51,9 @@ impl Handler for NoSetterReturnHandler {
       use AstView::Node::*;
       match node {
         SetterProp(_) => true,
-        ClassMethod(method) => method.kind() == AstView::MethodKind::Setter,
+        ClassMethod(method) => {
+          method.method_kind() == AstView::MethodKind::Setter
+        }
         FnDecl(_) | FnExpr(_) | ArrowExpr(_) => false,
         _ => {
           if let Some(parent) = node.parent() {


### PR DESCRIPTION
Upgrades swc_* and dprint-swc-ecma-ast-view, and fixes some implementation to pass the type check.