### PR TITLE
refactor: use `all_comments` on ast-view

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -273,9 +273,9 @@ dependencies = [
 
 [[package]]
 name = "dprint-swc-ecma-ast-view"
-version = "0.16.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb20b44f890c460fe78e04c13ea49e69821b58b7a36e7905f43719f6dd9badfa"
+checksum = "2a67b73960128ad2a3babed25572e30156eb97a6512bb216d806aa8d3b7f42a9"
 dependencies = [
  "bumpalo",
  "fnv",
@@ -1202,9 +1202,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecmascript"
-version = "0.31.3"
+version = "0.31.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45286c7e1199a0c9ef13951535f5c6f777228d26df2fcf2d2d81ef11d0f22e40"
+checksum = "9148743bf5d6dcc482fd4db219968b216bff61a475c7838e0f60e00886cfa2b4"
 dependencies = [
  "swc_ecma_ast",
  "swc_ecma_parser",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ serde = { version = "1.0.125", features = ["derive"] }
 serde_json = "1.0.64"
 swc_atoms = "0.2.6"
 swc_common = "0.10.17"
-swc_ecmascript = { version = "0.31.3", features = ["parser", "transforms", "utils", "visit"] }
+swc_ecmascript = { version = "0.31.4", features = ["parser", "transforms", "utils", "visit"] }
 regex = "=1.4.3"
 once_cell = "1.5.2"
 derive_more = { version = "0.99.13", features = ["display"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ regex = "=1.4.3"
 once_cell = "1.5.2"
 derive_more = { version = "0.99.13", features = ["display"] }
 anyhow = "1.0.40"
-dprint-swc-ecma-ast-view = "0.16.0"
+dprint-swc-ecma-ast-view = "0.17.0"
 if_chain = "1.0.1"
 
 [dev-dependencies]

--- a/examples/dlint/js.rs
+++ b/examples/dlint/js.rs
@@ -8,8 +8,9 @@ use deno_core::JsRuntime;
 use deno_core::OpState;
 use deno_core::RuntimeOptions;
 use deno_core::ZeroCopyBuf;
+use deno_lint::context::Context;
 use deno_lint::control_flow::ControlFlow;
-use deno_lint::linter::{Context, Plugin};
+use deno_lint::linter::Plugin;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::{HashMap, HashSet};
@@ -156,7 +157,7 @@ impl Plugin for JsRuleRunner {
       .runtime
       .op_state()
       .borrow_mut()
-      .put(context.control_flow.clone());
+      .put(context.control_flow().clone());
 
     deno_core::futures::executor::block_on(
       self.runtime.mod_evaluate(self.module_id).next(),

--- a/examples/dlint/main.rs
+++ b/examples/dlint/main.rs
@@ -192,7 +192,7 @@ fn run_linter(
       linter_builder = linter_builder.add_plugin(js_runner);
     }
 
-    let mut linter = linter_builder.build();
+    let linter = linter_builder.build();
 
     let (source_file, diagnostics) = linter
       .lint(file_path.to_string_lossy().to_string(), source_code)

--- a/src/ast_parser.rs
+++ b/src/ast_parser.rs
@@ -156,6 +156,10 @@ impl AstParser {
     }
   }
 
+  pub(crate) fn set_source_map(&mut self, source_map: Rc<SourceMap>) {
+    self.source_map = source_map;
+  }
+
   pub(crate) fn parse_program(
     &self,
     file_name: &str,

--- a/src/ast_parser.rs
+++ b/src/ast_parser.rs
@@ -1,4 +1,5 @@
 // Copyright 2020-2021 the Deno authors. All rights reserved. MIT license.
+use dprint_swc_ecma_ast_view::TokenAndSpan;
 use std::cell::RefCell;
 use std::error::Error;
 use std::fmt;
@@ -165,7 +166,7 @@ impl AstParser {
     file_name: &str,
     syntax: Syntax,
     source_code: &str,
-  ) -> Result<(ast::Program, SingleThreadedComments), SwcDiagnosticBuffer> {
+  ) -> Result<ParsedData, SwcDiagnosticBuffer> {
     // NOTE: calling `self.source_map.new_source_file` mutates `source_map`
     // even though it's of type `Rc`.
     let swc_source_file = self.source_map.new_source_file(
@@ -183,6 +184,8 @@ impl AstParser {
       Some(&comments),
     );
 
+    let tokens: Vec<TokenAndSpan> = lexer.clone().into_iter().collect();
+
     let mut parser = Parser::new_from(lexer);
 
     let parse_result = parser.parse_program().map_err(move |err| {
@@ -197,7 +200,11 @@ impl AstParser {
       })
     });
 
-    parse_result.map(|program| (program, comments))
+    parse_result.map(|program| ParsedData {
+      program,
+      comments,
+      tokens,
+    })
   }
 
   pub(crate) fn get_span_location(&self, span: Span) -> swc_common::Loc {
@@ -209,4 +216,10 @@ impl Default for AstParser {
   fn default() -> Self {
     Self::new()
   }
+}
+
+pub(crate) struct ParsedData {
+  pub(crate) program: ast::Program,
+  pub(crate) comments: SingleThreadedComments,
+  pub(crate) tokens: Vec<TokenAndSpan>,
 }

--- a/src/context.rs
+++ b/src/context.rs
@@ -3,27 +3,64 @@ use crate::diagnostic::{LintDiagnostic, Position, Range};
 use crate::ignore_directives::IgnoreDirective;
 use crate::scopes::Scope;
 use dprint_swc_ecma_ast_view as AstView;
-use std::cell::RefCell;
 use std::collections::HashSet;
 use std::rc::Rc;
 use std::time::Instant;
 use swc_common::{SourceMap, Span, SyntaxContext};
 
 pub struct Context<'view> {
-  pub file_name: String,
-  pub diagnostics: Vec<LintDiagnostic>,
-  pub(crate) plugin_codes: HashSet<String>,
-  pub source_map: Rc<SourceMap>,
-  pub(crate) program: AstView::Program<'view>,
-  pub ignore_directives: RefCell<Vec<IgnoreDirective>>,
-  pub(crate) scope: Scope,
-  // TODO(magurotuna): Making control_flow public is just needed for implementing plugin prototype.
-  // It will be likely possible to revert it to `pub(crate)` later.
-  pub control_flow: ControlFlow,
-  pub(crate) top_level_ctxt: SyntaxContext,
+  file_name: String,
+  diagnostics: Vec<LintDiagnostic>,
+  plugin_codes: HashSet<String>,
+  source_map: Rc<SourceMap>,
+  program: AstView::Program<'view>,
+  ignore_directives: Vec<IgnoreDirective>,
+  scope: Scope,
+  control_flow: ControlFlow,
+  top_level_ctxt: SyntaxContext,
 }
 
 impl<'view> Context<'view> {
+  pub fn file_name(&self) -> &str {
+    &self.file_name
+  }
+
+  pub fn diagnostics(&self) -> &[LintDiagnostic] {
+    &self.diagnostics
+  }
+
+  pub fn plugin_codes(&self) -> &HashSet<String> {
+    &self.plugin_codes
+  }
+
+  pub fn source_map(&self) -> Rc<SourceMap> {
+    Rc::clone(&self.source_map)
+  }
+
+  pub fn program(&self) -> &AstView::Program<'view> {
+    &self.program
+  }
+
+  pub fn ignore_directives(&self) -> &[IgnoreDirective] {
+    &self.ignore_directives
+  }
+
+  pub fn ignore_directives_mut(&mut self) -> &mut [IgnoreDirective] {
+    &mut self.ignore_directives
+  }
+
+  pub fn scope(&self) -> &Scope {
+    &self.scope
+  }
+
+  pub fn control_flow(&self) -> &ControlFlow {
+    &self.control_flow
+  }
+
+  pub(crate) fn top_level_ctxt(&self) -> SyntaxContext {
+    self.top_level_ctxt
+  }
+
   pub fn add_diagnostic(
     &mut self,
     span: Span,

--- a/src/context.rs
+++ b/src/context.rs
@@ -2,9 +2,7 @@ use crate::control_flow::ControlFlow;
 use crate::diagnostic::{LintDiagnostic, Position, Range};
 use crate::ignore_directives::IgnoreDirective;
 use crate::scopes::Scope;
-use dprint_swc_ecma_ast_view::{
-  self as AstView, BytePos, RootNode, SpannedExt,
-};
+use dprint_swc_ecma_ast_view::{self as AstView, BytePos, RootNode};
 use std::collections::HashSet;
 use std::rc::Rc;
 use std::time::Instant;
@@ -86,7 +84,11 @@ impl<'view> Context<'view> {
   }
 
   pub fn all_comments(&self) -> impl Iterator<Item = &'view Comment> {
-    self.program.leading_comments_fast(&self.program)
+    self
+      .program
+      .comments()
+      .expect("Program should have information about comments, but doesn't")
+      .all_comments()
   }
 
   pub fn leading_comments_at(

--- a/src/context.rs
+++ b/src/context.rs
@@ -24,6 +24,27 @@ pub struct Context<'view> {
 }
 
 impl<'view> Context<'view> {
+  pub(crate) fn new(
+    file_name: String,
+    source_map: Rc<SourceMap>,
+    program: AstView::Program<'view>,
+    ignore_directives: Vec<IgnoreDirective>,
+    scope: Scope,
+    control_flow: ControlFlow,
+    top_level_ctxt: SyntaxContext,
+  ) -> Self {
+    Self {
+      file_name,
+      source_map,
+      program,
+      ignore_directives,
+      scope,
+      control_flow,
+      top_level_ctxt,
+      diagnostics: Vec::new(),
+      plugin_codes: HashSet::new(),
+    }
+  }
   pub fn file_name(&self) -> &str {
     &self.file_name
   }
@@ -48,7 +69,7 @@ impl<'view> Context<'view> {
     &self.ignore_directives
   }
 
-  pub fn ignore_directives_mut(&mut self) -> &mut [IgnoreDirective] {
+  pub fn ignore_directives_mut(&mut self) -> &mut Vec<IgnoreDirective> {
     &mut self.ignore_directives
   }
 
@@ -64,18 +85,8 @@ impl<'view> Context<'view> {
     self.top_level_ctxt
   }
 
-  pub fn all_leading_comments(&self) -> impl Iterator<Item = &'view Comment> {
-    self.program.leading_comments_fast(&self.program)
-  }
-
-  pub fn all_trailing_comments(&self) -> impl Iterator<Item = &'view Comment> {
-    self.program.trailing_comments_fast(&self.program)
-  }
-
   pub fn all_comments(&self) -> impl Iterator<Item = &'view Comment> {
-    self
-      .all_leading_comments()
-      .chain(self.all_trailing_comments())
+    self.program.leading_comments_fast(&self.program)
   }
 
   pub fn leading_comments_at(

--- a/src/context.rs
+++ b/src/context.rs
@@ -1,0 +1,86 @@
+use crate::control_flow::ControlFlow;
+use crate::diagnostic::{LintDiagnostic, Position, Range};
+use crate::ignore_directives::IgnoreDirective;
+use crate::scopes::Scope;
+use dprint_swc_ecma_ast_view as AstView;
+use std::cell::RefCell;
+use std::collections::HashSet;
+use std::rc::Rc;
+use std::time::Instant;
+use swc_common::{SourceMap, Span, SyntaxContext};
+
+pub struct Context<'view> {
+  pub file_name: String,
+  pub diagnostics: Vec<LintDiagnostic>,
+  pub(crate) plugin_codes: HashSet<String>,
+  pub source_map: Rc<SourceMap>,
+  pub(crate) program: AstView::Program<'view>,
+  pub ignore_directives: RefCell<Vec<IgnoreDirective>>,
+  pub(crate) scope: Scope,
+  // TODO(magurotuna): Making control_flow public is just needed for implementing plugin prototype.
+  // It will be likely possible to revert it to `pub(crate)` later.
+  pub control_flow: ControlFlow,
+  pub(crate) top_level_ctxt: SyntaxContext,
+}
+
+impl<'view> Context<'view> {
+  pub fn add_diagnostic(
+    &mut self,
+    span: Span,
+    code: impl ToString,
+    message: impl ToString,
+  ) {
+    let diagnostic =
+      self.create_diagnostic(span, code.to_string(), message.to_string(), None);
+    self.diagnostics.push(diagnostic);
+  }
+
+  pub fn add_diagnostic_with_hint(
+    &mut self,
+    span: Span,
+    code: impl ToString,
+    message: impl ToString,
+    hint: impl ToString,
+  ) {
+    let diagnostic =
+      self.create_diagnostic(span, code, message, Some(hint.to_string()));
+    self.diagnostics.push(diagnostic);
+  }
+
+  pub(crate) fn create_diagnostic(
+    &self,
+    span: Span,
+    code: impl ToString,
+    message: impl ToString,
+    maybe_hint: Option<String>,
+  ) -> LintDiagnostic {
+    let time_start = Instant::now();
+    let start = Position::new(
+      self.source_map.lookup_byte_offset(span.lo()).pos,
+      self.source_map.lookup_char_pos(span.lo()),
+    );
+    let end = Position::new(
+      self.source_map.lookup_byte_offset(span.hi()).pos,
+      self.source_map.lookup_char_pos(span.hi()),
+    );
+
+    let diagnostic = LintDiagnostic {
+      range: Range { start, end },
+      filename: self.file_name.clone(),
+      message: message.to_string(),
+      code: code.to_string(),
+      hint: maybe_hint,
+    };
+
+    let time_end = Instant::now();
+    debug!(
+      "Context::create_diagnostic took {:?}",
+      time_end - time_start
+    );
+    diagnostic
+  }
+
+  pub fn set_plugin_codes(&mut self, codes: HashSet<String>) {
+    self.plugin_codes = codes;
+  }
+}

--- a/src/control_flow.rs
+++ b/src/control_flow.rs
@@ -792,7 +792,7 @@ mod tests {
   use crate::test_util;
 
   fn analyze_flow(src: &str) -> ControlFlow {
-    let (program, _, _) = test_util::parse(src);
+    let (program, _, _, _) = test_util::parse(src);
     ControlFlow::analyze(&program)
   }
 

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -1,5 +1,5 @@
 // Copyright 2020-2021 the Deno authors. All rights reserved. MIT license.
-use crate::linter::Context;
+use crate::context::Context;
 use dprint_swc_ecma_ast_view::{self as AstView, NodeTrait};
 
 pub trait Handler {

--- a/src/ignore_directives.rs
+++ b/src/ignore_directives.rs
@@ -1,6 +1,5 @@
 // Copyright 2020-2021 the Deno authors. All rights reserved. MIT license.
 use crate::diagnostic::{LintDiagnostic, Position};
-use dprint_swc_ecma_ast_view::CommentsIterator;
 use once_cell::sync::Lazy;
 use regex::Regex;
 use std::collections::HashMap;
@@ -47,11 +46,11 @@ impl IgnoreDirective {
   }
 }
 
-pub fn parse_ignore_directives<'pg>(
+pub fn parse_ignore_directives<'view>(
   ignore_diagnostic_directive: &str,
   source_map: &SourceMap,
-  leading_comments: CommentsIterator<'pg>,
-  trailing_comments: CommentsIterator<'pg>,
+  leading_comments: impl Iterator<Item = &'view Comment>,
+  trailing_comments: impl Iterator<Item = &'view Comment>,
 ) -> Vec<IgnoreDirective> {
   let mut ignore_directives = vec![];
 
@@ -157,13 +156,13 @@ object | undefined {}
     let trailing_coms = Rc::try_unwrap(trailing)
       .expect("Failed to get trailing comments")
       .into_inner();
-    let leading = leading_coms.into_iter().collect();
-    let trailing = trailing_coms.into_iter().collect();
+    let leading: Vec<&Comment> = leading_coms.values().flatten().collect();
+    let trailing: Vec<&Comment> = trailing_coms.values().flatten().collect();
     let directives = parse_ignore_directives(
       "deno-lint-ignore",
       &ast_parser.source_map,
-      &leading,
-      &trailing,
+      leading.into_iter(),
+      trailing.into_iter(),
     );
 
     assert_eq!(directives.len(), 4);

--- a/src/ignore_directives.rs
+++ b/src/ignore_directives.rs
@@ -69,12 +69,11 @@ impl IgnoreDirective {
 pub fn parse_ignore_directives<'view>(
   ignore_diagnostic_directive: &str,
   source_map: &SourceMap,
-  leading_comments: impl Iterator<Item = &'view Comment>,
-  trailing_comments: impl Iterator<Item = &'view Comment>,
+  comments: impl Iterator<Item = &'view Comment>,
 ) -> Vec<IgnoreDirective> {
   let mut ignore_directives = vec![];
 
-  for comment in leading_comments.chain(trailing_comments) {
+  for comment in comments {
     if let Some(ignore) = parse_ignore_comment(
       &ignore_diagnostic_directive,
       source_map,
@@ -173,8 +172,7 @@ object | undefined {}
     let directives = parse_ignore_directives(
       "deno-lint-ignore",
       &source_map,
-      leading.into_iter(),
-      trailing.into_iter(),
+      leading.into_iter().chain(trailing),
     );
 
     assert_eq!(directives.len(), 4);

--- a/src/ignore_directives.rs
+++ b/src/ignore_directives.rs
@@ -11,14 +11,6 @@ use swc_common::Span;
 static IGNORE_COMMENT_CODE_RE: Lazy<Regex> =
   Lazy::new(|| Regex::new(r",\s*|\s").unwrap());
 
-/*
-#[derive(Clone, Debug, PartialEq)]
-pub enum IgnoreDirective {
-  Global(DirectiveContent),
-  Line(DirectiveContent),
-}
-*/
-
 #[derive(Clone, Debug, PartialEq)]
 pub struct IgnoreDirective {
   position: Position,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,7 @@ extern crate log;
 mod test_util;
 
 pub mod ast_parser;
-mod context;
+pub mod context;
 // TODO(magurotuna): Making control_flow public is just needed for implementing plugin prototype.
 // It will be likely possible to remove `pub` later.
 pub mod control_flow;
@@ -30,6 +30,7 @@ mod lint_tests {
   use crate::linter::*;
   use crate::rules::{get_recommended_rules, LintRule};
   use crate::test_util::{assert_diagnostic, parse};
+  use dprint_swc_ecma_ast_view::TokenAndSpan;
   use std::rc::Rc;
   use swc_common::comments::SingleThreadedComments;
   use swc_common::SourceMap;
@@ -41,7 +42,7 @@ mod lint_tests {
     unused_dir: bool,
     rules: Vec<Box<dyn LintRule>>,
   ) -> Vec<LintDiagnostic> {
-    let mut linter = LinterBuilder::default()
+    let linter = LinterBuilder::default()
       .lint_unknown_rules(unknown_rules)
       .lint_unused_ignore_directives(unused_dir)
       .rules(rules)
@@ -57,18 +58,25 @@ mod lint_tests {
     ast: Program,
     comments: SingleThreadedComments,
     source_map: Rc<SourceMap>,
+    tokens: Vec<TokenAndSpan>,
     unknown_rules: bool,
     unused_dir: bool,
     rules: Vec<Box<dyn LintRule>>,
   ) -> Vec<LintDiagnostic> {
-    let mut linter = LinterBuilder::default()
+    let linter = LinterBuilder::default()
       .lint_unknown_rules(unknown_rules)
       .lint_unused_ignore_directives(unused_dir)
       .rules(rules)
       .build();
 
     let (_, diagnostics) = linter
-      .lint_with_ast("lint_test.ts".to_string(), &ast, comments, source_map)
+      .lint_with_ast(
+        "lint_test.ts".to_string(),
+        &ast,
+        &comments,
+        source_map,
+        &tokens,
+      )
       .expect("Failed to lint");
     diagnostics
   }
@@ -85,6 +93,7 @@ mod lint_tests {
     ast: Program,
     comments: SingleThreadedComments,
     source_map: Rc<SourceMap>,
+    tokens: Vec<TokenAndSpan>,
     unknown_rules: bool,
     unused_dir: bool,
   ) -> Vec<LintDiagnostic> {
@@ -92,6 +101,7 @@ mod lint_tests {
       ast,
       comments,
       source_map,
+      tokens,
       unknown_rules,
       unused_dir,
       get_recommended_rules(),
@@ -255,9 +265,10 @@ const _fooBar = 42;
 
   #[test]
   fn empty_file_with_ast() {
-    let (ast, comments, source_map) = parse("");
-    let diagnostics =
-      lint_recommended_rules_with_ast(ast, comments, source_map, true, false);
+    let (ast, comments, source_map, tokens) = parse("");
+    let diagnostics = lint_recommended_rules_with_ast(
+      ast, comments, source_map, tokens, true, false,
+    );
     assert!(diagnostics.is_empty());
   }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,7 @@ extern crate log;
 mod test_util;
 
 pub mod ast_parser;
+mod context;
 // TODO(magurotuna): Making control_flow public is just needed for implementing plugin prototype.
 // It will be likely possible to remove `pub` later.
 pub mod control_flow;

--- a/src/linter.rs
+++ b/src/linter.rs
@@ -248,8 +248,7 @@ impl Linter {
       }
     }
 
-    filtered_diagnostics
-      .sort_by(|a, b| a.range.start.line.cmp(&b.range.start.line));
+    filtered_diagnostics.sort_by_key(|d| d.range.start.line);
 
     let end = Instant::now();
     debug!("Linter::filter_diagnostics took {:#?}", end - start);

--- a/src/linter.rs
+++ b/src/linter.rs
@@ -261,7 +261,7 @@ impl Linter {
     );
     self.has_linted = true;
 
-    self.ast_parser.source_map = source_map;
+    self.ast_parser.set_source_map(source_map);
 
     let start = Instant::now();
 

--- a/src/linter.rs
+++ b/src/linter.rs
@@ -187,7 +187,7 @@ impl Linter {
     Ok((source_file, diagnostics))
   }
 
-  fn filter_diagnostics(&self, context: &mut Context) -> Vec<LintDiagnostic> {
+  fn filter_diagnostics(&self, context: Context) -> Vec<LintDiagnostic> {
     let start = Instant::now();
 
     let (executed_rule_codes, available_rule_codes) = {
@@ -311,7 +311,7 @@ impl Linter {
 
       let mut context = Context {
         file_name,
-        source_map: self.ast_parser.source_map.clone(),
+        source_map: Rc::clone(&self.ast_parser.source_map),
         program: pg,
         ignore_directives,
         scope,
@@ -332,7 +332,7 @@ impl Linter {
         let _ = plugin.run(&mut context, program.clone());
       }
 
-      self.filter_diagnostics(&mut context)
+      self.filter_diagnostics(context)
     });
 
     let end = Instant::now();

--- a/src/linter.rs
+++ b/src/linter.rs
@@ -173,7 +173,7 @@ impl Linter {
     ast: &swc_ecmascript::ast::Program,
     comments: &SingleThreadedComments,
     source_map: Rc<SourceMap>,
-    tokens: &Vec<TokenAndSpan>,
+    tokens: &[TokenAndSpan],
   ) -> Result<
     (Rc<swc_common::SourceFile>, Vec<LintDiagnostic>),
     SwcDiagnosticBuffer,
@@ -266,7 +266,7 @@ impl Linter {
     file_name: String,
     program: &swc_ecmascript::ast::Program,
     comments: &SingleThreadedComments,
-    tokens: &Vec<TokenAndSpan>,
+    tokens: &[TokenAndSpan],
     source_file: &SourceFile,
   ) -> Vec<LintDiagnostic> {
     let start = Instant::now();

--- a/src/linter.rs
+++ b/src/linter.rs
@@ -10,7 +10,7 @@ use crate::ignore_directives::parse_ignore_comment;
 use crate::ignore_directives::parse_ignore_directives;
 use crate::rules::{get_all_rules, LintRule};
 use crate::scopes::Scope;
-use dprint_swc_ecma_ast_view::{self as AstView, SpannedExt};
+use dprint_swc_ecma_ast_view::{self as AstView, RootNode};
 use std::rc::Rc;
 use std::time::Instant;
 use swc_common::comments::SingleThreadedComments;
@@ -315,8 +315,7 @@ impl Linter {
       ignore_directives.extend(parse_ignore_directives(
         &self.ignore_diagnostic_directive,
         &self.ast_parser.source_map,
-        pg.leading_comments_fast(&pg),
-        pg.trailing_comments_fast(&pg),
+        pg.comments().unwrap().all_comments(),
       ));
 
       let mut context = Context::new(

--- a/src/linter.rs
+++ b/src/linter.rs
@@ -97,7 +97,6 @@ impl LinterBuilder {
 }
 
 pub struct Linter {
-  has_linted: bool,
   ast_parser: AstParser,
   ignore_file_directive: String,
   ignore_diagnostic_directive: String,
@@ -119,7 +118,6 @@ impl Linter {
     plugins: Vec<Box<dyn Plugin>>,
   ) -> Self {
     Linter {
-      has_linted: false,
       ast_parser: AstParser::new(),
       ignore_file_directive,
       ignore_diagnostic_directive,
@@ -132,18 +130,13 @@ impl Linter {
   }
 
   pub fn lint(
-    &mut self,
+    mut self,
     file_name: String,
     source_code: String,
   ) -> Result<
     (Rc<swc_common::SourceFile>, Vec<LintDiagnostic>),
     SwcDiagnosticBuffer,
   > {
-    assert!(
-      !self.has_linted,
-      "Linter can be used only on a single module."
-    );
-    self.has_linted = true;
     let start = Instant::now();
 
     let parse_result =
@@ -169,7 +162,7 @@ impl Linter {
   }
 
   pub fn lint_with_ast(
-    &mut self,
+    mut self,
     file_name: String,
     ast: &swc_ecmascript::ast::Program,
     comments: swc_common::comments::SingleThreadedComments,
@@ -178,12 +171,6 @@ impl Linter {
     (Rc<swc_common::SourceFile>, Vec<LintDiagnostic>),
     SwcDiagnosticBuffer,
   > {
-    assert!(
-      !self.has_linted,
-      "Linter can be used only on a single module."
-    );
-    self.has_linted = true;
-
     self.ast_parser.set_source_map(source_map);
 
     let start = Instant::now();

--- a/src/rules.rs
+++ b/src/rules.rs
@@ -95,7 +95,7 @@ pub enum ProgramRef<'view> {
 }
 
 pub trait LintRule {
-  /// Creates a instance of this rule.
+  /// Creates an instance of this rule.
   fn new() -> Box<Self>
   where
     Self: Sized;

--- a/src/rules.rs
+++ b/src/rules.rs
@@ -88,9 +88,9 @@ pub mod valid_typeof;
 
 const DUMMY_NODE: () = ();
 
-pub enum ProgramRef<'a> {
-  Module(&'a swc_ecmascript::ast::Module),
-  Script(&'a swc_ecmascript::ast::Script),
+pub enum ProgramRef<'view> {
+  Module(&'view swc_ecmascript::ast::Module),
+  Script(&'view swc_ecmascript::ast::Script),
 }
 
 pub trait LintRule {
@@ -101,14 +101,18 @@ pub trait LintRule {
 
   /// Executes lint on the given `Program`.
   /// TODO(@magurotuna): remove this after all rules get to use ast_view
-  fn lint_program<'a>(&self, context: &mut Context, program: ProgramRef<'a>);
+  fn lint_program<'view>(
+    &self,
+    context: &mut Context<'view>,
+    program: ProgramRef<'view>,
+  );
 
   /// Executes lint using `dprint-swc-ecma-ast-view`.
   /// Falls back to the `lint_program` method if not implemented.
-  fn lint_program_with_ast_view(
+  fn lint_program_with_ast_view<'view>(
     &self,
-    context: &mut Context,
-    program: dprint_swc_ecma_ast_view::Program,
+    context: &mut Context<'view>,
+    program: dprint_swc_ecma_ast_view::Program<'view>,
   ) {
     use ProgramView::*;
     let program_ref = match program {

--- a/src/rules.rs
+++ b/src/rules.rs
@@ -1,5 +1,5 @@
 // Copyright 2020-2021 the Deno authors. All rights reserved. MIT license.
-use crate::linter::Context;
+use crate::context::Context;
 use dprint_swc_ecma_ast_view::Program as ProgramView;
 
 pub mod adjacent_overload_signatures;

--- a/src/rules/adjacent_overload_signatures.rs
+++ b/src/rules/adjacent_overload_signatures.rs
@@ -27,7 +27,11 @@ impl LintRule for AdjacentOverloadSignatures {
     "adjacent-overload-signatures"
   }
 
-  fn lint_program(&self, context: &mut Context, program: ProgramRef<'_>) {
+  fn lint_program<'view>(
+    &self,
+    context: &mut Context<'view>,
+    program: ProgramRef<'view>,
+  ) {
     let mut visitor = AdjacentOverloadSignaturesVisitor::new(context);
     match program {
       ProgramRef::Module(ref m) => m.visit_all_with(&DUMMY_NODE, &mut visitor),
@@ -107,12 +111,12 @@ export function bar(): void {}
   }
 }
 
-struct AdjacentOverloadSignaturesVisitor<'c> {
-  context: &'c mut Context,
+struct AdjacentOverloadSignaturesVisitor<'c, 'view> {
+  context: &'c mut Context<'view>,
 }
 
-impl<'c> AdjacentOverloadSignaturesVisitor<'c> {
-  fn new(context: &'c mut Context) -> Self {
+impl<'c, 'view> AdjacentOverloadSignaturesVisitor<'c, 'view> {
+  fn new(context: &'c mut Context<'view>) -> Self {
     Self { context }
   }
 
@@ -232,7 +236,7 @@ impl ExtractMethod for TsTypeElement {
   }
 }
 
-impl<'c> VisitAll for AdjacentOverloadSignaturesVisitor<'c> {
+impl<'c, 'view> VisitAll for AdjacentOverloadSignaturesVisitor<'c, 'view> {
   fn visit_script(&mut self, script: &Script, _parent: &dyn Node) {
     self.check(&script.body);
   }

--- a/src/rules/ban_ts_comment.rs
+++ b/src/rules/ban_ts_comment.rs
@@ -45,22 +45,13 @@ impl LintRule for BanTsComment {
   fn lint_program(&self, context: &mut Context, _program: ProgramRef<'_>) {
     let mut violated_comment_spans = Vec::new();
 
-    violated_comment_spans.extend(
-      context.leading_comments.values().flatten().filter_map(|c| {
-        if check_comment(c) {
-          Some(c.span)
-        } else {
-          None
-        }
-      }),
-    );
-    violated_comment_spans.extend(
-      context
-        .trailing_comments
-        .values()
-        .flatten()
-        .filter_map(|c| if check_comment(c) { Some(c.span) } else { None }),
-    );
+    violated_comment_spans.extend(context.all_comments().filter_map(|c| {
+      if check_comment(c) {
+        Some(c.span)
+      } else {
+        None
+      }
+    }));
 
     for span in violated_comment_spans {
       self.report(context, span);

--- a/src/rules/ban_types.rs
+++ b/src/rules/ban_types.rs
@@ -24,7 +24,11 @@ impl LintRule for BanTypes {
     "ban-types"
   }
 
-  fn lint_program(&self, context: &mut Context, program: ProgramRef<'_>) {
+  fn lint_program<'view>(
+    &self,
+    context: &mut Context<'view>,
+    program: ProgramRef<'view>,
+  ) {
     let mut visitor = BanTypesVisitor::new(context);
     match program {
       ProgramRef::Module(ref m) => visitor.visit_module(m, &DUMMY_NODE),
@@ -74,12 +78,12 @@ let f: Record<string, unknown>;
   }
 }
 
-struct BanTypesVisitor<'c> {
-  context: &'c mut Context,
+struct BanTypesVisitor<'c, 'view> {
+  context: &'c mut Context<'view>,
 }
 
-impl<'c> BanTypesVisitor<'c> {
-  fn new(context: &'c mut Context) -> Self {
+impl<'c, 'view> BanTypesVisitor<'c, 'view> {
+  fn new(context: &'c mut Context<'view>) -> Self {
     Self { context }
   }
 }
@@ -104,7 +108,7 @@ fn get_message(ident: impl AsRef<str>) -> Option<&'static str> {
   BAN_TYPES_MESSAGE.get(ident.as_ref()).copied()
 }
 
-impl<'c> Visit for BanTypesVisitor<'c> {
+impl<'c, 'view> Visit for BanTypesVisitor<'c, 'view> {
   fn visit_ts_type_ref(&mut self, ts_type_ref: &TsTypeRef, _parent: &dyn Node) {
     if let TsEntityName::Ident(ident) = &ts_type_ref.type_name {
       if let Some(message) = get_message(&ident.sym) {

--- a/src/rules/ban_untagged_ignore.rs
+++ b/src/rules/ban_untagged_ignore.rs
@@ -19,8 +19,7 @@ impl LintRule for BanUntaggedIgnore {
 
   fn lint_program(&self, context: &mut Context, _program: ProgramRef<'_>) {
     let violated_spans: Vec<Span> = context
-      .ignore_directives
-      .borrow()
+      .ignore_directives()
       .iter()
       .filter_map(|d| {
         if d.codes.is_empty() {

--- a/src/rules/ban_untagged_ignore.rs
+++ b/src/rules/ban_untagged_ignore.rs
@@ -22,8 +22,8 @@ impl LintRule for BanUntaggedIgnore {
       .ignore_directives()
       .iter()
       .filter_map(|d| {
-        if d.codes.is_empty() {
-          Some(d.span)
+        if d.codes().is_empty() {
+          Some(d.span())
         } else {
           None
         }

--- a/src/rules/ban_untagged_todo.rs
+++ b/src/rules/ban_untagged_todo.rs
@@ -29,22 +29,13 @@ impl LintRule for BanUntaggedTodo {
   fn lint_program(&self, context: &mut Context, _program: ProgramRef<'_>) {
     let mut violated_comment_spans = Vec::new();
 
-    violated_comment_spans.extend(
-      context.leading_comments.values().flatten().filter_map(|c| {
-        if check_comment(c) {
-          Some(c.span)
-        } else {
-          None
-        }
-      }),
-    );
-    violated_comment_spans.extend(
-      context
-        .trailing_comments
-        .values()
-        .flatten()
-        .filter_map(|c| if check_comment(c) { Some(c.span) } else { None }),
-    );
+    violated_comment_spans.extend(context.all_comments().filter_map(|c| {
+      if check_comment(c) {
+        Some(c.span)
+      } else {
+        None
+      }
+    }));
 
     for span in violated_comment_spans {
       self.report(context, span);

--- a/src/rules/camelcase.rs
+++ b/src/rules/camelcase.rs
@@ -31,7 +31,11 @@ impl LintRule for Camelcase {
     "camelcase"
   }
 
-  fn lint_program(&self, context: &mut Context, program: ProgramRef<'_>) {
+  fn lint_program<'view>(
+    &self,
+    context: &mut Context<'view>,
+    program: ProgramRef<'view>,
+  ) {
     let mut visitor = CamelcaseVisitor::new(context);
     match program {
       ProgramRef::Module(ref m) => visitor.visit_module(m, &DUMMY_NODE),
@@ -389,15 +393,15 @@ impl IdentToCheck {
   }
 }
 
-struct CamelcaseVisitor<'c> {
-  context: &'c mut Context,
+struct CamelcaseVisitor<'c, 'view> {
+  context: &'c mut Context<'view>,
   errors: BTreeMap<Span, IdentToCheck>,
   /// Already visited identifiers
   visited: BTreeSet<Span>,
 }
 
-impl<'c> CamelcaseVisitor<'c> {
-  fn new(context: &'c mut Context) -> Self {
+impl<'c, 'view> CamelcaseVisitor<'c, 'view> {
+  fn new(context: &'c mut Context<'view>) -> Self {
     Self {
       context,
       errors: BTreeMap::new(),
@@ -552,7 +556,7 @@ impl<'c> CamelcaseVisitor<'c> {
   }
 }
 
-impl<'c> Visit for CamelcaseVisitor<'c> {
+impl<'c, 'view> Visit for CamelcaseVisitor<'c, 'view> {
   fn visit_fn_decl(&mut self, fn_decl: &FnDecl, _: &dyn Node) {
     if fn_decl.declare {
       return;

--- a/src/rules/constructor_super.rs
+++ b/src/rules/constructor_super.rs
@@ -25,7 +25,11 @@ impl LintRule for ConstructorSuper {
     "constructor-super"
   }
 
-  fn lint_program(&self, context: &mut Context, program: ProgramRef<'_>) {
+  fn lint_program<'view>(
+    &self,
+    context: &mut Context<'view>,
+    program: ProgramRef<'view>,
+  ) {
     let mut visitor = ConstructorSuperVisitor::new(context);
     match program {
       ProgramRef::Module(ref m) => visitor.visit_module(m, &DUMMY_NODE),
@@ -159,12 +163,12 @@ fn return_before_super(constructor: &Constructor) -> Option<&ReturnStmt> {
   None
 }
 
-struct ConstructorSuperVisitor<'c> {
-  context: &'c mut Context,
+struct ConstructorSuperVisitor<'c, 'view> {
+  context: &'c mut Context<'view>,
 }
 
-impl<'c> ConstructorSuperVisitor<'c> {
-  fn new(context: &'c mut Context) -> Self {
+impl<'c, 'view> ConstructorSuperVisitor<'c, 'view> {
+  fn new(context: &'c mut Context<'view>) -> Self {
     Self { context }
   }
 
@@ -236,7 +240,7 @@ impl<'c> ConstructorSuperVisitor<'c> {
   }
 }
 
-impl<'c> Visit for ConstructorSuperVisitor<'c> {
+impl<'c, 'view> Visit for ConstructorSuperVisitor<'c, 'view> {
   noop_visit_type!();
 
   fn visit_class(&mut self, class: &Class, parent: &dyn Node) {

--- a/src/rules/default_param_last.rs
+++ b/src/rules/default_param_last.rs
@@ -18,7 +18,11 @@ impl LintRule for DefaultParamLast {
     "default-param-last"
   }
 
-  fn lint_program(&self, context: &mut Context, program: ProgramRef<'_>) {
+  fn lint_program<'view>(
+    &self,
+    context: &mut Context<'view>,
+    program: ProgramRef<'view>,
+  ) {
     let mut visitor = DefaultParamLastVisitor::new(context);
     match program {
       ProgramRef::Module(ref m) => m.visit_all_with(&DUMMY_NODE, &mut visitor),
@@ -54,12 +58,12 @@ function f(a = 2, b = 3) {}
   }
 }
 
-struct DefaultParamLastVisitor<'c> {
-  context: &'c mut Context,
+struct DefaultParamLastVisitor<'c, 'view> {
+  context: &'c mut Context<'view>,
 }
 
-impl<'c> DefaultParamLastVisitor<'c> {
-  fn new(context: &'c mut Context) -> Self {
+impl<'c, 'view> DefaultParamLastVisitor<'c, 'view> {
+  fn new(context: &'c mut Context<'view>) -> Self {
     Self { context }
   }
 
@@ -93,7 +97,7 @@ impl<'c> DefaultParamLastVisitor<'c> {
   }
 }
 
-impl<'c> VisitAll for DefaultParamLastVisitor<'c> {
+impl<'c, 'view> VisitAll for DefaultParamLastVisitor<'c, 'view> {
   noop_visit_type!();
 
   fn visit_function(&mut self, function: &Function, _parent: &dyn Node) {

--- a/src/rules/eqeqeq.rs
+++ b/src/rules/eqeqeq.rs
@@ -35,7 +35,11 @@ impl LintRule for Eqeqeq {
     CODE
   }
 
-  fn lint_program(&self, context: &mut Context, program: ProgramRef<'_>) {
+  fn lint_program<'view>(
+    &self,
+    context: &mut Context<'view>,
+    program: ProgramRef<'view>,
+  ) {
     let mut visitor = EqeqeqVisitor::new(context);
     match program {
       ProgramRef::Module(ref m) => visitor.visit_module(m, &DUMMY_NODE),
@@ -67,17 +71,17 @@ if ("hello world" !== input) {}
   }
 }
 
-struct EqeqeqVisitor<'c> {
-  context: &'c mut Context,
+struct EqeqeqVisitor<'c, 'view> {
+  context: &'c mut Context<'view>,
 }
 
-impl<'c> EqeqeqVisitor<'c> {
-  fn new(context: &'c mut Context) -> Self {
+impl<'c, 'view> EqeqeqVisitor<'c, 'view> {
+  fn new(context: &'c mut Context<'view>) -> Self {
     Self { context }
   }
 }
 
-impl<'c> Visit for EqeqeqVisitor<'c> {
+impl<'c, 'view> Visit for EqeqeqVisitor<'c, 'view> {
   noop_visit_type!();
 
   fn visit_bin_expr(&mut self, bin_expr: &BinExpr, parent: &dyn Node) {

--- a/src/rules/explicit_function_return_type.rs
+++ b/src/rules/explicit_function_return_type.rs
@@ -15,7 +15,11 @@ impl LintRule for ExplicitFunctionReturnType {
     "explicit-function-return-type"
   }
 
-  fn lint_program(&self, context: &mut Context, program: ProgramRef<'_>) {
+  fn lint_program<'view>(
+    &self,
+    context: &mut Context<'view>,
+    program: ProgramRef<'view>,
+  ) {
     let mut visitor = ExplicitFunctionReturnTypeVisitor::new(context);
     match program {
       ProgramRef::Module(ref m) => visitor.visit_module(m, &DUMMY_NODE),
@@ -45,17 +49,17 @@ function anotherCalc(): void { return; }
   }
 }
 
-struct ExplicitFunctionReturnTypeVisitor<'c> {
-  context: &'c mut Context,
+struct ExplicitFunctionReturnTypeVisitor<'c, 'view> {
+  context: &'c mut Context<'view>,
 }
 
-impl<'c> ExplicitFunctionReturnTypeVisitor<'c> {
-  fn new(context: &'c mut Context) -> Self {
+impl<'c, 'view> ExplicitFunctionReturnTypeVisitor<'c, 'view> {
+  fn new(context: &'c mut Context<'view>) -> Self {
     Self { context }
   }
 }
 
-impl<'c> Visit for ExplicitFunctionReturnTypeVisitor<'c> {
+impl<'c, 'view> Visit for ExplicitFunctionReturnTypeVisitor<'c, 'view> {
   noop_visit_type!();
 
   fn visit_function(

--- a/src/rules/explicit_module_boundary_types.rs
+++ b/src/rules/explicit_module_boundary_types.rs
@@ -21,7 +21,11 @@ impl LintRule for ExplicitModuleBoundaryTypes {
     "explicit-module-boundary-types"
   }
 
-  fn lint_program(&self, context: &mut Context, program: ProgramRef<'_>) {
+  fn lint_program<'view>(
+    &self,
+    context: &mut Context<'view>,
+    program: ProgramRef<'view>,
+  ) {
     let mut visitor = ExplicitModuleBoundaryTypesVisitor::new(context);
     match program {
       ProgramRef::Module(ref m) => visitor.visit_module(m, &DUMMY_NODE),
@@ -68,12 +72,12 @@ function isValid() {
   }
 }
 
-struct ExplicitModuleBoundaryTypesVisitor<'c> {
-  context: &'c mut Context,
+struct ExplicitModuleBoundaryTypesVisitor<'c, 'view> {
+  context: &'c mut Context<'view>,
 }
 
-impl<'c> ExplicitModuleBoundaryTypesVisitor<'c> {
-  fn new(context: &'c mut Context) -> Self {
+impl<'c, 'view> ExplicitModuleBoundaryTypesVisitor<'c, 'view> {
+  fn new(context: &'c mut Context<'view>) -> Self {
     Self { context }
   }
 
@@ -158,7 +162,7 @@ impl<'c> ExplicitModuleBoundaryTypesVisitor<'c> {
   }
 }
 
-impl<'c> Visit for ExplicitModuleBoundaryTypesVisitor<'c> {
+impl<'c, 'view> Visit for ExplicitModuleBoundaryTypesVisitor<'c, 'view> {
   noop_visit_type!();
 
   fn visit_module_decl(

--- a/src/rules/for_direction.rs
+++ b/src/rules/for_direction.rs
@@ -30,7 +30,11 @@ impl LintRule for ForDirection {
     "for-direction"
   }
 
-  fn lint_program(&self, context: &mut Context, program: ProgramRef<'_>) {
+  fn lint_program<'view>(
+    &self,
+    context: &mut Context<'view>,
+    program: ProgramRef<'view>,
+  ) {
     let mut visitor = ForDirectionVisitor::new(context);
     match program {
       ProgramRef::Module(ref m) => m.visit_all_with(&DUMMY_NODE, &mut visitor),
@@ -63,12 +67,12 @@ const MESSAGE: &str = "Update clause moves variable in the wrong direction";
 const HINT: &str =
   "Flip the update clause logic or change the continuation step condition";
 
-struct ForDirectionVisitor<'c> {
-  context: &'c mut Context,
+struct ForDirectionVisitor<'c, 'view> {
+  context: &'c mut Context<'view>,
 }
 
-impl<'c> ForDirectionVisitor<'c> {
-  fn new(context: &'c mut Context) -> Self {
+impl<'c, 'view> ForDirectionVisitor<'c, 'view> {
+  fn new(context: &'c mut Context<'view>) -> Self {
     Self { context }
   }
 
@@ -146,7 +150,7 @@ impl<'c> ForDirectionVisitor<'c> {
   }
 }
 
-impl<'c> VisitAll for ForDirectionVisitor<'c> {
+impl<'c, 'view> VisitAll for ForDirectionVisitor<'c, 'view> {
   noop_visit_type!();
 
   fn visit_for_stmt(&mut self, for_stmt: &ForStmt, _parent: &dyn Node) {

--- a/src/rules/getter_return.rs
+++ b/src/rules/getter_return.rs
@@ -150,7 +150,7 @@ impl<'c> GetterReturnVisitor<'c> {
 
     if self
       .context
-      .control_flow
+      .control_flow()
       .meta(getter_body_span.lo)
       .unwrap()
       .continues_execution()

--- a/src/rules/getter_return.rs
+++ b/src/rules/getter_return.rs
@@ -45,7 +45,11 @@ impl LintRule for GetterReturn {
     CODE
   }
 
-  fn lint_program(&self, context: &mut Context, program: ProgramRef<'_>) {
+  fn lint_program<'view>(
+    &self,
+    context: &mut Context<'view>,
+    program: ProgramRef<'view>,
+  ) {
     let mut visitor = GetterReturnVisitor::new(context);
     match program {
       ProgramRef::Module(ref m) => visitor.visit_module(m, &DUMMY_NODE),
@@ -89,8 +93,8 @@ class Person {
   }
 }
 
-struct GetterReturnVisitor<'c> {
-  context: &'c mut Context,
+struct GetterReturnVisitor<'c, 'view> {
+  context: &'c mut Context<'view>,
   errors: BTreeMap<Span, GetterReturnMessage>,
   /// If this visitor is currently in a getter, its name is stored.
   getter_name: Option<String>,
@@ -98,8 +102,8 @@ struct GetterReturnVisitor<'c> {
   has_return: bool,
 }
 
-impl<'c> GetterReturnVisitor<'c> {
-  fn new(context: &'c mut Context) -> Self {
+impl<'c, 'view> GetterReturnVisitor<'c, 'view> {
+  fn new(context: &'c mut Context<'view>) -> Self {
     Self {
       context,
       errors: BTreeMap::new(),
@@ -184,7 +188,7 @@ impl<'c> GetterReturnVisitor<'c> {
   }
 }
 
-impl<'c> Visit for GetterReturnVisitor<'c> {
+impl<'c, 'view> Visit for GetterReturnVisitor<'c, 'view> {
   noop_visit_type!();
 
   fn visit_fn_decl(&mut self, fn_decl: &FnDecl, _: &dyn Node) {

--- a/src/rules/no_array_constructor.rs
+++ b/src/rules/no_array_constructor.rs
@@ -26,7 +26,11 @@ impl LintRule for NoArrayConstructor {
     CODE
   }
 
-  fn lint_program(&self, context: &mut Context, program: ProgramRef<'_>) {
+  fn lint_program<'view>(
+    &self,
+    context: &mut Context<'view>,
+    program: ProgramRef<'view>,
+  ) {
     let mut visitor = NoArrayConstructorVisitor::new(context);
     match program {
       ProgramRef::Module(ref m) => m.visit_all_with(&DUMMY_NODE, &mut visitor),
@@ -66,12 +70,12 @@ const c = [1,2,3];
   }
 }
 
-struct NoArrayConstructorVisitor<'c> {
-  context: &'c mut Context,
+struct NoArrayConstructorVisitor<'c, 'view> {
+  context: &'c mut Context<'view>,
 }
 
-impl<'c> NoArrayConstructorVisitor<'c> {
-  fn new(context: &'c mut Context) -> Self {
+impl<'c, 'view> NoArrayConstructorVisitor<'c, 'view> {
+  fn new(context: &'c mut Context<'view>) -> Self {
     Self { context }
   }
 
@@ -84,7 +88,7 @@ impl<'c> NoArrayConstructorVisitor<'c> {
   }
 }
 
-impl<'c> VisitAll for NoArrayConstructorVisitor<'c> {
+impl<'c, 'view> VisitAll for NoArrayConstructorVisitor<'c, 'view> {
   noop_visit_type!();
 
   fn visit_new_expr(&mut self, new_expr: &NewExpr, _parent: &dyn Node) {

--- a/src/rules/no_async_promise_executor.rs
+++ b/src/rules/no_async_promise_executor.rs
@@ -26,7 +26,11 @@ impl LintRule for NoAsyncPromiseExecutor {
     CODE
   }
 
-  fn lint_program(&self, context: &mut Context, program: ProgramRef<'_>) {
+  fn lint_program<'view>(
+    &self,
+    context: &mut Context<'view>,
+    program: ProgramRef<'view>,
+  ) {
     let mut visitor = NoAsyncPromiseExecutorVisitor::new(context);
     match program {
       ProgramRef::Module(ref m) => m.visit_all_with(&DUMMY_NODE, &mut visitor),
@@ -65,12 +69,12 @@ new Promise((resolve, reject) => {});
   }
 }
 
-struct NoAsyncPromiseExecutorVisitor<'c> {
-  context: &'c mut Context,
+struct NoAsyncPromiseExecutorVisitor<'c, 'view> {
+  context: &'c mut Context<'view>,
 }
 
-impl<'c> NoAsyncPromiseExecutorVisitor<'c> {
-  fn new(context: &'c mut Context) -> Self {
+impl<'c, 'view> NoAsyncPromiseExecutorVisitor<'c, 'view> {
+  fn new(context: &'c mut Context<'view>) -> Self {
     Self { context }
   }
 }
@@ -84,7 +88,7 @@ fn is_async_function(expr: &Expr) -> bool {
   }
 }
 
-impl<'c> VisitAll for NoAsyncPromiseExecutorVisitor<'c> {
+impl<'c, 'view> VisitAll for NoAsyncPromiseExecutorVisitor<'c, 'view> {
   noop_visit_type!();
 
   fn visit_new_expr(&mut self, new_expr: &NewExpr, _parent: &dyn Node) {

--- a/src/rules/no_case_declarations.rs
+++ b/src/rules/no_case_declarations.rs
@@ -28,7 +28,11 @@ impl LintRule for NoCaseDeclarations {
     CODE
   }
 
-  fn lint_program(&self, context: &mut Context, program: ProgramRef<'_>) {
+  fn lint_program<'view>(
+    &self,
+    context: &mut Context<'view>,
+    program: ProgramRef<'view>,
+  ) {
     let mut visitor = NoCaseDeclarationsVisitor::new(context);
     match program {
       ProgramRef::Module(ref m) => m.visit_all_with(&DUMMY_NODE, &mut visitor),
@@ -89,17 +93,17 @@ switch (choice) {
   }
 }
 
-struct NoCaseDeclarationsVisitor<'c> {
-  context: &'c mut Context,
+struct NoCaseDeclarationsVisitor<'c, 'view> {
+  context: &'c mut Context<'view>,
 }
 
-impl<'c> NoCaseDeclarationsVisitor<'c> {
-  fn new(context: &'c mut Context) -> Self {
+impl<'c, 'view> NoCaseDeclarationsVisitor<'c, 'view> {
+  fn new(context: &'c mut Context<'view>) -> Self {
     Self { context }
   }
 }
 
-impl<'c> VisitAll for NoCaseDeclarationsVisitor<'c> {
+impl<'c, 'view> VisitAll for NoCaseDeclarationsVisitor<'c, 'view> {
   noop_visit_type!();
 
   fn visit_switch_case(

--- a/src/rules/no_class_assign.rs
+++ b/src/rules/no_class_assign.rs
@@ -73,7 +73,7 @@ impl<'c> VisitAll for NoClassAssignVisitor<'c> {
   fn visit_assign_expr(&mut self, assign_expr: &AssignExpr, _node: &dyn Node) {
     let ids = find_lhs_ids(&assign_expr.left);
     for id in ids {
-      let var = self.context.scope.var(&id);
+      let var = self.context.scope().var(&id);
       if let Some(var) = var {
         if let BindingKind::Class = var.kind() {
           self.context.add_diagnostic_with_hint(

--- a/src/rules/no_class_assign.rs
+++ b/src/rules/no_class_assign.rs
@@ -26,7 +26,11 @@ impl LintRule for NoClassAssign {
     CODE
   }
 
-  fn lint_program(&self, context: &mut Context, program: ProgramRef<'_>) {
+  fn lint_program<'view>(
+    &self,
+    context: &mut Context<'view>,
+    program: ProgramRef<'view>,
+  ) {
     let mut visitor = NoClassAssignVisitor::new(context);
     match program {
       ProgramRef::Module(ref m) => m.visit_all_with(&DUMMY_NODE, &mut visitor),
@@ -57,17 +61,17 @@ c = 0;  // reassigning the variable `c`
   }
 }
 
-struct NoClassAssignVisitor<'c> {
-  context: &'c mut Context,
+struct NoClassAssignVisitor<'c, 'view> {
+  context: &'c mut Context<'view>,
 }
 
-impl<'c> NoClassAssignVisitor<'c> {
-  fn new(context: &'c mut Context) -> Self {
+impl<'c, 'view> NoClassAssignVisitor<'c, 'view> {
+  fn new(context: &'c mut Context<'view>) -> Self {
     Self { context }
   }
 }
 
-impl<'c> VisitAll for NoClassAssignVisitor<'c> {
+impl<'c, 'view> VisitAll for NoClassAssignVisitor<'c, 'view> {
   noop_visit_type!();
 
   fn visit_assign_expr(&mut self, assign_expr: &AssignExpr, _node: &dyn Node) {

--- a/src/rules/no_compare_neg_zero.rs
+++ b/src/rules/no_compare_neg_zero.rs
@@ -40,7 +40,11 @@ impl LintRule for NoCompareNegZero {
     CODE
   }
 
-  fn lint_program(&self, context: &mut Context, program: ProgramRef<'_>) {
+  fn lint_program<'view>(
+    &self,
+    context: &mut Context<'view>,
+    program: ProgramRef<'view>,
+  ) {
     let mut visitor = NoCompareNegZeroVisitor::new(context);
     match program {
       ProgramRef::Module(ref m) => m.visit_all_with(&DUMMY_NODE, &mut visitor),
@@ -67,17 +71,17 @@ if (Object.is(x, -0)) {}
   }
 }
 
-struct NoCompareNegZeroVisitor<'c> {
-  context: &'c mut Context,
+struct NoCompareNegZeroVisitor<'c, 'view> {
+  context: &'c mut Context<'view>,
 }
 
-impl<'c> NoCompareNegZeroVisitor<'c> {
-  fn new(context: &'c mut Context) -> Self {
+impl<'c, 'view> NoCompareNegZeroVisitor<'c, 'view> {
+  fn new(context: &'c mut Context<'view>) -> Self {
     Self { context }
   }
 }
 
-impl<'c> VisitAll for NoCompareNegZeroVisitor<'c> {
+impl<'c, 'view> VisitAll for NoCompareNegZeroVisitor<'c, 'view> {
   noop_visit_type!();
 
   fn visit_bin_expr(&mut self, bin_expr: &BinExpr, _parent: &dyn Node) {

--- a/src/rules/no_cond_assign.rs
+++ b/src/rules/no_cond_assign.rs
@@ -39,7 +39,11 @@ impl LintRule for NoCondAssign {
     CODE
   }
 
-  fn lint_program(&self, context: &mut Context, program: ProgramRef<'_>) {
+  fn lint_program<'view>(
+    &self,
+    context: &mut Context<'view>,
+    program: ProgramRef<'view>,
+  ) {
     let mut visitor = NoCondAssignVisitor::new(context);
     match program {
       ProgramRef::Module(ref m) => m.visit_all_with(&DUMMY_NODE, &mut visitor),
@@ -85,12 +89,12 @@ function setHeight(someNode) {
   }
 }
 
-struct NoCondAssignVisitor<'c> {
-  context: &'c mut Context,
+struct NoCondAssignVisitor<'c, 'view> {
+  context: &'c mut Context<'view>,
 }
 
-impl<'c> NoCondAssignVisitor<'c> {
-  fn new(context: &'c mut Context) -> Self {
+impl<'c, 'view> NoCondAssignVisitor<'c, 'view> {
+  fn new(context: &'c mut Context<'view>) -> Self {
     Self { context }
   }
 
@@ -119,7 +123,7 @@ impl<'c> NoCondAssignVisitor<'c> {
   }
 }
 
-impl<'c> VisitAll for NoCondAssignVisitor<'c> {
+impl<'c, 'view> VisitAll for NoCondAssignVisitor<'c, 'view> {
   noop_visit_type!();
 
   fn visit_if_stmt(

--- a/src/rules/no_const_assign.rs
+++ b/src/rules/no_const_assign.rs
@@ -113,7 +113,7 @@ impl<'c> NoConstAssignVisitor<'c> {
 
   fn check_scope_for_const(&mut self, span: Span, name: &Ident) {
     let id = name.to_id();
-    if let Some(v) = self.context.scope.var(&id) {
+    if let Some(v) = self.context.scope().var(&id) {
       if let BindingKind::Const = v.kind() {
         self.context.add_diagnostic_with_hint(
           span,

--- a/src/rules/no_const_assign.rs
+++ b/src/rules/no_const_assign.rs
@@ -22,7 +22,11 @@ impl LintRule for NoConstAssign {
     "no-const-assign"
   }
 
-  fn lint_program(&self, context: &mut Context, program: ProgramRef<'_>) {
+  fn lint_program<'view>(
+    &self,
+    context: &mut Context<'view>,
+    program: ProgramRef<'view>,
+  ) {
     let mut visitor = NoConstAssignVisitor::new(context);
     match program {
       ProgramRef::Module(ref m) => visitor.visit_module(m, &DUMMY_NODE),
@@ -56,12 +60,12 @@ for (const c in [1,2,3]) {}
   }
 }
 
-struct NoConstAssignVisitor<'c> {
-  context: &'c mut Context,
+struct NoConstAssignVisitor<'c, 'view> {
+  context: &'c mut Context<'view>,
 }
 
-impl<'c> NoConstAssignVisitor<'c> {
-  fn new(context: &'c mut Context) -> Self {
+impl<'c, 'view> NoConstAssignVisitor<'c, 'view> {
+  fn new(context: &'c mut Context<'view>) -> Self {
     Self { context }
   }
 
@@ -126,7 +130,7 @@ impl<'c> NoConstAssignVisitor<'c> {
   }
 }
 
-impl<'c> Visit for NoConstAssignVisitor<'c> {
+impl<'c, 'view> Visit for NoConstAssignVisitor<'c, 'view> {
   fn visit_assign_expr(&mut self, assign_expr: &AssignExpr, _node: &dyn Node) {
     match &assign_expr.left {
       PatOrExpr::Expr(pat_expr) => {

--- a/src/rules/no_constant_condition.rs
+++ b/src/rules/no_constant_condition.rs
@@ -37,7 +37,11 @@ impl LintRule for NoConstantCondition {
     CODE
   }
 
-  fn lint_program(&self, context: &mut Context, program: ProgramRef<'_>) {
+  fn lint_program<'view>(
+    &self,
+    context: &mut Context<'view>,
+    program: ProgramRef<'view>,
+  ) {
     let mut visitor = NoConstantConditionVisitor::new(context);
     match program {
       ProgramRef::Module(ref m) => m.visit_all_with(&DUMMY_NODE, &mut visitor),
@@ -68,12 +72,12 @@ do {} while (x === 2);
   }
 }
 
-struct NoConstantConditionVisitor<'c> {
-  context: &'c mut Context,
+struct NoConstantConditionVisitor<'c, 'view> {
+  context: &'c mut Context<'view>,
 }
 
-impl<'c> NoConstantConditionVisitor<'c> {
-  fn new(context: &'c mut Context) -> Self {
+impl<'c, 'view> NoConstantConditionVisitor<'c, 'view> {
+  fn new(context: &'c mut Context<'view>) -> Self {
     Self { context }
   }
 
@@ -195,7 +199,7 @@ impl<'c> NoConstantConditionVisitor<'c> {
   }
 }
 
-impl<'c> VisitAll for NoConstantConditionVisitor<'c> {
+impl<'c, 'view> VisitAll for NoConstantConditionVisitor<'c, 'view> {
   noop_visit_type!();
 
   fn visit_cond_expr(&mut self, cond_expr: &CondExpr, _parent: &dyn Node) {

--- a/src/rules/no_control_regex.rs
+++ b/src/rules/no_control_regex.rs
@@ -166,7 +166,7 @@ impl<'c> VisitAll for NoControlRegexVisitor<'c> {
   fn visit_new_expr(&mut self, new_expr: &NewExpr, _: &dyn Node) {
     if let Expr::Ident(ident) = &*new_expr.callee {
       if let Some(args) = &new_expr.args {
-        if let Some(regex) = extract_regex(&self.context.scope, ident, args) {
+        if let Some(regex) = extract_regex(self.context.scope(), ident, args) {
           self.check_regex(regex.as_str(), new_expr.span);
         }
       }
@@ -177,7 +177,7 @@ impl<'c> VisitAll for NoControlRegexVisitor<'c> {
     if let ExprOrSuper::Expr(expr) = &call_expr.callee {
       if let Expr::Ident(ident) = expr.as_ref() {
         if let Some(regex) =
-          extract_regex(&self.context.scope, ident, &call_expr.args)
+          extract_regex(self.context.scope(), ident, &call_expr.args)
         {
           self.check_regex(regex.as_str(), call_expr.span);
         }

--- a/src/rules/no_control_regex.rs
+++ b/src/rules/no_control_regex.rs
@@ -44,7 +44,11 @@ impl LintRule for NoControlRegex {
     CODE
   }
 
-  fn lint_program(&self, context: &mut Context, program: ProgramRef<'_>) {
+  fn lint_program<'view>(
+    &self,
+    context: &mut Context<'view>,
+    program: ProgramRef<'view>,
+  ) {
     let mut visitor = NoControlRegexVisitor::new(context);
     match program {
       ProgramRef::Module(ref m) => m.visit_all_with(&DUMMY_NODE, &mut visitor),
@@ -80,12 +84,12 @@ const pattern4 = new RegExp("\\u0020");
   }
 }
 
-struct NoControlRegexVisitor<'c> {
-  context: &'c mut Context,
+struct NoControlRegexVisitor<'c, 'view> {
+  context: &'c mut Context<'view>,
 }
 
-impl<'c> NoControlRegexVisitor<'c> {
-  fn new(context: &'c mut Context) -> Self {
+impl<'c, 'view> NoControlRegexVisitor<'c, 'view> {
+  fn new(context: &'c mut Context<'view>) -> Self {
     Self { context }
   }
 
@@ -156,7 +160,7 @@ fn read_hex_until_brace(iter: &mut Peekable<Chars>) -> Option<u64> {
   u64::from_str_radix(s.as_str(), 16).ok()
 }
 
-impl<'c> VisitAll for NoControlRegexVisitor<'c> {
+impl<'c, 'view> VisitAll for NoControlRegexVisitor<'c, 'view> {
   noop_visit_type!();
 
   fn visit_regex(&mut self, regex: &Regex, _: &dyn Node) {

--- a/src/rules/no_debugger.rs
+++ b/src/rules/no_debugger.rs
@@ -35,7 +35,11 @@ impl LintRule for NoDebugger {
     CODE
   }
 
-  fn lint_program(&self, context: &mut Context, program: ProgramRef<'_>) {
+  fn lint_program<'view>(
+    &self,
+    context: &mut Context<'view>,
+    program: ProgramRef<'view>,
+  ) {
     let mut visitor = NoDebuggerVisitor::new(context);
     match program {
       ProgramRef::Module(ref m) => visitor.visit_module(m, &DUMMY_NODE),
@@ -68,17 +72,17 @@ function isLongString(x: string) {
 "#
   }
 }
-struct NoDebuggerVisitor<'c> {
-  context: &'c mut Context,
+struct NoDebuggerVisitor<'c, 'view> {
+  context: &'c mut Context<'view>,
 }
 
-impl<'c> NoDebuggerVisitor<'c> {
-  fn new(context: &'c mut Context) -> Self {
+impl<'c, 'view> NoDebuggerVisitor<'c, 'view> {
+  fn new(context: &'c mut Context<'view>) -> Self {
     Self { context }
   }
 }
 
-impl<'c> Visit for NoDebuggerVisitor<'c> {
+impl<'c, 'view> Visit for NoDebuggerVisitor<'c, 'view> {
   noop_visit_type!();
 
   fn visit_debugger_stmt(

--- a/src/rules/no_delete_var.rs
+++ b/src/rules/no_delete_var.rs
@@ -37,7 +37,11 @@ impl LintRule for NoDeleteVar {
     CODE
   }
 
-  fn lint_program(&self, context: &mut Context, program: ProgramRef<'_>) {
+  fn lint_program<'view>(
+    &self,
+    context: &mut Context<'view>,
+    program: ProgramRef<'view>,
+  ) {
     let mut visitor = NoDeleteVarVisitor::new(context);
     match program {
       ProgramRef::Module(ref m) => visitor.visit_module(m, &DUMMY_NODE),
@@ -73,17 +77,17 @@ delete obj.a; // returns true;
   }
 }
 
-struct NoDeleteVarVisitor<'c> {
-  context: &'c mut Context,
+struct NoDeleteVarVisitor<'c, 'view> {
+  context: &'c mut Context<'view>,
 }
 
-impl<'c> NoDeleteVarVisitor<'c> {
-  fn new(context: &'c mut Context) -> Self {
+impl<'c, 'view> NoDeleteVarVisitor<'c, 'view> {
+  fn new(context: &'c mut Context<'view>) -> Self {
     Self { context }
   }
 }
 
-impl<'c> Visit for NoDeleteVarVisitor<'c> {
+impl<'c, 'view> Visit for NoDeleteVarVisitor<'c, 'view> {
   noop_visit_type!();
 
   fn visit_unary_expr(&mut self, unary_expr: &UnaryExpr, _parent: &dyn Node) {

--- a/src/rules/no_deprecated_deno_api.rs
+++ b/src/rules/no_deprecated_deno_api.rs
@@ -207,7 +207,7 @@ impl Handler for NoDeprecatedDenoApiHandler {
     if_chain! {
       if let ExprOrSuper::Expr(Expr::Ident(ref obj)) = &member_expr.obj;
       let obj_symbol = obj.sym();
-      if !is_shadowed(obj_symbol, &ctx.scope);
+      if !is_shadowed(obj_symbol, ctx.scope());
       if let Some(prop_symbol) = extract_symbol(&member_expr.prop);
       if let Ok(deprecated_api) = DeprecatedApi::try_from((obj_symbol, prop_symbol));
       then {

--- a/src/rules/no_dupe_args.rs
+++ b/src/rules/no_dupe_args.rs
@@ -40,7 +40,11 @@ impl LintRule for NoDupeArgs {
     "no-dupe-args"
   }
 
-  fn lint_program(&self, context: &mut Context, program: ProgramRef<'_>) {
+  fn lint_program<'view>(
+    &self,
+    context: &mut Context<'view>,
+    program: ProgramRef<'view>,
+  ) {
     let mut visitor = NoDupeArgsVisitor::new(context);
     match program {
       ProgramRef::Module(ref m) => m.visit_all_with(&DUMMY_NODE, &mut visitor),
@@ -72,13 +76,13 @@ function withoutDupes(a, b, c) {
   }
 }
 
-struct NoDupeArgsVisitor<'c> {
-  context: &'c mut Context,
+struct NoDupeArgsVisitor<'c, 'view> {
+  context: &'c mut Context<'view>,
   error_spans: BTreeSet<Span>,
 }
 
-impl<'c> NoDupeArgsVisitor<'c> {
-  fn new(context: &'c mut Context) -> Self {
+impl<'c, 'view> NoDupeArgsVisitor<'c, 'view> {
+  fn new(context: &'c mut Context<'view>) -> Self {
     Self {
       context,
       error_spans: BTreeSet::new(),
@@ -123,7 +127,7 @@ impl<'c> NoDupeArgsVisitor<'c> {
   }
 }
 
-impl<'c> VisitAll for NoDupeArgsVisitor<'c> {
+impl<'ctx, 'view> VisitAll for NoDupeArgsVisitor<'ctx, 'view> {
   noop_visit_type!();
 
   fn visit_function(&mut self, function: &Function, _parent: &dyn Node) {

--- a/src/rules/no_dupe_class_members.rs
+++ b/src/rules/no_dupe_class_members.rs
@@ -39,7 +39,11 @@ impl LintRule for NoDupeClassMembers {
     CODE
   }
 
-  fn lint_program(&self, context: &mut Context, program: ProgramRef<'_>) {
+  fn lint_program<'view>(
+    &self,
+    context: &mut Context<'view>,
+    program: ProgramRef<'view>,
+  ) {
     let mut visitor = NoDupeClassMembersVisitor::new(context);
     match program {
       ProgramRef::Module(ref m) => visitor.visit_module(m, &DUMMY_NODE),
@@ -72,12 +76,12 @@ class Foo {
   }
 }
 
-struct NoDupeClassMembersVisitor<'c> {
-  context: &'c mut Context,
+struct NoDupeClassMembersVisitor<'c, 'view> {
+  context: &'c mut Context<'view>,
 }
 
-impl<'c> NoDupeClassMembersVisitor<'c> {
-  fn new(context: &'c mut Context) -> Self {
+impl<'c, 'view> NoDupeClassMembersVisitor<'c, 'view> {
+  fn new(context: &'c mut Context<'view>) -> Self {
     Self { context }
   }
 
@@ -91,7 +95,7 @@ impl<'c> NoDupeClassMembersVisitor<'c> {
   }
 }
 
-impl<'c> Visit for NoDupeClassMembersVisitor<'c> {
+impl<'c, 'view> Visit for NoDupeClassMembersVisitor<'c, 'view> {
   noop_visit_type!();
 
   fn visit_class(&mut self, class: &Class, _: &dyn Node) {
@@ -101,13 +105,13 @@ impl<'c> Visit for NoDupeClassMembersVisitor<'c> {
   }
 }
 
-struct ClassVisitor<'a, 'b> {
-  root_visitor: &'b mut NoDupeClassMembersVisitor<'a>,
+struct ClassVisitor<'a, 'b, 'view> {
+  root_visitor: &'b mut NoDupeClassMembersVisitor<'a, 'view>,
   appeared_methods: BTreeMap<MethodToCheck, Vec<(Span, String)>>,
 }
 
-impl<'a, 'b> ClassVisitor<'a, 'b> {
-  fn new(root_visitor: &'b mut NoDupeClassMembersVisitor<'a>) -> Self {
+impl<'a, 'b, 'view> ClassVisitor<'a, 'b, 'view> {
+  fn new(root_visitor: &'b mut NoDupeClassMembersVisitor<'a, 'view>) -> Self {
     Self {
       root_visitor,
       appeared_methods: BTreeMap::new(),
@@ -128,7 +132,7 @@ impl<'a, 'b> ClassVisitor<'a, 'b> {
   }
 }
 
-impl<'a, 'b> Visit for ClassVisitor<'a, 'b> {
+impl<'a, 'b, 'view> Visit for ClassVisitor<'a, 'b, 'view> {
   noop_visit_type!();
 
   fn visit_class(&mut self, class: &Class, _: &dyn Node) {

--- a/src/rules/no_dupe_else_if.rs
+++ b/src/rules/no_dupe_else_if.rs
@@ -40,7 +40,11 @@ impl LintRule for NoDupeElseIf {
     CODE
   }
 
-  fn lint_program(&self, context: &mut Context, program: ProgramRef<'_>) {
+  fn lint_program<'view>(
+    &self,
+    context: &mut Context<'view>,
+    program: ProgramRef<'view>,
+  ) {
     let mut visitor = NoDupeElseIfVisitor::new(context);
     match program {
       ProgramRef::Module(ref m) => m.visit_all_with(&DUMMY_NODE, &mut visitor),
@@ -83,13 +87,13 @@ else if (a === 7) {}
 /// A visitor to check the `no-dupe-else-if` rule.
 /// Determination logic is ported from ESLint's implementation. For more, see:
 /// [eslint/no-dupe-else-if.js](https://github.com/eslint/eslint/blob/master/lib/rules/no-dupe-else-if.js).
-struct NoDupeElseIfVisitor<'c> {
-  context: &'c mut Context,
+struct NoDupeElseIfVisitor<'c, 'view> {
+  context: &'c mut Context<'view>,
   checked_span: HashSet<Span>,
 }
 
-impl<'c> NoDupeElseIfVisitor<'c> {
-  fn new(context: &'c mut Context) -> Self {
+impl<'c, 'view> NoDupeElseIfVisitor<'c, 'view> {
+  fn new(context: &'c mut Context<'view>) -> Self {
     Self {
       context,
       checked_span: HashSet::new(),
@@ -97,7 +101,7 @@ impl<'c> NoDupeElseIfVisitor<'c> {
   }
 }
 
-impl<'c> VisitAll for NoDupeElseIfVisitor<'c> {
+impl<'c, 'view> VisitAll for NoDupeElseIfVisitor<'c, 'view> {
   noop_visit_type!();
 
   fn visit_if_stmt(&mut self, if_stmt: &IfStmt, _: &dyn Node) {

--- a/src/rules/no_dupe_keys.rs
+++ b/src/rules/no_dupe_keys.rs
@@ -40,7 +40,11 @@ impl LintRule for NoDupeKeys {
     CODE
   }
 
-  fn lint_program(&self, context: &mut Context, program: ProgramRef<'_>) {
+  fn lint_program<'view>(
+    &self,
+    context: &mut Context<'view>,
+    program: ProgramRef<'view>,
+  ) {
     let mut visitor = NoDupeKeysVisitor::new(context);
     match program {
       ProgramRef::Module(ref m) => m.visit_all_with(&DUMMY_NODE, &mut visitor),
@@ -82,12 +86,12 @@ var foo = {
   }
 }
 
-struct NoDupeKeysVisitor<'c> {
-  context: &'c mut Context,
+struct NoDupeKeysVisitor<'c, 'view> {
+  context: &'c mut Context<'view>,
 }
 
-impl<'c> NoDupeKeysVisitor<'c> {
-  fn new(context: &'c mut Context) -> Self {
+impl<'c, 'view> NoDupeKeysVisitor<'c, 'view> {
+  fn new(context: &'c mut Context<'view>) -> Self {
     Self { context }
   }
 
@@ -191,7 +195,7 @@ impl PropertyInfo {
   }
 }
 
-impl<'c> VisitAll for NoDupeKeysVisitor<'c> {
+impl<'c, 'view> VisitAll for NoDupeKeysVisitor<'c, 'view> {
   noop_visit_type!();
 
   fn visit_object_lit(&mut self, obj_lit: &ObjectLit, _parent: &dyn Node) {

--- a/src/rules/no_duplicate_case.rs
+++ b/src/rules/no_duplicate_case.rs
@@ -37,7 +37,11 @@ impl LintRule for NoDuplicateCase {
     CODE
   }
 
-  fn lint_program(&self, context: &mut Context, program: ProgramRef<'_>) {
+  fn lint_program<'view>(
+    &self,
+    context: &mut Context<'view>,
+    program: ProgramRef<'view>,
+  ) {
     let mut visitor = NoDuplicateCaseVisitor::new(context);
     match program {
       ProgramRef::Module(ref m) => m.visit_all_with(&DUMMY_NODE, &mut visitor),
@@ -84,17 +88,17 @@ switch (someText) {
   }
 }
 
-struct NoDuplicateCaseVisitor<'c> {
-  context: &'c mut Context,
+struct NoDuplicateCaseVisitor<'c, 'view> {
+  context: &'c mut Context<'view>,
 }
 
-impl<'c> NoDuplicateCaseVisitor<'c> {
-  fn new(context: &'c mut Context) -> Self {
+impl<'c, 'view> NoDuplicateCaseVisitor<'c, 'view> {
+  fn new(context: &'c mut Context<'view>) -> Self {
     Self { context }
   }
 }
 
-impl<'c> VisitAll for NoDuplicateCaseVisitor<'c> {
+impl<'c, 'view> VisitAll for NoDuplicateCaseVisitor<'c, 'view> {
   noop_visit_type!();
 
   fn visit_switch_stmt(&mut self, switch_stmt: &SwitchStmt, _: &dyn Node) {

--- a/src/rules/no_empty.rs
+++ b/src/rules/no_empty.rs
@@ -1,8 +1,5 @@
 // Copyright 2020-2021 the Deno authors. All rights reserved. MIT license.
 use super::{Context, LintRule, ProgramRef, DUMMY_NODE};
-use std::collections::HashMap;
-use swc_common::comments::Comment;
-use swc_common::BytePos;
 use swc_ecmascript::ast::{
   ArrowExpr, BlockStmt, BlockStmtOrExpr, Constructor, Function, SwitchStmt,
 };
@@ -161,14 +158,9 @@ trait ContainsComments {
 
 impl ContainsComments for BlockStmt {
   fn contains_comments(&self, context: &Context) -> bool {
-    let contains = |comments: &HashMap<BytePos, Vec<Comment>>| {
-      comments
-        .values()
-        .flatten()
-        .any(|comment| self.span.contains(comment.span))
-    };
-
-    contains(&context.leading_comments) || contains(&context.trailing_comments)
+    context
+      .all_comments()
+      .any(|comment| self.span.contains(comment.span))
   }
 }
 

--- a/src/rules/no_empty.rs
+++ b/src/rules/no_empty.rs
@@ -22,7 +22,11 @@ impl LintRule for NoEmpty {
     CODE
   }
 
-  fn lint_program(&self, context: &mut Context, program: ProgramRef<'_>) {
+  fn lint_program<'view>(
+    &self,
+    context: &mut Context<'view>,
+    program: ProgramRef<'view>,
+  ) {
     let mut visitor = NoEmptyVisitor::new(context);
     match program {
       ProgramRef::Module(ref m) => visitor.visit_module(m, &DUMMY_NODE),
@@ -87,17 +91,17 @@ try {
   }
 }
 
-struct NoEmptyVisitor<'c> {
-  context: &'c mut Context,
+struct NoEmptyVisitor<'c, 'view> {
+  context: &'c mut Context<'view>,
 }
 
-impl<'c> NoEmptyVisitor<'c> {
-  fn new(context: &'c mut Context) -> Self {
+impl<'c, 'view> NoEmptyVisitor<'c, 'view> {
+  fn new(context: &'c mut Context<'view>) -> Self {
     Self { context }
   }
 }
 
-impl<'c> Visit for NoEmptyVisitor<'c> {
+impl<'c, 'view> Visit for NoEmptyVisitor<'c, 'view> {
   noop_visit_type!();
 
   fn visit_function(&mut self, function: &Function, _parent: &dyn Node) {

--- a/src/rules/no_empty_character_class.rs
+++ b/src/rules/no_empty_character_class.rs
@@ -26,7 +26,11 @@ impl LintRule for NoEmptyCharacterClass {
     CODE
   }
 
-  fn lint_program(&self, context: &mut Context, program: ProgramRef<'_>) {
+  fn lint_program<'view>(
+    &self,
+    context: &mut Context<'view>,
+    program: ProgramRef<'view>,
+  ) {
     let mut visitor = NoEmptyCharacterClassVisitor::new(context);
     match program {
       ProgramRef::Module(ref m) => visitor.visit_module(m, &DUMMY_NODE),
@@ -60,17 +64,17 @@ a typo or mistake.
   }
 }
 
-struct NoEmptyCharacterClassVisitor<'c> {
-  context: &'c mut Context,
+struct NoEmptyCharacterClassVisitor<'c, 'view> {
+  context: &'c mut Context<'view>,
 }
 
-impl<'c> NoEmptyCharacterClassVisitor<'c> {
-  fn new(context: &'c mut Context) -> Self {
+impl<'c, 'view> NoEmptyCharacterClassVisitor<'c, 'view> {
+  fn new(context: &'c mut Context<'view>) -> Self {
     Self { context }
   }
 }
 
-impl<'c> Visit for NoEmptyCharacterClassVisitor<'c> {
+impl<'c, 'view> Visit for NoEmptyCharacterClassVisitor<'c, 'view> {
   noop_visit_type!();
 
   fn visit_regex(&mut self, regex: &Regex, _parent: &dyn Node) {

--- a/src/rules/no_empty_character_class.rs
+++ b/src/rules/no_empty_character_class.rs
@@ -76,7 +76,7 @@ impl<'c> Visit for NoEmptyCharacterClassVisitor<'c> {
   fn visit_regex(&mut self, regex: &Regex, _parent: &dyn Node) {
     let raw_regex = self
       .context
-      .source_map
+      .source_map()
       .span_to_snippet(regex.span)
       .expect("error in loading snippet");
 

--- a/src/rules/no_empty_interface.rs
+++ b/src/rules/no_empty_interface.rs
@@ -42,7 +42,11 @@ impl LintRule for NoEmptyInterface {
     CODE
   }
 
-  fn lint_program(&self, context: &mut Context, program: ProgramRef<'_>) {
+  fn lint_program<'view>(
+    &self,
+    context: &mut Context<'view>,
+    program: ProgramRef<'view>,
+  ) {
     let mut visitor = NoEmptyInterfaceVisitor::new(context);
     match program {
       ProgramRef::Module(ref m) => visitor.visit_module(m, &DUMMY_NODE),
@@ -82,17 +86,17 @@ interface Baz extends Foo, Bar {}
   }
 }
 
-struct NoEmptyInterfaceVisitor<'c> {
-  context: &'c mut Context,
+struct NoEmptyInterfaceVisitor<'c, 'view> {
+  context: &'c mut Context<'view>,
 }
 
-impl<'c> NoEmptyInterfaceVisitor<'c> {
-  fn new(context: &'c mut Context) -> Self {
+impl<'c, 'view> NoEmptyInterfaceVisitor<'c, 'view> {
+  fn new(context: &'c mut Context<'view>) -> Self {
     Self { context }
   }
 }
 
-impl<'c> Visit for NoEmptyInterfaceVisitor<'c> {
+impl<'c, 'view> Visit for NoEmptyInterfaceVisitor<'c, 'view> {
   fn visit_ts_interface_decl(
     &mut self,
     interface_decl: &TsInterfaceDecl,

--- a/src/rules/no_empty_pattern.rs
+++ b/src/rules/no_empty_pattern.rs
@@ -25,7 +25,11 @@ impl LintRule for NoEmptyPattern {
     CODE
   }
 
-  fn lint_program(&self, context: &mut Context, program: ProgramRef<'_>) {
+  fn lint_program<'view>(
+    &self,
+    context: &mut Context<'view>,
+    program: ProgramRef<'view>,
+  ) {
     let mut visitor = NoEmptyPatternVisitor::new(context);
     match program {
       ProgramRef::Module(ref m) => visitor.visit_module(m, &DUMMY_NODE),
@@ -71,17 +75,17 @@ function myFunc([a = []]) {}
   }
 }
 
-struct NoEmptyPatternVisitor<'c> {
-  context: &'c mut Context,
+struct NoEmptyPatternVisitor<'c, 'view> {
+  context: &'c mut Context<'view>,
 }
 
-impl<'c> NoEmptyPatternVisitor<'c> {
-  fn new(context: &'c mut Context) -> Self {
+impl<'c, 'view> NoEmptyPatternVisitor<'c, 'view> {
+  fn new(context: &'c mut Context<'view>) -> Self {
     Self { context }
   }
 }
 
-impl<'c> Visit for NoEmptyPatternVisitor<'c> {
+impl<'c, 'view> Visit for NoEmptyPatternVisitor<'c, 'view> {
   noop_visit_type!();
 
   fn visit_object_pat_prop(

--- a/src/rules/no_eval.rs
+++ b/src/rules/no_eval.rs
@@ -26,7 +26,11 @@ impl LintRule for NoEval {
     CODE
   }
 
-  fn lint_program(&self, context: &mut Context, program: ProgramRef<'_>) {
+  fn lint_program<'view>(
+    &self,
+    context: &mut Context<'view>,
+    program: ProgramRef<'view>,
+  ) {
     let mut visitor = NoEvalVisitor::new(context);
     match program {
       ProgramRef::Module(ref m) => visitor.visit_module(m, &DUMMY_NODE),
@@ -57,12 +61,12 @@ const value = obj[x];
   }
 }
 
-struct NoEvalVisitor<'c> {
-  context: &'c mut Context,
+struct NoEvalVisitor<'c, 'view> {
+  context: &'c mut Context<'view>,
 }
 
-impl<'c> NoEvalVisitor<'c> {
-  fn new(context: &'c mut Context) -> Self {
+impl<'c, 'view> NoEvalVisitor<'c, 'view> {
+  fn new(context: &'c mut Context<'view>) -> Self {
     Self { context }
   }
 
@@ -97,7 +101,7 @@ impl<'c> NoEvalVisitor<'c> {
   }
 }
 
-impl<'c> Visit for NoEvalVisitor<'c> {
+impl<'c, 'view> Visit for NoEvalVisitor<'c, 'view> {
   noop_visit_type!();
 
   fn visit_var_declarator(&mut self, v: &VarDeclarator, _: &dyn Node) {

--- a/src/rules/no_ex_assign.rs
+++ b/src/rules/no_ex_assign.rs
@@ -88,7 +88,7 @@ impl<'c> VisitAll for NoExAssignVisitor<'c> {
     let ids = find_lhs_ids(&assign_expr.left);
 
     for id in ids {
-      let var = self.context.scope.var(&id);
+      let var = self.context.scope().var(&id);
 
       if let Some(var) = var {
         if let BindingKind::CatchClause = var.kind() {

--- a/src/rules/no_ex_assign.rs
+++ b/src/rules/no_ex_assign.rs
@@ -35,7 +35,11 @@ impl LintRule for NoExAssign {
     CODE
   }
 
-  fn lint_program(&self, context: &mut Context, program: ProgramRef<'_>) {
+  fn lint_program<'view>(
+    &self,
+    context: &mut Context<'view>,
+    program: ProgramRef<'view>,
+  ) {
     let mut visitor = NoExAssignVisitor::new(context);
     match program {
       ProgramRef::Module(ref m) => m.visit_all_with(&DUMMY_NODE, &mut visitor),
@@ -71,17 +75,17 @@ try {
   }
 }
 
-struct NoExAssignVisitor<'c> {
-  context: &'c mut Context,
+struct NoExAssignVisitor<'c, 'view> {
+  context: &'c mut Context<'view>,
 }
 
-impl<'c> NoExAssignVisitor<'c> {
-  fn new(context: &'c mut Context) -> Self {
+impl<'c, 'view> NoExAssignVisitor<'c, 'view> {
+  fn new(context: &'c mut Context<'view>) -> Self {
     Self { context }
   }
 }
 
-impl<'c> VisitAll for NoExAssignVisitor<'c> {
+impl<'c, 'view> VisitAll for NoExAssignVisitor<'c, 'view> {
   noop_visit_type!();
 
   fn visit_assign_expr(&mut self, assign_expr: &AssignExpr, _: &dyn Node) {

--- a/src/rules/no_explicit_any.rs
+++ b/src/rules/no_explicit_any.rs
@@ -23,7 +23,11 @@ impl LintRule for NoExplicitAny {
     CODE
   }
 
-  fn lint_program(&self, context: &mut Context, program: ProgramRef<'_>) {
+  fn lint_program<'view>(
+    &self,
+    context: &mut Context<'view>,
+    program: ProgramRef<'view>,
+  ) {
     let mut visitor = NoExplicitAnyVisitor::new(context);
     match program {
       ProgramRef::Module(ref m) => visitor.visit_module(m, &DUMMY_NODE),
@@ -56,17 +60,17 @@ function foo(): undefined { return undefined; }
   }
 }
 
-struct NoExplicitAnyVisitor<'c> {
-  context: &'c mut Context,
+struct NoExplicitAnyVisitor<'c, 'view> {
+  context: &'c mut Context<'view>,
 }
 
-impl<'c> NoExplicitAnyVisitor<'c> {
-  fn new(context: &'c mut Context) -> Self {
+impl<'c, 'view> NoExplicitAnyVisitor<'c, 'view> {
+  fn new(context: &'c mut Context<'view>) -> Self {
     Self { context }
   }
 }
 
-impl<'c> Visit for NoExplicitAnyVisitor<'c> {
+impl<'c, 'view> Visit for NoExplicitAnyVisitor<'c, 'view> {
   fn visit_ts_keyword_type(
     &mut self,
     ts_keyword_type: &TsKeywordType,

--- a/src/rules/no_extra_boolean_cast.rs
+++ b/src/rules/no_extra_boolean_cast.rs
@@ -43,7 +43,11 @@ impl LintRule for NoExtraBooleanCast {
     CODE
   }
 
-  fn lint_program(&self, context: &mut Context, program: ProgramRef<'_>) {
+  fn lint_program<'view>(
+    &self,
+    context: &mut Context<'view>,
+    program: ProgramRef<'view>,
+  ) {
     let mut visitor = NoExtraBooleanCastVisitor::new(context);
     match program {
       ProgramRef::Module(ref m) => m.visit_all_with(&DUMMY_NODE, &mut visitor),
@@ -77,12 +81,12 @@ for(;foo;) {}
   }
 }
 
-struct NoExtraBooleanCastVisitor<'c> {
-  context: &'c mut Context,
+struct NoExtraBooleanCastVisitor<'c, 'view> {
+  context: &'c mut Context<'view>,
 }
 
-impl<'c> NoExtraBooleanCastVisitor<'c> {
-  fn new(context: &'c mut Context) -> Self {
+impl<'c, 'view> NoExtraBooleanCastVisitor<'c, 'view> {
+  fn new(context: &'c mut Context<'view>) -> Self {
     Self { context }
   }
 
@@ -160,7 +164,7 @@ impl<'c> NoExtraBooleanCastVisitor<'c> {
   }
 }
 
-impl<'c> VisitAll for NoExtraBooleanCastVisitor<'c> {
+impl<'c, 'view> VisitAll for NoExtraBooleanCastVisitor<'c, 'view> {
   noop_visit_type!();
 
   fn visit_cond_expr(&mut self, cond_expr: &CondExpr, _: &dyn Node) {

--- a/src/rules/no_extra_non_null_assertion.rs
+++ b/src/rules/no_extra_non_null_assertion.rs
@@ -38,7 +38,11 @@ impl LintRule for NoExtraNonNullAssertion {
     CODE
   }
 
-  fn lint_program(&self, context: &mut Context, program: ProgramRef<'_>) {
+  fn lint_program<'view>(
+    &self,
+    context: &mut Context<'view>,
+    program: ProgramRef<'view>,
+  ) {
     let mut visitor = NoExtraNonNullAssertionVisitor::new(context);
     match program {
       ProgramRef::Module(ref m) => m.visit_all_with(&DUMMY_NODE, &mut visitor),
@@ -75,12 +79,12 @@ function anotherFunc(bar?: { str: string }) { return bar?.str; }
   }
 }
 
-struct NoExtraNonNullAssertionVisitor<'c> {
-  context: &'c mut Context,
+struct NoExtraNonNullAssertionVisitor<'c, 'view> {
+  context: &'c mut Context<'view>,
 }
 
-impl<'c> NoExtraNonNullAssertionVisitor<'c> {
-  fn new(context: &'c mut Context) -> Self {
+impl<'c, 'view> NoExtraNonNullAssertionVisitor<'c, 'view> {
+  fn new(context: &'c mut Context<'view>) -> Self {
     Self { context }
   }
 
@@ -104,7 +108,7 @@ impl<'c> NoExtraNonNullAssertionVisitor<'c> {
   }
 }
 
-impl<'c> VisitAll for NoExtraNonNullAssertionVisitor<'c> {
+impl<'c, 'view> VisitAll for NoExtraNonNullAssertionVisitor<'c, 'view> {
   fn visit_ts_non_null_expr(
     &mut self,
     ts_non_null_expr: &TsNonNullExpr,

--- a/src/rules/no_extra_semi.rs
+++ b/src/rules/no_extra_semi.rs
@@ -36,7 +36,11 @@ impl LintRule for NoExtraSemi {
     CODE
   }
 
-  fn lint_program(&self, context: &mut Context, program: ProgramRef<'_>) {
+  fn lint_program<'view>(
+    &self,
+    context: &mut Context<'view>,
+    program: ProgramRef<'view>,
+  ) {
     let mut visitor = NoExtraSemiVisitor::new(context);
     match program {
       ProgramRef::Module(ref m) => m.visit_with(&DUMMY_NODE, &mut visitor),
@@ -67,17 +71,17 @@ function foo() {}
   }
 }
 
-struct NoExtraSemiVisitor<'c> {
-  context: &'c mut Context,
+struct NoExtraSemiVisitor<'c, 'view> {
+  context: &'c mut Context<'view>,
 }
 
-impl<'c> NoExtraSemiVisitor<'c> {
-  fn new(context: &'c mut Context) -> Self {
+impl<'c, 'view> NoExtraSemiVisitor<'c, 'view> {
+  fn new(context: &'c mut Context<'view>) -> Self {
     Self { context }
   }
 }
 
-impl<'c> Visit for NoExtraSemiVisitor<'c> {
+impl<'c, 'view> Visit for NoExtraSemiVisitor<'c, 'view> {
   noop_visit_type!();
 
   fn visit_empty_stmt(&mut self, empty_stmt: &EmptyStmt, _parent: &dyn Node) {

--- a/src/rules/no_fallthrough.rs
+++ b/src/rules/no_fallthrough.rs
@@ -38,7 +38,11 @@ impl LintRule for NoFallthrough {
     CODE
   }
 
-  fn lint_program(&self, context: &mut Context, program: ProgramRef<'_>) {
+  fn lint_program<'view>(
+    &self,
+    context: &mut Context<'view>,
+    program: ProgramRef<'view>,
+  ) {
     let mut visitor = NoFallthroughVisitor { context };
     match program {
       ProgramRef::Module(ref m) => visitor.visit_module(m, &DUMMY_NODE),
@@ -96,11 +100,11 @@ switch(myVar) {
   }
 }
 
-struct NoFallthroughVisitor<'c> {
-  context: &'c mut Context,
+struct NoFallthroughVisitor<'c, 'view> {
+  context: &'c mut Context<'view>,
 }
 
-impl<'c> Visit for NoFallthroughVisitor<'c> {
+impl<'c, 'view> Visit for NoFallthroughVisitor<'c, 'view> {
   noop_visit_type!();
 
   fn visit_switch_cases(&mut self, cases: &[SwitchCase], parent: &dyn Node) {

--- a/src/rules/no_fallthrough.rs
+++ b/src/rules/no_fallthrough.rs
@@ -173,7 +173,9 @@ impl<'c, 'view> Visit for NoFallthroughVisitor<'c, 'view> {
   }
 }
 
-fn allow_fall_through<'c>(comments: impl Iterator<Item = &'c Comment>) -> bool {
+fn allow_fall_through<'c>(
+  mut comments: impl Iterator<Item = &'c Comment>,
+) -> bool {
   comments.any(|comment| {
     let l = comment.text.to_ascii_lowercase();
     l.contains("fallthrough")

--- a/src/rules/no_fallthrough.rs
+++ b/src/rules/no_fallthrough.rs
@@ -133,7 +133,7 @@ impl<'c> Visit for NoFallthroughVisitor<'c> {
       // Handle return / throw / break / continue
       for (idx, stmt) in case.cons.iter().enumerate() {
         let last = idx + 1 == case.cons.len();
-        let metadata = self.context.control_flow.meta(stmt.span().lo);
+        let metadata = self.context.control_flow().meta(stmt.span().lo);
         stops_exec |= metadata.map(|v| v.stops_execution()).unwrap_or(false);
         if stops_exec {
           should_emit_err = false;
@@ -165,7 +165,7 @@ impl<'c> Visit for NoFallthroughVisitor<'c> {
           hi: cases[case_idx + 1].span.lo(),
           ctxt: case.span.ctxt,
         };
-        let span_lines = self.context.source_map.span_to_lines(span).unwrap();
+        let span_lines = self.context.source_map().span_to_lines(span).unwrap();
         // When the case body contains only new lines `case.cons` will be empty.
         // This means there are no statements detected so we must detect case
         // bodies made up of only new lines by counting the total amount of new lines.

--- a/src/rules/no_func_assign.rs
+++ b/src/rules/no_func_assign.rs
@@ -101,7 +101,7 @@ impl<'c> VisitAll for NoFuncAssignVisitor<'c> {
     let ids = find_lhs_ids(&assign_expr.left);
 
     for id in ids {
-      let var = self.context.scope.var(&id);
+      let var = self.context.scope().var(&id);
       if let Some(var) = var {
         if let BindingKind::Function = var.kind() {
           self.context.add_diagnostic_with_hint(

--- a/src/rules/no_func_assign.rs
+++ b/src/rules/no_func_assign.rs
@@ -38,7 +38,11 @@ impl LintRule for NoFuncAssign {
     CODE
   }
 
-  fn lint_program(&self, context: &mut Context, program: ProgramRef<'_>) {
+  fn lint_program<'view>(
+    &self,
+    context: &mut Context<'view>,
+    program: ProgramRef<'view>,
+  ) {
     let mut visitor = NoFuncAssignVisitor::new(context);
     match program {
       ProgramRef::Module(ref m) => m.visit_all_with(&DUMMY_NODE, &mut visitor),
@@ -84,17 +88,17 @@ myFuncVar = bar;  // variable reassignment, not function re-declaration
   }
 }
 
-struct NoFuncAssignVisitor<'c> {
-  context: &'c mut Context,
+struct NoFuncAssignVisitor<'c, 'view> {
+  context: &'c mut Context<'view>,
 }
 
-impl<'c> NoFuncAssignVisitor<'c> {
-  fn new(context: &'c mut Context) -> Self {
+impl<'c, 'view> NoFuncAssignVisitor<'c, 'view> {
+  fn new(context: &'c mut Context<'view>) -> Self {
     Self { context }
   }
 }
 
-impl<'c> VisitAll for NoFuncAssignVisitor<'c> {
+impl<'c, 'view> VisitAll for NoFuncAssignVisitor<'c, 'view> {
   noop_visit_type!();
 
   fn visit_assign_expr(&mut self, assign_expr: &AssignExpr, _node: &dyn Node) {

--- a/src/rules/no_global_assign.rs
+++ b/src/rules/no_global_assign.rs
@@ -141,7 +141,7 @@ impl<'c> NoGlobalAssignVisitor<'c> {
   }
 
   fn check(&mut self, span: Span, id: Id) {
-    if id.1 != self.context.top_level_ctxt {
+    if id.1 != self.context.top_level_ctxt() {
       return;
     }
 

--- a/src/rules/no_global_assign.rs
+++ b/src/rules/no_global_assign.rs
@@ -42,7 +42,11 @@ impl LintRule for NoGlobalAssign {
     CODE
   }
 
-  fn lint_program(&self, context: &mut Context, program: ProgramRef<'_>) {
+  fn lint_program<'view>(
+    &self,
+    context: &mut Context<'view>,
+    program: ProgramRef<'view>,
+  ) {
     let mut collector = Collector {
       bindings: Default::default(),
     };
@@ -128,15 +132,15 @@ impl Visit for Collector {
   fn visit_expr(&mut self, _: &Expr, _: &dyn Node) {}
 }
 
-struct NoGlobalAssignVisitor<'c> {
-  context: &'c mut Context,
+struct NoGlobalAssignVisitor<'c, 'view> {
+  context: &'c mut Context<'view>,
   /// This hashset only contains top level bindings, so using HashSet<JsWord>
   /// also can be an option.
   bindings: HashSet<Id>,
 }
 
-impl<'c> NoGlobalAssignVisitor<'c> {
-  fn new(context: &'c mut Context, bindings: HashSet<Id>) -> Self {
+impl<'c, 'view> NoGlobalAssignVisitor<'c, 'view> {
+  fn new(context: &'c mut Context<'view>, bindings: HashSet<Id>) -> Self {
     Self { context, bindings }
   }
 
@@ -167,7 +171,7 @@ impl<'c> NoGlobalAssignVisitor<'c> {
   }
 }
 
-impl<'c> Visit for NoGlobalAssignVisitor<'c> {
+impl<'c, 'view> Visit for NoGlobalAssignVisitor<'c, 'view> {
   noop_visit_type!();
 
   fn visit_assign_expr(&mut self, e: &AssignExpr, _: &dyn Node) {

--- a/src/rules/no_import_assign.rs
+++ b/src/rules/no_import_assign.rs
@@ -169,7 +169,7 @@ impl<'c> NoImportAssignVisitor<'c> {
   fn check(&mut self, span: Span, i: &Ident, is_assign_to_prop: bool) {
     // All imports are top-level and as a result,
     // if an identifier is not top-level, we are not assigning to import
-    if i.span.ctxt != self.context.top_level_ctxt {
+    if i.span.ctxt != self.context.top_level_ctxt() {
       return;
     }
 
@@ -216,7 +216,7 @@ impl<'c> NoImportAssignVisitor<'c> {
 
   fn is_modifier(&self, obj: &Expr, prop: &Expr) -> bool {
     if let Expr::Ident(obj) = obj {
-      if self.context.top_level_ctxt != obj.span.ctxt {
+      if self.context.top_level_ctxt() != obj.span.ctxt {
         return false;
       }
       if self.other_bindings.contains(&obj.to_id()) {

--- a/src/rules/no_import_assign.rs
+++ b/src/rules/no_import_assign.rs
@@ -32,7 +32,11 @@ impl LintRule for NoImportAssign {
     CODE
   }
 
-  fn lint_program(&self, context: &mut Context, program: ProgramRef<'_>) {
+  fn lint_program<'view>(
+    &self,
+    context: &mut Context<'view>,
+    program: ProgramRef<'view>,
+  ) {
     let mut collector = Collector {
       imports: Default::default(),
       ns_imports: Default::default(),
@@ -141,8 +145,8 @@ impl Visit for Collector {
   fn visit_expr(&mut self, _: &Expr, _: &dyn Node) {}
 }
 
-struct NoImportAssignVisitor<'c> {
-  context: &'c mut Context,
+struct NoImportAssignVisitor<'c, 'view> {
+  context: &'c mut Context<'view>,
   /// This hashset only contains top level bindings, so using HashSet<JsWord>
   /// also can be an option.
   imports: HashSet<Id>,
@@ -151,9 +155,9 @@ struct NoImportAssignVisitor<'c> {
   other_bindings: HashSet<Id>,
 }
 
-impl<'c> NoImportAssignVisitor<'c> {
+impl<'c, 'view> NoImportAssignVisitor<'c, 'view> {
   fn new(
-    context: &'c mut Context,
+    context: &'c mut Context<'view>,
     imports: HashSet<Id>,
     ns_imports: HashSet<Id>,
     other_bindings: HashSet<Id>,
@@ -295,7 +299,7 @@ impl<'c> NoImportAssignVisitor<'c> {
   }
 }
 
-impl<'c> Visit for NoImportAssignVisitor<'c> {
+impl<'c, 'view> Visit for NoImportAssignVisitor<'c, 'view> {
   noop_visit_type!();
 
   fn visit_pat(&mut self, n: &Pat, _: &dyn Node) {

--- a/src/rules/no_inferrable_types.rs
+++ b/src/rules/no_inferrable_types.rs
@@ -38,7 +38,11 @@ impl LintRule for NoInferrableTypes {
     CODE
   }
 
-  fn lint_program(&self, context: &mut Context, program: ProgramRef<'_>) {
+  fn lint_program<'view>(
+    &self,
+    context: &mut Context<'view>,
+    program: ProgramRef<'view>,
+  ) {
     let mut visitor = NoInferrableTypesVisitor::new(context);
     match program {
       ProgramRef::Module(ref m) => m.visit_all_with(&DUMMY_NODE, &mut visitor),
@@ -113,12 +117,12 @@ function fn(s = 5, t = true) {}
   }
 }
 
-struct NoInferrableTypesVisitor<'c> {
-  context: &'c mut Context,
+struct NoInferrableTypesVisitor<'c, 'view> {
+  context: &'c mut Context<'view>,
 }
 
-impl<'c> NoInferrableTypesVisitor<'c> {
-  fn new(context: &'c mut Context) -> Self {
+impl<'c, 'view> NoInferrableTypesVisitor<'c, 'view> {
+  fn new(context: &'c mut Context<'view>) -> Self {
     Self { context }
   }
 
@@ -343,7 +347,7 @@ impl<'c> NoInferrableTypesVisitor<'c> {
   }
 }
 
-impl<'c> VisitAll for NoInferrableTypesVisitor<'c> {
+impl<'c, 'view> VisitAll for NoInferrableTypesVisitor<'c, 'view> {
   fn visit_function(&mut self, function: &Function, _: &dyn Node) {
     for param in &function.params {
       if let Pat::Assign(assign_pat) = &param.pat {

--- a/src/rules/no_inner_declarations.rs
+++ b/src/rules/no_inner_declarations.rs
@@ -41,7 +41,11 @@ impl LintRule for NoInnerDeclarations {
     CODE
   }
 
-  fn lint_program(&self, context: &mut Context, program: ProgramRef<'_>) {
+  fn lint_program<'view>(
+    &self,
+    context: &mut Context<'view>,
+    program: ProgramRef<'view>,
+  ) {
     let mut valid_visitor = ValidDeclsVisitor::new();
     match program {
       ProgramRef::Module(ref m) => {
@@ -205,14 +209,14 @@ impl VisitAll for ValidDeclsVisitor {
   }
 }
 
-struct NoInnerDeclarationsVisitor<'c> {
-  context: &'c mut Context,
+struct NoInnerDeclarationsVisitor<'c, 'view> {
+  context: &'c mut Context<'view>,
   valid_decls: HashSet<Span>,
   in_function: bool,
 }
 
-impl<'c> NoInnerDeclarationsVisitor<'c> {
-  fn new(context: &'c mut Context, valid_decls: HashSet<Span>) -> Self {
+impl<'c, 'view> NoInnerDeclarationsVisitor<'c, 'view> {
+  fn new(context: &'c mut Context<'view>, valid_decls: HashSet<Span>) -> Self {
     Self {
       context,
       valid_decls,
@@ -221,7 +225,7 @@ impl<'c> NoInnerDeclarationsVisitor<'c> {
   }
 }
 
-impl<'c> NoInnerDeclarationsVisitor<'c> {
+impl<'c, 'view> NoInnerDeclarationsVisitor<'c, 'view> {
   fn add_diagnostic(&mut self, span: Span, kind: &str) {
     let root = if self.in_function {
       "function"
@@ -238,7 +242,7 @@ impl<'c> NoInnerDeclarationsVisitor<'c> {
   }
 }
 
-impl<'c> Visit for NoInnerDeclarationsVisitor<'c> {
+impl<'c, 'view> Visit for NoInnerDeclarationsVisitor<'c, 'view> {
   noop_visit_type!();
 
   fn visit_arrow_expr(&mut self, arrow_expr: &ArrowExpr, _: &dyn Node) {

--- a/src/rules/no_invalid_regexp.rs
+++ b/src/rules/no_invalid_regexp.rs
@@ -27,7 +27,11 @@ impl LintRule for NoInvalidRegexp {
     CODE
   }
 
-  fn lint_program(&self, context: &mut Context, program: ProgramRef<'_>) {
+  fn lint_program<'view>(
+    &self,
+    context: &mut Context<'view>,
+    program: ProgramRef<'view>,
+  ) {
     let mut visitor = NoInvalidRegexpVisitor::new(context);
     match program {
       ProgramRef::Module(ref m) => visitor.visit_module(m, &DUMMY_NODE),
@@ -63,13 +67,13 @@ fn check_expr_for_string_literal(expr: &Expr) -> Option<String> {
   None
 }
 
-struct NoInvalidRegexpVisitor<'c> {
-  context: &'c mut Context,
+struct NoInvalidRegexpVisitor<'c, 'view> {
+  context: &'c mut Context<'view>,
   validator: EcmaRegexValidator,
 }
 
-impl<'c> NoInvalidRegexpVisitor<'c> {
-  fn new(context: &'c mut Context) -> Self {
+impl<'c, 'view> NoInvalidRegexpVisitor<'c, 'view> {
+  fn new(context: &'c mut Context<'view>) -> Self {
     Self {
       context,
       validator: EcmaRegexValidator::new(EcmaVersion::Es2018),
@@ -120,7 +124,7 @@ impl<'c> NoInvalidRegexpVisitor<'c> {
   }
 }
 
-impl<'c> Visit for NoInvalidRegexpVisitor<'c> {
+impl<'c, 'view> Visit for NoInvalidRegexpVisitor<'c, 'view> {
   noop_visit_type!();
 
   fn visit_regex(

--- a/src/rules/no_irregular_whitespace.rs
+++ b/src/rules/no_irregular_whitespace.rs
@@ -55,7 +55,11 @@ impl LintRule for NoIrregularWhitespace {
     CODE
   }
 
-  fn lint_program<'view>(&self, context: &mut Context<'view>, program: ProgramRef<'view>) {
+  fn lint_program<'view>(
+    &self,
+    context: &mut Context<'view>,
+    program: ProgramRef<'view>,
+  ) {
     let mut visitor = NoIrregularWhitespaceVisitor::default();
     match program {
       ProgramRef::Module(ref m) => visitor.visit_module(m, &DUMMY_NODE),

--- a/src/rules/no_irregular_whitespace.rs
+++ b/src/rules/no_irregular_whitespace.rs
@@ -55,7 +55,7 @@ impl LintRule for NoIrregularWhitespace {
     CODE
   }
 
-  fn lint_program(&self, context: &mut Context, program: ProgramRef<'_>) {
+  fn lint_program<'view>(&self, context: &mut Context<'view>, program: ProgramRef<'view>) {
     let mut visitor = NoIrregularWhitespaceVisitor::default();
     match program {
       ProgramRef::Module(ref m) => visitor.visit_module(m, &DUMMY_NODE),

--- a/src/rules/no_irregular_whitespace.rs
+++ b/src/rules/no_irregular_whitespace.rs
@@ -68,7 +68,7 @@ impl LintRule for NoIrregularWhitespace {
       ProgramRef::Module(ref m) => m.span,
       ProgramRef::Script(ref s) => s.span,
     };
-    let file_and_lines = context.source_map.span_to_lines(span).unwrap();
+    let file_and_lines = context.source_map().span_to_lines(span).unwrap();
     let file = file_and_lines.file;
 
     for line_index in 0..file.count_lines() {

--- a/src/rules/no_misused_new.rs
+++ b/src/rules/no_misused_new.rs
@@ -38,7 +38,11 @@ impl LintRule for NoMisusedNew {
     Box::new(NoMisusedNew)
   }
 
-  fn lint_program(&self, context: &mut Context, program: ProgramRef<'_>) {
+  fn lint_program<'view>(
+    &self,
+    context: &mut Context<'view>,
+    program: ProgramRef<'view>,
+  ) {
     let mut visitor = NoMisusedNewVisitor::new(context);
     match program {
       ProgramRef::Module(ref m) => m.visit_all_with(&DUMMY_NODE, &mut visitor),
@@ -85,12 +89,12 @@ interface I {
   }
 }
 
-struct NoMisusedNewVisitor<'c> {
-  context: &'c mut Context,
+struct NoMisusedNewVisitor<'c, 'view> {
+  context: &'c mut Context<'view>,
 }
 
-impl<'c> NoMisusedNewVisitor<'c> {
-  fn new(context: &'c mut Context) -> Self {
+impl<'c, 'view> NoMisusedNewVisitor<'c, 'view> {
+  fn new(context: &'c mut Context<'view>) -> Self {
     Self { context }
   }
 
@@ -109,7 +113,7 @@ impl<'c> NoMisusedNewVisitor<'c> {
   }
 }
 
-impl<'c> VisitAll for NoMisusedNewVisitor<'c> {
+impl<'c, 'view> VisitAll for NoMisusedNewVisitor<'c, 'view> {
   fn visit_ts_type_alias_decl(&mut self, t: &TsTypeAliasDecl, _: &dyn Node) {
     if let TsType::TsTypeLit(lit) = &*t.type_ann {
       for member in &lit.members {

--- a/src/rules/no_mixed_spaces_and_tabs.rs
+++ b/src/rules/no_mixed_spaces_and_tabs.rs
@@ -49,32 +49,17 @@ impl LintRule for NoMixedSpacesAndTabs {
 
     let mut excluded_ranges = visitor.ranges;
 
-    context.leading_comments.values().for_each(|comments| {
-      for comment in comments {
-        let lines = context
-          .source_map()
-          .span_to_lines(comment.span)
-          .unwrap()
-          .lines;
-        for line in lines.iter().skip(1) {
-          let (lo, hi) = file.line_bounds(line.line_index as usize);
-          excluded_ranges.push(Span::new(lo, hi, SyntaxContext::empty()));
-        }
+    for comment in context.all_comments() {
+      let lines = context
+        .source_map()
+        .span_to_lines(comment.span)
+        .unwrap()
+        .lines;
+      for line in lines.iter().skip(1) {
+        let (lo, hi) = file.line_bounds(line.line_index as usize);
+        excluded_ranges.push(Span::new(lo, hi, SyntaxContext::empty()));
       }
-    });
-    context.trailing_comments.values().for_each(|comments| {
-      for comment in comments {
-        let lines = context
-          .source_map()
-          .span_to_lines(comment.span)
-          .unwrap()
-          .lines;
-        for line in lines.iter().skip(1) {
-          let (lo, hi) = file.line_bounds(line.line_index as usize);
-          excluded_ranges.push(Span::new(lo, hi, SyntaxContext::empty()));
-        }
-      }
-    });
+    }
 
     let excluded_ranges = excluded_ranges.iter();
     for line_index in 0..file.count_lines() {

--- a/src/rules/no_mixed_spaces_and_tabs.rs
+++ b/src/rules/no_mixed_spaces_and_tabs.rs
@@ -44,7 +44,7 @@ impl LintRule for NoMixedSpacesAndTabs {
       ProgramRef::Module(ref m) => m.span,
       ProgramRef::Script(ref s) => s.span,
     };
-    let file_and_lines = context.source_map.span_to_lines(span).unwrap();
+    let file_and_lines = context.source_map().span_to_lines(span).unwrap();
     let file = file_and_lines.file;
 
     let mut excluded_ranges = visitor.ranges;
@@ -52,7 +52,7 @@ impl LintRule for NoMixedSpacesAndTabs {
     context.leading_comments.values().for_each(|comments| {
       for comment in comments {
         let lines = context
-          .source_map
+          .source_map()
           .span_to_lines(comment.span)
           .unwrap()
           .lines;
@@ -65,7 +65,7 @@ impl LintRule for NoMixedSpacesAndTabs {
     context.trailing_comments.values().for_each(|comments| {
       for comment in comments {
         let lines = context
-          .source_map
+          .source_map()
           .span_to_lines(comment.span)
           .unwrap()
           .lines;

--- a/src/rules/no_mixed_spaces_and_tabs.rs
+++ b/src/rules/no_mixed_spaces_and_tabs.rs
@@ -33,7 +33,11 @@ impl LintRule for NoMixedSpacesAndTabs {
     CODE
   }
 
-  fn lint_program(&self, context: &mut Context, program: ProgramRef<'_>) {
+  fn lint_program<'view>(
+    &self,
+    context: &mut Context<'view>,
+    program: ProgramRef<'view>,
+  ) {
     let mut visitor = NoMixedSpacesAndTabsVisitor::default();
     match program {
       ProgramRef::Module(ref m) => m.visit_all_with(&DUMMY_NODE, &mut visitor),

--- a/src/rules/no_namespace.rs
+++ b/src/rules/no_namespace.rs
@@ -31,7 +31,7 @@ impl LintRule for NoNamespace {
     context: &mut Context,
     program: dprint_swc_ecma_ast_view::Program<'_>,
   ) {
-    if context.file_name.ends_with(".d.ts") {
+    if context.file_name().ends_with(".d.ts") {
       return;
     }
 

--- a/src/rules/no_new_symbol.rs
+++ b/src/rules/no_new_symbol.rs
@@ -23,7 +23,11 @@ impl LintRule for NoNewSymbol {
     CODE
   }
 
-  fn lint_program(&self, context: &mut Context, program: ProgramRef<'_>) {
+  fn lint_program<'view>(
+    &self,
+    context: &mut Context<'view>,
+    program: ProgramRef<'view>,
+  ) {
     let mut visitor = NoNewSymbolVisitor::new(context);
     match program {
       ProgramRef::Module(ref m) => m.visit_all_with(&DUMMY_NODE, &mut visitor),
@@ -32,17 +36,17 @@ impl LintRule for NoNewSymbol {
   }
 }
 
-struct NoNewSymbolVisitor<'c> {
-  context: &'c mut Context,
+struct NoNewSymbolVisitor<'c, 'view> {
+  context: &'c mut Context<'view>,
 }
 
-impl<'c> NoNewSymbolVisitor<'c> {
-  fn new(context: &'c mut Context) -> Self {
+impl<'c, 'view> NoNewSymbolVisitor<'c, 'view> {
+  fn new(context: &'c mut Context<'view>) -> Self {
     Self { context }
   }
 }
 
-impl<'c> VisitAll for NoNewSymbolVisitor<'c> {
+impl<'c, 'view> VisitAll for NoNewSymbolVisitor<'c, 'view> {
   noop_visit_type!();
 
   fn visit_new_expr(&mut self, new_expr: &NewExpr, _parent: &dyn Node) {

--- a/src/rules/no_non_null_asserted_optional_chain.rs
+++ b/src/rules/no_non_null_asserted_optional_chain.rs
@@ -17,7 +17,11 @@ impl LintRule for NoNonNullAssertedOptionalChain {
     "no-non-null-asserted-optional-chain"
   }
 
-  fn lint_program(&self, context: &mut Context, program: ProgramRef<'_>) {
+  fn lint_program<'view>(
+    &self,
+    context: &mut Context<'view>,
+    program: ProgramRef<'view>,
+  ) {
     let mut visitor = NoNonNullAssertedOptionalChainVisitor::new(context);
     match program {
       ProgramRef::Module(ref m) => visitor.visit_module(m, &DUMMY_NODE),
@@ -26,12 +30,12 @@ impl LintRule for NoNonNullAssertedOptionalChain {
   }
 }
 
-struct NoNonNullAssertedOptionalChainVisitor<'c> {
-  context: &'c mut Context,
+struct NoNonNullAssertedOptionalChainVisitor<'c, 'view> {
+  context: &'c mut Context<'view>,
 }
 
-impl<'c> NoNonNullAssertedOptionalChainVisitor<'c> {
-  fn new(context: &'c mut Context) -> Self {
+impl<'c, 'view> NoNonNullAssertedOptionalChainVisitor<'c, 'view> {
+  fn new(context: &'c mut Context<'view>) -> Self {
     Self { context }
   }
 
@@ -50,7 +54,7 @@ impl<'c> NoNonNullAssertedOptionalChainVisitor<'c> {
   }
 }
 
-impl<'c> Visit for NoNonNullAssertedOptionalChainVisitor<'c> {
+impl<'c, 'view> Visit for NoNonNullAssertedOptionalChainVisitor<'c, 'view> {
   fn visit_ts_non_null_expr(
     &mut self,
     ts_non_null_expr: &swc_ecmascript::ast::TsNonNullExpr,

--- a/src/rules/no_non_null_assertion.rs
+++ b/src/rules/no_non_null_assertion.rs
@@ -14,7 +14,11 @@ impl LintRule for NoNonNullAssertion {
     "no-non-null-assertion"
   }
 
-  fn lint_program(&self, context: &mut Context, program: ProgramRef<'_>) {
+  fn lint_program<'view>(
+    &self,
+    context: &mut Context<'view>,
+    program: ProgramRef<'view>,
+  ) {
     let mut visitor = NoNonNullAssertionVisitor::new(context);
     match program {
       ProgramRef::Module(ref m) => visitor.visit_module(m, &DUMMY_NODE),
@@ -23,17 +27,17 @@ impl LintRule for NoNonNullAssertion {
   }
 }
 
-struct NoNonNullAssertionVisitor<'c> {
-  context: &'c mut Context,
+struct NoNonNullAssertionVisitor<'c, 'view> {
+  context: &'c mut Context<'view>,
 }
 
-impl<'c> NoNonNullAssertionVisitor<'c> {
-  fn new(context: &'c mut Context) -> Self {
+impl<'c, 'view> NoNonNullAssertionVisitor<'c, 'view> {
+  fn new(context: &'c mut Context<'view>) -> Self {
     Self { context }
   }
 }
 
-impl<'c> Visit for NoNonNullAssertionVisitor<'c> {
+impl<'c, 'view> Visit for NoNonNullAssertionVisitor<'c, 'view> {
   fn visit_ts_non_null_expr(
     &mut self,
     non_null_expr: &swc_ecmascript::ast::TsNonNullExpr,

--- a/src/rules/no_obj_calls.rs
+++ b/src/rules/no_obj_calls.rs
@@ -30,7 +30,11 @@ impl LintRule for NoObjCalls {
     CODE
   }
 
-  fn lint_program(&self, context: &mut Context, program: ProgramRef<'_>) {
+  fn lint_program<'view>(
+    &self,
+    context: &mut Context<'view>,
+    program: ProgramRef<'view>,
+  ) {
     let mut visitor = NoObjCallsVisitor::new(context);
     match program {
       ProgramRef::Module(ref m) => visitor.visit_module(m, &DUMMY_NODE),
@@ -39,12 +43,12 @@ impl LintRule for NoObjCalls {
   }
 }
 
-struct NoObjCallsVisitor<'c> {
-  context: &'c mut Context,
+struct NoObjCallsVisitor<'c, 'view> {
+  context: &'c mut Context<'view>,
 }
 
-impl<'c> NoObjCallsVisitor<'c> {
-  fn new(context: &'c mut Context) -> Self {
+impl<'c, 'view> NoObjCallsVisitor<'c, 'view> {
+  fn new(context: &'c mut Context<'view>) -> Self {
     Self { context }
   }
 
@@ -63,7 +67,7 @@ impl<'c> NoObjCallsVisitor<'c> {
   }
 }
 
-impl<'c> Visit for NoObjCallsVisitor<'c> {
+impl<'c, 'view> Visit for NoObjCallsVisitor<'c, 'view> {
   noop_visit_type!();
 
   fn visit_call_expr(&mut self, call_expr: &CallExpr, _parent: &dyn Node) {

--- a/src/rules/no_octal.rs
+++ b/src/rules/no_octal.rs
@@ -24,7 +24,11 @@ impl LintRule for NoOctal {
     CODE
   }
 
-  fn lint_program(&self, context: &mut Context, program: ProgramRef<'_>) {
+  fn lint_program<'view>(
+    &self,
+    context: &mut Context<'view>,
+    program: ProgramRef<'view>,
+  ) {
     let mut visitor = NoOctalVisitor::new(context);
     match program {
       ProgramRef::Module(ref m) => visitor.visit_module(m, &DUMMY_NODE),
@@ -33,17 +37,17 @@ impl LintRule for NoOctal {
   }
 }
 
-struct NoOctalVisitor<'c> {
-  context: &'c mut Context,
+struct NoOctalVisitor<'c, 'view> {
+  context: &'c mut Context<'view>,
 }
 
-impl<'c> NoOctalVisitor<'c> {
-  fn new(context: &'c mut Context) -> Self {
+impl<'c, 'view> NoOctalVisitor<'c, 'view> {
+  fn new(context: &'c mut Context<'view>) -> Self {
     Self { context }
   }
 }
 
-impl<'c> Visit for NoOctalVisitor<'c> {
+impl<'c, 'view> Visit for NoOctalVisitor<'c, 'view> {
   fn visit_number(&mut self, literal_num: &Number, _parent: &dyn Node) {
     static OCTAL: Lazy<Regex> = Lazy::new(|| Regex::new(r"^0[0-9]").unwrap());
 

--- a/src/rules/no_octal.rs
+++ b/src/rules/no_octal.rs
@@ -49,7 +49,7 @@ impl<'c> Visit for NoOctalVisitor<'c> {
 
     let raw_number = self
       .context
-      .source_map
+      .source_map()
       .span_to_snippet(literal_num.span)
       .expect("error in loading snippet");
 

--- a/src/rules/no_prototype_builtins.rs
+++ b/src/rules/no_prototype_builtins.rs
@@ -35,7 +35,11 @@ impl LintRule for NoPrototypeBuiltins {
     CODE
   }
 
-  fn lint_program(&self, context: &mut Context, program: ProgramRef<'_>) {
+  fn lint_program<'view>(
+    &self,
+    context: &mut Context<'view>,
+    program: ProgramRef<'view>,
+  ) {
     let mut visitor = NoPrototypeBuiltinsVisitor::new(context);
     match program {
       ProgramRef::Module(ref m) => visitor.visit_module(m, &DUMMY_NODE),
@@ -44,17 +48,17 @@ impl LintRule for NoPrototypeBuiltins {
   }
 }
 
-struct NoPrototypeBuiltinsVisitor<'c> {
-  context: &'c mut Context,
+struct NoPrototypeBuiltinsVisitor<'c, 'view> {
+  context: &'c mut Context<'view>,
 }
 
-impl<'c> NoPrototypeBuiltinsVisitor<'c> {
-  fn new(context: &'c mut Context) -> Self {
+impl<'c, 'view> NoPrototypeBuiltinsVisitor<'c, 'view> {
+  fn new(context: &'c mut Context<'view>) -> Self {
     Self { context }
   }
 }
 
-impl<'c> Visit for NoPrototypeBuiltinsVisitor<'c> {
+impl<'c, 'view> Visit for NoPrototypeBuiltinsVisitor<'c, 'view> {
   noop_visit_type!();
 
   fn visit_call_expr(&mut self, call_expr: &CallExpr, _parent: &dyn Node) {

--- a/src/rules/no_redeclare.rs
+++ b/src/rules/no_redeclare.rs
@@ -26,7 +26,11 @@ impl LintRule for NoRedeclare {
     CODE
   }
 
-  fn lint_program(&self, context: &mut Context, program: ProgramRef<'_>) {
+  fn lint_program<'view>(
+    &self,
+    context: &mut Context<'view>,
+    program: ProgramRef<'view>,
+  ) {
     let mut visitor = NoRedeclareVisitor {
       context,
       bindings: Default::default(),
@@ -38,13 +42,13 @@ impl LintRule for NoRedeclare {
   }
 }
 
-struct NoRedeclareVisitor<'c> {
-  context: &'c mut Context,
+struct NoRedeclareVisitor<'c, 'view> {
+  context: &'c mut Context<'view>,
   /// TODO(kdy1): Change this to HashMap<Id, Vec<Span>> and use those spans to point previous bindings/
   bindings: HashSet<Id>,
 }
 
-impl<'c> NoRedeclareVisitor<'c> {
+impl<'c, 'view> NoRedeclareVisitor<'c, 'view> {
   fn declare(&mut self, i: &Ident) {
     let id = i.to_id();
 
@@ -54,7 +58,7 @@ impl<'c> NoRedeclareVisitor<'c> {
   }
 }
 
-impl<'c> Visit for NoRedeclareVisitor<'c> {
+impl<'c, 'view> Visit for NoRedeclareVisitor<'c, 'view> {
   noop_visit_type!();
 
   fn visit_fn_decl(&mut self, f: &FnDecl, _: &dyn Node) {

--- a/src/rules/no_regex_spaces.rs
+++ b/src/rules/no_regex_spaces.rs
@@ -85,7 +85,7 @@ impl<'c> VisitAll for NoRegexSpacesVisitor<'c> {
   fn visit_new_expr(&mut self, new_expr: &NewExpr, _: &dyn Node) {
     if let Expr::Ident(ident) = &*new_expr.callee {
       if let Some(args) = &new_expr.args {
-        if let Some(regex) = extract_regex(&self.context.scope, ident, args) {
+        if let Some(regex) = extract_regex(self.context.scope(), ident, args) {
           self.check_regex(regex.as_str(), new_expr.span);
         }
       }
@@ -96,7 +96,7 @@ impl<'c> VisitAll for NoRegexSpacesVisitor<'c> {
     if let ExprOrSuper::Expr(expr) = &call_expr.callee {
       if let Expr::Ident(ident) = expr.as_ref() {
         if let Some(regex) =
-          extract_regex(&self.context.scope, ident, &call_expr.args)
+          extract_regex(self.context.scope(), ident, &call_expr.args)
         {
           self.check_regex(regex.as_str(), call_expr.span);
         }

--- a/src/rules/no_regex_spaces.rs
+++ b/src/rules/no_regex_spaces.rs
@@ -27,7 +27,11 @@ impl LintRule for NoRegexSpaces {
     CODE
   }
 
-  fn lint_program(&self, context: &mut Context, program: ProgramRef<'_>) {
+  fn lint_program<'view>(
+    &self,
+    context: &mut Context<'view>,
+    program: ProgramRef<'view>,
+  ) {
     let mut visitor = NoRegexSpacesVisitor::new(context);
     match program {
       ProgramRef::Module(ref m) => m.visit_all_with(&DUMMY_NODE, &mut visitor),
@@ -36,12 +40,12 @@ impl LintRule for NoRegexSpaces {
   }
 }
 
-struct NoRegexSpacesVisitor<'c> {
-  context: &'c mut Context,
+struct NoRegexSpacesVisitor<'c, 'view> {
+  context: &'c mut Context<'view>,
 }
 
-impl<'c> NoRegexSpacesVisitor<'c> {
-  fn new(context: &'c mut Context) -> Self {
+impl<'c, 'view> NoRegexSpacesVisitor<'c, 'view> {
+  fn new(context: &'c mut Context<'view>) -> Self {
     Self { context }
   }
 
@@ -75,7 +79,7 @@ impl<'c> NoRegexSpacesVisitor<'c> {
   }
 }
 
-impl<'c> VisitAll for NoRegexSpacesVisitor<'c> {
+impl<'c, 'view> VisitAll for NoRegexSpacesVisitor<'c, 'view> {
   noop_visit_type!();
 
   fn visit_regex(&mut self, regex: &Regex, _: &dyn Node) {

--- a/src/rules/no_self_assign.rs
+++ b/src/rules/no_self_assign.rs
@@ -49,7 +49,11 @@ impl LintRule for NoSelfAssign {
     CODE
   }
 
-  fn lint_program(&self, context: &mut Context, program: ProgramRef<'_>) {
+  fn lint_program<'view>(
+    &self,
+    context: &mut Context<'view>,
+    program: ProgramRef<'view>,
+  ) {
     let mut visitor = NoSelfAssignVisitor::new(context);
     match program {
       ProgramRef::Module(ref m) => m.visit_all_with(&DUMMY_NODE, &mut visitor),
@@ -58,12 +62,12 @@ impl LintRule for NoSelfAssign {
   }
 }
 
-struct NoSelfAssignVisitor<'c> {
-  context: &'c mut Context,
+struct NoSelfAssignVisitor<'c, 'view> {
+  context: &'c mut Context<'view>,
 }
 
-impl<'c> NoSelfAssignVisitor<'c> {
-  fn new(context: &'c mut Context) -> Self {
+impl<'c, 'view> NoSelfAssignVisitor<'c, 'view> {
+  fn new(context: &'c mut Context<'view>) -> Self {
     Self { context }
   }
 
@@ -284,7 +288,7 @@ impl<'c> NoSelfAssignVisitor<'c> {
   }
 }
 
-impl<'c> VisitAll for NoSelfAssignVisitor<'c> {
+impl<'c, 'view> VisitAll for NoSelfAssignVisitor<'c, 'view> {
   noop_visit_type!();
 
   fn visit_assign_expr(

--- a/src/rules/no_shadow_restricted_names.rs
+++ b/src/rules/no_shadow_restricted_names.rs
@@ -64,7 +64,7 @@ impl<'c> NoShadowRestrictedNamesVisitor<'c> {
         // trying to assign `undefined`
         // Check is scope is valid for current pattern
         if &ident.id.sym == "undefined" && check_scope {
-          if let Some(_binding) = self.context.scope.var(&ident.to_id()) {
+          if let Some(_binding) = self.context.scope().var(&ident.to_id()) {
             self.report_shadowing(&ident.id);
           }
           return;

--- a/src/rules/no_shadow_restricted_names.rs
+++ b/src/rules/no_shadow_restricted_names.rs
@@ -25,7 +25,11 @@ impl LintRule for NoShadowRestrictedNames {
     Box::new(NoShadowRestrictedNames)
   }
 
-  fn lint_program(&self, context: &mut Context, program: ProgramRef<'_>) {
+  fn lint_program<'view>(
+    &self,
+    context: &mut Context<'view>,
+    program: ProgramRef<'view>,
+  ) {
     let mut visitor = NoShadowRestrictedNamesVisitor::new(context);
     match program {
       ProgramRef::Module(ref m) => m.visit_all_with(&DUMMY_NODE, &mut visitor),
@@ -42,12 +46,12 @@ impl LintRule for NoShadowRestrictedNames {
   }
 }
 
-struct NoShadowRestrictedNamesVisitor<'c> {
-  context: &'c mut Context,
+struct NoShadowRestrictedNamesVisitor<'c, 'view> {
+  context: &'c mut Context<'view>,
 }
 
-impl<'c> NoShadowRestrictedNamesVisitor<'c> {
-  fn new(context: &'c mut Context) -> Self {
+impl<'c, 'view> NoShadowRestrictedNamesVisitor<'c, 'view> {
+  fn new(context: &'c mut Context<'view>) -> Self {
     Self { context }
   }
 
@@ -119,7 +123,7 @@ impl<'c> NoShadowRestrictedNamesVisitor<'c> {
   }
 }
 
-impl<'c> VisitAll for NoShadowRestrictedNamesVisitor<'c> {
+impl<'c, 'view> VisitAll for NoShadowRestrictedNamesVisitor<'c, 'view> {
   noop_visit_type!();
 
   fn visit_var_decl(&mut self, node: &VarDecl, _: &dyn Node) {

--- a/src/rules/no_sparse_arrays.rs
+++ b/src/rules/no_sparse_arrays.rs
@@ -15,7 +15,11 @@ impl LintRule for NoSparseArrays {
     "no-sparse-arrays"
   }
 
-  fn lint_program(&self, context: &mut Context, program: ProgramRef<'_>) {
+  fn lint_program<'view>(
+    &self,
+    context: &mut Context<'view>,
+    program: ProgramRef<'view>,
+  ) {
     let mut visitor = NoSparseArraysVisitor::new(context);
     match program {
       ProgramRef::Module(ref m) => visitor.visit_module(m, &DUMMY_NODE),
@@ -24,17 +28,17 @@ impl LintRule for NoSparseArrays {
   }
 }
 
-struct NoSparseArraysVisitor<'c> {
-  context: &'c mut Context,
+struct NoSparseArraysVisitor<'c, 'view> {
+  context: &'c mut Context<'view>,
 }
 
-impl<'c> NoSparseArraysVisitor<'c> {
-  fn new(context: &'c mut Context) -> Self {
+impl<'c, 'view> NoSparseArraysVisitor<'c, 'view> {
+  fn new(context: &'c mut Context<'view>) -> Self {
     Self { context }
   }
 }
 
-impl<'c> Visit for NoSparseArraysVisitor<'c> {
+impl<'c, 'view> Visit for NoSparseArraysVisitor<'c, 'view> {
   noop_visit_type!();
 
   fn visit_array_lit(

--- a/src/rules/no_this_alias.rs
+++ b/src/rules/no_this_alias.rs
@@ -24,7 +24,11 @@ impl LintRule for NoThisAlias {
     CODE
   }
 
-  fn lint_program(&self, context: &mut Context, program: ProgramRef<'_>) {
+  fn lint_program<'view>(
+    &self,
+    context: &mut Context<'view>,
+    program: ProgramRef<'view>,
+  ) {
     let mut visitor = NoThisAliasVisitor::new(context);
     match program {
       ProgramRef::Module(ref m) => m.visit_all_with(&DUMMY_NODE, &mut visitor),
@@ -33,17 +37,17 @@ impl LintRule for NoThisAlias {
   }
 }
 
-struct NoThisAliasVisitor<'c> {
-  context: &'c mut Context,
+struct NoThisAliasVisitor<'c, 'view> {
+  context: &'c mut Context<'view>,
 }
 
-impl<'c> NoThisAliasVisitor<'c> {
-  fn new(context: &'c mut Context) -> Self {
+impl<'c, 'view> NoThisAliasVisitor<'c, 'view> {
+  fn new(context: &'c mut Context<'view>) -> Self {
     Self { context }
   }
 }
 
-impl<'c> VisitAll for NoThisAliasVisitor<'c> {
+impl<'c, 'view> VisitAll for NoThisAliasVisitor<'c, 'view> {
   noop_visit_type!();
 
   fn visit_var_decl(&mut self, var_decl: &VarDecl, _parent: &dyn Node) {

--- a/src/rules/no_throw_literal.rs
+++ b/src/rules/no_throw_literal.rs
@@ -16,7 +16,11 @@ impl LintRule for NoThrowLiteral {
     "no-throw-literal"
   }
 
-  fn lint_program(&self, context: &mut Context, program: ProgramRef<'_>) {
+  fn lint_program<'view>(
+    &self,
+    context: &mut Context<'view>,
+    program: ProgramRef<'view>,
+  ) {
     let mut visitor = NoThrowLiteralVisitor::new(context);
     match program {
       ProgramRef::Module(ref m) => visitor.visit_module(m, &DUMMY_NODE),
@@ -25,17 +29,17 @@ impl LintRule for NoThrowLiteral {
   }
 }
 
-struct NoThrowLiteralVisitor<'c> {
-  context: &'c mut Context,
+struct NoThrowLiteralVisitor<'c, 'view> {
+  context: &'c mut Context<'view>,
 }
 
-impl<'c> NoThrowLiteralVisitor<'c> {
-  fn new(context: &'c mut Context) -> Self {
+impl<'c, 'view> NoThrowLiteralVisitor<'c, 'view> {
+  fn new(context: &'c mut Context<'view>) -> Self {
     Self { context }
   }
 }
 
-impl<'c> Visit for NoThrowLiteralVisitor<'c> {
+impl<'c, 'view> Visit for NoThrowLiteralVisitor<'c, 'view> {
   noop_visit_type!();
 
   fn visit_throw_stmt(&mut self, throw_stmt: &ThrowStmt, _parent: &dyn Node) {

--- a/src/rules/no_undef.rs
+++ b/src/rules/no_undef.rs
@@ -23,7 +23,11 @@ impl LintRule for NoUndef {
     "no-undef"
   }
 
-  fn lint_program(&self, context: &mut Context, program: ProgramRef<'_>) {
+  fn lint_program<'view>(
+    &self,
+    context: &mut Context<'view>,
+    program: ProgramRef<'view>,
+  ) {
     let mut collector = BindingCollector {
       declared: Default::default(),
     };
@@ -165,13 +169,13 @@ impl VisitAll for BindingCollector {
   }
 }
 
-struct NoUndefVisitor<'c> {
-  context: &'c mut Context,
+struct NoUndefVisitor<'c, 'view> {
+  context: &'c mut Context<'view>,
   declared: HashSet<Id>,
 }
 
-impl<'c> NoUndefVisitor<'c> {
-  fn new(context: &'c mut Context, declared: HashSet<Id>) -> Self {
+impl<'c, 'view> NoUndefVisitor<'c, 'view> {
+  fn new(context: &'c mut Context<'view>, declared: HashSet<Id>) -> Self {
     Self { context, declared }
   }
 
@@ -208,7 +212,7 @@ impl<'c> NoUndefVisitor<'c> {
   }
 }
 
-impl<'c> Visit for NoUndefVisitor<'c> {
+impl<'c, 'view> Visit for NoUndefVisitor<'c, 'view> {
   noop_visit_type!();
 
   fn visit_member_expr(&mut self, e: &MemberExpr, _: &dyn Node) {

--- a/src/rules/no_undef.rs
+++ b/src/rules/no_undef.rs
@@ -180,7 +180,7 @@ impl<'c> NoUndefVisitor<'c> {
     //
     // function foo(Map) { ... }
     //
-    if ident.span.ctxt != self.context.top_level_ctxt {
+    if ident.span.ctxt != self.context.top_level_ctxt() {
       return;
     }
 

--- a/src/rules/no_unreachable.rs
+++ b/src/rules/no_unreachable.rs
@@ -24,7 +24,11 @@ impl LintRule for NoUnreachable {
     CODE
   }
 
-  fn lint_program(&self, context: &mut Context, program: ProgramRef<'_>) {
+  fn lint_program<'view>(
+    &self,
+    context: &mut Context<'view>,
+    program: ProgramRef<'view>,
+  ) {
     let mut visitor = NoUnreachableVisitor::new(context);
     match program {
       ProgramRef::Module(ref m) => visitor.visit_module(m, &DUMMY_NODE),
@@ -33,17 +37,17 @@ impl LintRule for NoUnreachable {
   }
 }
 
-struct NoUnreachableVisitor<'c> {
-  context: &'c mut Context,
+struct NoUnreachableVisitor<'c, 'view> {
+  context: &'c mut Context<'view>,
 }
 
-impl<'c> NoUnreachableVisitor<'c> {
-  fn new(context: &'c mut Context) -> Self {
+impl<'c, 'view> NoUnreachableVisitor<'c, 'view> {
+  fn new(context: &'c mut Context<'view>) -> Self {
     Self { context }
   }
 }
 
-impl<'c> Visit for NoUnreachableVisitor<'c> {
+impl<'c, 'view> Visit for NoUnreachableVisitor<'c, 'view> {
   fn visit_stmt(&mut self, stmt: &Stmt, _: &dyn Node) {
     stmt.visit_children_with(self);
 

--- a/src/rules/no_unreachable.rs
+++ b/src/rules/no_unreachable.rs
@@ -68,7 +68,7 @@ impl<'c> Visit for NoUnreachableVisitor<'c> {
       _ => {}
     }
 
-    if let Some(meta) = self.context.control_flow.meta(stmt.span().lo) {
+    if let Some(meta) = self.context.control_flow().meta(stmt.span().lo) {
       if meta.unreachable {
         self.context.add_diagnostic(stmt.span(), CODE, MESSAGE)
       }

--- a/src/rules/no_unused_vars.rs
+++ b/src/rules/no_unused_vars.rs
@@ -48,7 +48,11 @@ impl LintRule for NoUnusedVars {
     CODE
   }
 
-  fn lint_program(&self, context: &mut Context, program: ProgramRef<'_>) {
+  fn lint_program<'view>(
+    &self,
+    context: &mut Context<'view>,
+    program: ProgramRef<'view>,
+  ) {
     let mut collector = Collector::default();
     match program {
       ProgramRef::Module(ref m) => m.visit_with(&DUMMY_NODE, &mut collector),
@@ -301,15 +305,15 @@ fn get_id(r: &TsEntityName) -> Id {
   }
 }
 
-struct NoUnusedVarVisitor<'c> {
-  context: &'c mut Context,
+struct NoUnusedVarVisitor<'c, 'view> {
+  context: &'c mut Context<'view>,
   used_vars: HashSet<Id>,
   used_types: HashSet<Id>,
 }
 
-impl<'c> NoUnusedVarVisitor<'c> {
+impl<'c, 'view> NoUnusedVarVisitor<'c, 'view> {
   fn new(
-    context: &'c mut Context,
+    context: &'c mut Context<'view>,
     used_vars: HashSet<Id>,
     used_types: HashSet<Id>,
   ) -> Self {
@@ -321,7 +325,7 @@ impl<'c> NoUnusedVarVisitor<'c> {
   }
 }
 
-impl<'c> NoUnusedVarVisitor<'c> {
+impl<'c, 'view> NoUnusedVarVisitor<'c, 'view> {
   fn handle_id(&mut self, ident: &Ident) {
     if ident.sym.starts_with('_') {
       return;
@@ -339,7 +343,7 @@ impl<'c> NoUnusedVarVisitor<'c> {
   }
 }
 
-impl<'c> Visit for NoUnusedVarVisitor<'c> {
+impl<'c, 'view> Visit for NoUnusedVarVisitor<'c, 'view> {
   fn visit_arrow_expr(&mut self, expr: &ArrowExpr, _: &dyn Node) {
     let declared_idents: Vec<Ident> = find_ids(&expr.params);
 

--- a/src/rules/no_var.rs
+++ b/src/rules/no_var.rs
@@ -20,7 +20,11 @@ impl LintRule for NoVar {
     CODE
   }
 
-  fn lint_program(&self, context: &mut Context, program: ProgramRef<'_>) {
+  fn lint_program<'view>(
+    &self,
+    context: &mut Context<'view>,
+    program: ProgramRef<'view>,
+  ) {
     let mut visitor = NoVarVisitor::new(context);
     match program {
       ProgramRef::Module(ref m) => visitor.visit_module(m, &DUMMY_NODE),
@@ -47,17 +51,17 @@ let bar = 2;
   }
 }
 
-struct NoVarVisitor<'c> {
-  context: &'c mut Context,
+struct NoVarVisitor<'c, 'view> {
+  context: &'c mut Context<'view>,
 }
 
-impl<'c> NoVarVisitor<'c> {
-  fn new(context: &'c mut Context) -> Self {
+impl<'c, 'view> NoVarVisitor<'c, 'view> {
+  fn new(context: &'c mut Context<'view>) -> Self {
     Self { context }
   }
 }
 
-impl<'c> Visit for NoVarVisitor<'c> {
+impl<'c, 'view> Visit for NoVarVisitor<'c, 'view> {
   noop_visit_type!();
 
   fn visit_var_decl(&mut self, var_decl: &VarDecl, _parent: &dyn Node) {

--- a/src/rules/prefer_as_const.rs
+++ b/src/rules/prefer_as_const.rs
@@ -40,7 +40,11 @@ impl LintRule for PreferAsConst {
     CODE
   }
 
-  fn lint_program(&self, context: &mut Context, program: ProgramRef<'_>) {
+  fn lint_program<'view>(
+    &self,
+    context: &mut Context<'view>,
+    program: ProgramRef<'view>,
+  ) {
     let mut visitor = PreferAsConstVisitor::new(context);
 
     match program {
@@ -50,12 +54,12 @@ impl LintRule for PreferAsConst {
   }
 }
 
-struct PreferAsConstVisitor<'c> {
-  context: &'c mut Context,
+struct PreferAsConstVisitor<'c, 'view> {
+  context: &'c mut Context<'view>,
 }
 
-impl<'c> PreferAsConstVisitor<'c> {
-  fn new(context: &'c mut Context) -> Self {
+impl<'c, 'view> PreferAsConstVisitor<'c, 'view> {
+  fn new(context: &'c mut Context<'view>) -> Self {
     Self { context }
   }
 
@@ -89,7 +93,7 @@ impl<'c> PreferAsConstVisitor<'c> {
   }
 }
 
-impl<'c> VisitAll for PreferAsConstVisitor<'c> {
+impl<'c, 'view> VisitAll for PreferAsConstVisitor<'c, 'view> {
   fn visit_ts_as_expr(&mut self, as_expr: &TsAsExpr, _: &dyn Node) {
     self.compare(&as_expr.type_ann, &as_expr.expr, as_expr.type_ann.span());
   }

--- a/src/rules/prefer_const.rs
+++ b/src/rules/prefer_const.rs
@@ -653,7 +653,7 @@ impl<'c> PreferConstVisitor<'c> {
   }
 
   fn report(&mut self, span: Span) {
-    if let Ok(s) = self.context.source_map.span_to_snippet(span) {
+    if let Ok(s) = self.context.source_map().span_to_snippet(span) {
       self.context.add_diagnostic_with_hint(
         span,
         CODE,

--- a/src/rules/prefer_const.rs
+++ b/src/rules/prefer_const.rs
@@ -48,7 +48,11 @@ impl LintRule for PreferConst {
     CODE
   }
 
-  fn lint_program(&self, context: &mut Context, program: ProgramRef<'_>) {
+  fn lint_program<'view>(
+    &self,
+    context: &mut Context<'view>,
+    program: ProgramRef<'view>,
+  ) {
     let mut collector = VariableCollector::new();
     match program {
       ProgramRef::Module(ref m) => collector.visit_module(m, &DUMMY_NODE),
@@ -579,11 +583,11 @@ impl Visit for VariableCollector {
   }
 }
 
-struct PreferConstVisitor<'c> {
+struct PreferConstVisitor<'c, 'view> {
   scopes: BTreeMap<ScopeRange, Scope>,
   cur_scope: ScopeRange,
   var_groups: DisjointSet,
-  context: &'c mut Context,
+  context: &'c mut Context<'view>,
 }
 
 enum ExtractIdentsArgs<'a> {
@@ -638,9 +642,9 @@ where
   }
 }
 
-impl<'c> PreferConstVisitor<'c> {
+impl<'c, 'view> PreferConstVisitor<'c, 'view> {
   fn new(
-    context: &'c mut Context,
+    context: &'c mut Context<'view>,
     scopes: BTreeMap<ScopeRange, Scope>,
     var_groups: DisjointSet,
   ) -> Self {
@@ -725,7 +729,7 @@ impl<'c> PreferConstVisitor<'c> {
   }
 }
 
-impl<'c> Visit for PreferConstVisitor<'c> {
+impl<'c, 'view> Visit for PreferConstVisitor<'c, 'view> {
   noop_visit_type!();
 
   fn visit_module(&mut self, module: &Module, _: &dyn Node) {

--- a/src/rules/prefer_const.rs
+++ b/src/rules/prefer_const.rs
@@ -979,7 +979,7 @@ mod variable_collector_tests {
   use crate::test_util;
 
   fn collect(src: &str) -> VariableCollector {
-    let (program, _, _) = test_util::parse(src);
+    let (program, _, _, _) = test_util::parse(src);
     let mut v = VariableCollector::new();
     v.visit_program(&program, &program);
     v

--- a/src/rules/prefer_namespace_keyword.rs
+++ b/src/rules/prefer_namespace_keyword.rs
@@ -57,7 +57,7 @@ impl<'c> Visit for PreferNamespaceKeywordVisitor<'c> {
 
     let snippet = self
       .context
-      .source_map
+      .source_map()
       .span_to_snippet(mod_decl.span)
       .expect("error in load snippet");
 

--- a/src/rules/prefer_namespace_keyword.rs
+++ b/src/rules/prefer_namespace_keyword.rs
@@ -24,7 +24,11 @@ impl LintRule for PreferNamespaceKeyword {
     CODE
   }
 
-  fn lint_program(&self, context: &mut Context, program: ProgramRef<'_>) {
+  fn lint_program<'view>(
+    &self,
+    context: &mut Context<'view>,
+    program: ProgramRef<'view>,
+  ) {
     let mut visitor = PreferNamespaceKeywordVisitor::new(context);
     match program {
       ProgramRef::Module(ref m) => visitor.visit_module(m, &DUMMY_NODE),
@@ -33,17 +37,17 @@ impl LintRule for PreferNamespaceKeyword {
   }
 }
 
-struct PreferNamespaceKeywordVisitor<'c> {
-  context: &'c mut Context,
+struct PreferNamespaceKeywordVisitor<'c, 'view> {
+  context: &'c mut Context<'view>,
 }
 
-impl<'c> PreferNamespaceKeywordVisitor<'c> {
-  fn new(context: &'c mut Context) -> Self {
+impl<'c, 'view> PreferNamespaceKeywordVisitor<'c, 'view> {
+  fn new(context: &'c mut Context<'view>) -> Self {
     Self { context }
   }
 }
 
-impl<'c> Visit for PreferNamespaceKeywordVisitor<'c> {
+impl<'c, 'view> Visit for PreferNamespaceKeywordVisitor<'c, 'view> {
   fn visit_ts_module_decl(
     &mut self,
     mod_decl: &TsModuleDecl,

--- a/src/rules/require_await.rs
+++ b/src/rules/require_await.rs
@@ -48,7 +48,11 @@ impl LintRule for RequireAwait {
     CODE
   }
 
-  fn lint_program(&self, context: &mut Context, program: ProgramRef<'_>) {
+  fn lint_program<'view>(
+    &self,
+    context: &mut Context<'view>,
+    program: ProgramRef<'view>,
+  ) {
     let mut visitor = RequireAwaitVisitor::new(context);
     match program {
       ProgramRef::Module(ref m) => visitor.visit_module(m, &DUMMY_NODE),
@@ -168,13 +172,13 @@ impl FunctionInfo {
   }
 }
 
-struct RequireAwaitVisitor<'c> {
-  context: &'c mut Context,
+struct RequireAwaitVisitor<'c, 'view> {
+  context: &'c mut Context<'view>,
   function_info: Option<Box<FunctionInfo>>,
 }
 
-impl<'c> RequireAwaitVisitor<'c> {
-  fn new(context: &'c mut Context) -> Self {
+impl<'c, 'view> RequireAwaitVisitor<'c, 'view> {
+  fn new(context: &'c mut Context<'view>) -> Self {
     Self {
       context,
       function_info: None,
@@ -217,7 +221,7 @@ fn is_body_empty(maybe_body: Option<&BlockStmt>) -> bool {
   maybe_body.map_or(true, |body| body.stmts.is_empty())
 }
 
-impl<'c> Visit for RequireAwaitVisitor<'c> {
+impl<'c, 'view> Visit for RequireAwaitVisitor<'c, 'view> {
   noop_visit_type!();
 
   fn visit_fn_decl(&mut self, fn_decl: &FnDecl, _: &dyn Node) {

--- a/src/rules/require_yield.rs
+++ b/src/rules/require_yield.rs
@@ -29,7 +29,11 @@ impl LintRule for RequireYield {
     CODE
   }
 
-  fn lint_program(&self, context: &mut Context, program: ProgramRef<'_>) {
+  fn lint_program<'view>(
+    &self,
+    context: &mut Context<'view>,
+    program: ProgramRef<'view>,
+  ) {
     let mut visitor = RequireYieldVisitor::new(context);
     match program {
       ProgramRef::Module(ref m) => visitor.visit_module(m, &DUMMY_NODE),
@@ -38,13 +42,13 @@ impl LintRule for RequireYield {
   }
 }
 
-struct RequireYieldVisitor<'c> {
-  context: &'c mut Context,
+struct RequireYieldVisitor<'c, 'view> {
+  context: &'c mut Context<'view>,
   yield_stack: Vec<u32>,
 }
 
-impl<'c> RequireYieldVisitor<'c> {
-  fn new(context: &'c mut Context) -> Self {
+impl<'c, 'view> RequireYieldVisitor<'c, 'view> {
+  fn new(context: &'c mut Context<'view>) -> Self {
     Self {
       context,
       yield_stack: vec![],
@@ -72,7 +76,7 @@ impl<'c> RequireYieldVisitor<'c> {
   }
 }
 
-impl<'c> Visit for RequireYieldVisitor<'c> {
+impl<'c, 'view> Visit for RequireYieldVisitor<'c, 'view> {
   noop_visit_type!();
 
   fn visit_yield_expr(&mut self, _yield_expr: &YieldExpr, _parent: &dyn Node) {

--- a/src/rules/single_var_declarator.rs
+++ b/src/rules/single_var_declarator.rs
@@ -16,7 +16,11 @@ impl LintRule for SingleVarDeclarator {
     "single-var-declarator"
   }
 
-  fn lint_program(&self, context: &mut Context, program: ProgramRef<'_>) {
+  fn lint_program<'view>(
+    &self,
+    context: &mut Context<'view>,
+    program: ProgramRef<'view>,
+  ) {
     let mut visitor = SingleVarDeclaratorVisitor::new(context);
     match program {
       ProgramRef::Module(ref m) => visitor.visit_module(m, &DUMMY_NODE),
@@ -25,17 +29,17 @@ impl LintRule for SingleVarDeclarator {
   }
 }
 
-struct SingleVarDeclaratorVisitor<'c> {
-  context: &'c mut Context,
+struct SingleVarDeclaratorVisitor<'c, 'view> {
+  context: &'c mut Context<'view>,
 }
 
-impl<'c> SingleVarDeclaratorVisitor<'c> {
-  fn new(context: &'c mut Context) -> Self {
+impl<'c, 'view> SingleVarDeclaratorVisitor<'c, 'view> {
+  fn new(context: &'c mut Context<'view>) -> Self {
     Self { context }
   }
 }
 
-impl<'c> Visit for SingleVarDeclaratorVisitor<'c> {
+impl<'c, 'view> Visit for SingleVarDeclaratorVisitor<'c, 'view> {
   noop_visit_type!();
 
   fn visit_var_decl(&mut self, var_decl: &VarDecl, _parent: &dyn Node) {

--- a/src/rules/triple_slash_reference.rs
+++ b/src/rules/triple_slash_reference.rs
@@ -30,22 +30,13 @@ impl LintRule for TripleSlashReference {
   fn lint_program(&self, context: &mut Context, _program: ProgramRef<'_>) {
     let mut violated_comment_spans = Vec::new();
 
-    violated_comment_spans.extend(
-      context.leading_comments.values().flatten().filter_map(|c| {
-        if check_comment(c) {
-          Some(c.span)
-        } else {
-          None
-        }
-      }),
-    );
-    violated_comment_spans.extend(
-      context
-        .trailing_comments
-        .values()
-        .flatten()
-        .filter_map(|c| if check_comment(c) { Some(c.span) } else { None }),
-    );
+    violated_comment_spans.extend(context.all_comments().filter_map(|c| {
+      if check_comment(c) {
+        Some(c.span)
+      } else {
+        None
+      }
+    }));
 
     for span in violated_comment_spans {
       self.report(context, span);

--- a/src/rules/triple_slash_reference.rs
+++ b/src/rules/triple_slash_reference.rs
@@ -64,6 +64,14 @@ mod tests {
   use crate::test_util::*;
 
   #[test]
+  fn magurotuna() {
+    assert_lint_err::<TripleSlashReference>(
+      r#"/// <reference path="foo" />"#,
+      0,
+    );
+  }
+
+  #[test]
   fn triple_slash_reference_valid() {
     assert_lint_ok! {
       TripleSlashReference,

--- a/src/rules/use_isnan.rs
+++ b/src/rules/use_isnan.rs
@@ -19,7 +19,11 @@ impl LintRule for UseIsNaN {
     "use-isnan"
   }
 
-  fn lint_program(&self, context: &mut Context, program: ProgramRef<'_>) {
+  fn lint_program<'view>(
+    &self,
+    context: &mut Context<'view>,
+    program: ProgramRef<'view>,
+  ) {
     let mut visitor = UseIsNaNVisitor::new(context);
     match program {
       ProgramRef::Module(ref m) => visitor.visit_module(m, &DUMMY_NODE),
@@ -28,12 +32,12 @@ impl LintRule for UseIsNaN {
   }
 }
 
-struct UseIsNaNVisitor<'c> {
-  context: &'c mut Context,
+struct UseIsNaNVisitor<'c, 'view> {
+  context: &'c mut Context<'view>,
 }
 
-impl<'c> UseIsNaNVisitor<'c> {
-  fn new(context: &'c mut Context) -> Self {
+impl<'c, 'view> UseIsNaNVisitor<'c, 'view> {
+  fn new(context: &'c mut Context<'view>) -> Self {
     Self { context }
   }
 }
@@ -42,7 +46,7 @@ fn is_nan_identifier(ident: &swc_ecmascript::ast::Ident) -> bool {
   ident.sym == *"NaN"
 }
 
-impl<'c> Visit for UseIsNaNVisitor<'c> {
+impl<'c, 'view> Visit for UseIsNaNVisitor<'c, 'view> {
   noop_visit_type!();
 
   fn visit_bin_expr(

--- a/src/rules/valid_typeof.rs
+++ b/src/rules/valid_typeof.rs
@@ -26,7 +26,11 @@ impl LintRule for ValidTypeof {
     CODE
   }
 
-  fn lint_program(&self, context: &mut Context, program: ProgramRef<'_>) {
+  fn lint_program<'view>(
+    &self,
+    context: &mut Context<'view>,
+    program: ProgramRef<'view>,
+  ) {
     let mut visitor = ValidTypeofVisitor::new(context);
     match program {
       ProgramRef::Module(ref m) => visitor.visit_module(m, &DUMMY_NODE),
@@ -91,17 +95,17 @@ typeof bar === typeof qux
   }
 }
 
-struct ValidTypeofVisitor<'c> {
-  context: &'c mut Context,
+struct ValidTypeofVisitor<'c, 'view> {
+  context: &'c mut Context<'view>,
 }
 
-impl<'c> ValidTypeofVisitor<'c> {
-  fn new(context: &'c mut Context) -> Self {
+impl<'c, 'view> ValidTypeofVisitor<'c, 'view> {
+  fn new(context: &'c mut Context<'view>) -> Self {
     Self { context }
   }
 }
 
-impl<'c> Visit for ValidTypeofVisitor<'c> {
+impl<'c, 'view> Visit for ValidTypeofVisitor<'c, 'view> {
   noop_visit_type!();
 
   fn visit_bin_expr(&mut self, bin_expr: &BinExpr, _parent: &dyn Node) {

--- a/src/scopes.rs
+++ b/src/scopes.rs
@@ -307,17 +307,11 @@ impl Visit for Analyzer<'_> {
 #[cfg(test)]
 mod tests {
   use super::{BindingKind, Scope, ScopeKind, Var};
-  use crate::ast_parser;
-  use crate::ast_parser::AstParser;
+  use crate::test_util;
   use swc_ecmascript::utils::Id;
 
   fn test_scope(source_code: &str) -> Scope {
-    let ast_parser = AstParser::new();
-    let syntax = ast_parser::get_default_ts_config();
-    let (program, _comments) = ast_parser
-      .parse_program("file_name.ts", syntax, source_code)
-      .unwrap();
-
+    let (program, _, _, _) = test_util::parse(source_code);
     Scope::analyze(&program)
   }
 

--- a/src/swc_util.rs
+++ b/src/swc_util.rs
@@ -148,7 +148,7 @@ impl<S: StringRepr> StringRepr for Option<S> {
   }
 }
 
-/// Find [Id]s in the lhs of an assigmnet expression.
+/// Find `Id`s in the lhs of an assigmnet expression.
 pub(crate) fn find_lhs_ids<I>(n: &PatOrExpr) -> Vec<I>
 where
   I: IdentLike,

--- a/src/test_util.rs
+++ b/src/test_util.rs
@@ -4,6 +4,7 @@ use crate::ast_parser;
 use crate::diagnostic::LintDiagnostic;
 use crate::linter::LinterBuilder;
 use crate::rules::LintRule;
+use dprint_swc_ecma_ast_view::TokenAndSpan;
 use std::marker::PhantomData;
 use std::rc::Rc;
 use swc_common::comments::SingleThreadedComments;
@@ -211,7 +212,7 @@ fn lint(
   source: &str,
   filename: String,
 ) -> Vec<LintDiagnostic> {
-  let mut linter = LinterBuilder::default()
+  let linter = LinterBuilder::default()
     .lint_unused_ignore_directives(false)
     .lint_unknown_rules(false)
     .syntax(ast_parser::get_default_ts_config())
@@ -362,12 +363,21 @@ pub fn assert_lint_err_on_line_n<T: LintRule + 'static>(
 
 pub fn parse(
   source_code: &str,
-) -> (Program, SingleThreadedComments, Rc<SourceMap>) {
+) -> (
+  Program,
+  SingleThreadedComments,
+  Rc<SourceMap>,
+  Vec<TokenAndSpan>,
+) {
   let ast_parser = ast_parser::AstParser::new();
   let syntax = ast_parser::get_default_ts_config();
-  let (program, comments) = ast_parser
+  let ast_parser::ParsedData {
+    program,
+    comments,
+    tokens,
+  } = ast_parser
     .parse_program("lint_test.ts", syntax, source_code)
     .unwrap();
   let source_map = Rc::clone(&ast_parser.source_map);
-  (program, comments, source_map)
+  (program, comments, source_map, tokens)
 }


### PR DESCRIPTION
This PR refactors several things:

- use `all_comments` I added to `dprint-swc-ecma-ast-view` in https://github.com/dprint/dprint-swc-ecma-ast-view/pull/18, instead of dealing with `trailing_comments` and `leading_comments` ourselves.
- move `Context` to its own module and make its fields private. Instead, it exposes getter methods to access the fields so we can control mutability more appropriately.
- add `dprint_swc_ecma_ast_view::Program` to `Context` as a field in order to call `all_comments` at any time. Accordingly, `Context` has a lifetime parameter `'view`, which indicates that `Context` cannot outlive the ast-view.
- remove `has_linted: bool` from the `Litner` struct. Instead the first parameters of `Linter::lint` and `Linter::lint_with_ast` have altered into `mut self` from `&mut self`. This way we can guarantee the actual linting occurs only once.