### PR TITLE
fix(no-unused-vars): mark fake function parameter `this` as used

### DIFF
--- a/src/rules/no_unused_vars.rs
+++ b/src/rules/no_unused_vars.rs
@@ -215,7 +215,7 @@ impl Visit for Collector {
     self.used_vars.insert(export.orig.to_id());
   }
 
-  /// Handl for-in/of loops
+  /// Handle for-in/of loops
   fn visit_var_decl_or_pat(&mut self, node: &VarDeclOrPat, _: &dyn Node) {
     // We need this because find_ids searches ids only in the pattern.
     node.visit_children_with(self);

--- a/src/rules/no_unused_vars.rs
+++ b/src/rules/no_unused_vars.rs
@@ -1185,6 +1185,21 @@ export default class Foo {
       "import type Foo from './foo.ts'; interface _Bar<T extends Foo> {}",
       "import type Foo from './foo.ts'; type _Bar<T extends Foo> = T;",
       "type Foo = { a: number }; function _bar<T extends keyof Foo>() {}",
+
+      // https://github.com/denoland/deno_lint/issues/667#issuecomment-821856328
+      // `this` as a fake parameter. See: https://www.typescriptlang.org/docs/handbook/functions.html#this-parameters
+      "export function f(this: void) {}",
+      "export const foo = { bar(this: Foo) {} };",
+      "export interface Foo { bar(this: void): void; }",
+      "export interface Foo { bar(baz: (this: void) => void ): void; }",
+      "export class Foo { bar(this: Foo) {} }",
+      r#"
+export abstract class Point4DPartial {
+    toString(this: Point4D): string {
+      return [this.getPosition(), this.z, this.getTime()].join(", ");
+    }
+}
+      "#,
     };
 
     // JSX or TSX


### PR DESCRIPTION
This patch fixes https://github.com/denoland/deno_lint/issues/667#issuecomment-821856328

~~This branch has been created from the branch of #677. So please merge #677 first.~~
~~The effective diff can be seen [here](https://github.com/magurotuna/deno_lint/compare/magurotuna:ast-view-comments...no-unused-vars/fake-this).~~