### PR TITLE
chore: apply clippy suggestions

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,12 +130,12 @@ For more concrete implementation visit [`deno`](https://github.com/denoland/deno
 
 ## Developing
 
-Make sure to have latest stable version of Rust installed (1.51.0).
+Make sure to have latest stable version of Rust installed (1.52.0).
 
 ```shell
 // check version
 $ rustc --version
-rustc 1.51.0 (2fd73fabe 2021-03-23)
+rustc 1.52.0 (88f19c6da 2021-05-03)
 
 // build all targets
 $ cargo build --all-targets

--- a/src/js_regex/reader.rs
+++ b/src/js_regex/reader.rs
@@ -141,27 +141,27 @@ mod tests {
   fn eat_test() {
     let mut reader = Reader::new();
     reader.reset("abcdefghijk", 0, 11, true);
-    assert_eq!(reader.eat('a'), true);
-    assert_eq!(reader.eat3('b', 'd', 'd'), false);
-    assert_eq!(reader.eat3('b', 'c', 'd'), true);
-    assert_eq!(reader.eat2('e', 'f'), true);
-    assert_eq!(reader.eat('h'), false);
-    assert_eq!(reader.eat('g'), true);
-    assert_eq!(reader.eat2('h', 'i'), true);
-    assert_eq!(reader.eat3('j', 'k', 'a'), false);
+    assert!(reader.eat('a'));
+    assert!(!reader.eat3('b', 'd', 'd'));
+    assert!(reader.eat3('b', 'c', 'd'));
+    assert!(reader.eat2('e', 'f'));
+    assert!(!reader.eat('h'));
+    assert!(reader.eat('g'));
+    assert!(reader.eat2('h', 'i'));
+    assert!(!reader.eat3('j', 'k', 'a'));
   }
 
   #[test]
   fn rewind_test() {
     let mut reader = Reader::new();
     reader.reset("abcd", 0, 4, true);
-    assert_eq!(reader.eat('a'), true);
-    assert_eq!(reader.eat3('b', 'd', 'd'), false);
-    assert_eq!(reader.eat3('b', 'c', 'd'), true);
+    assert!(reader.eat('a'));
+    assert!(!reader.eat3('b', 'd', 'd'));
+    assert!(reader.eat3('b', 'c', 'd'));
     reader.rewind(0);
-    assert_eq!(reader.eat('a'), true);
-    assert_eq!(reader.eat3('b', 'd', 'd'), false);
-    assert_eq!(reader.eat3('b', 'c', 'd'), true);
+    assert!(reader.eat('a'));
+    assert!(!reader.eat3('b', 'd', 'd'));
+    assert!(reader.eat3('b', 'c', 'd'));
   }
 
   #[test]


### PR DESCRIPTION
This PR

- applies clippy suggestions that recommend we use `assert!` instead of `assert_eq!` in comparing with boolean
- updates the rustc version in README.md