### PR TITLE
chore: upgrade swc and dprint-swc-ecma-ast-view

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -46,9 +46,9 @@ checksum = "28b2cd92db5cbd74e8e5028f7e27dd7aa3090e89e4f2a197cc7c8dfb69c7063b"
 
 [[package]]
 name = "ast_node"
-version = "0.7.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c84c445d38f7f29c82ed56c2cfae4885e5e6d9fb81b956ab31430757ddad5d7"
+checksum = "f93f52ce8fac3d0e6720a92b0576d737c01b1b5db4dd786e962e5925f00bf755"
 dependencies = [
  "darling",
  "pmutil",
@@ -273,9 +273,9 @@ dependencies = [
 
 [[package]]
 name = "dprint-swc-ecma-ast-view"
-version = "0.17.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a67b73960128ad2a3babed25572e30156eb97a6512bb216d806aa8d3b7f42a9"
+checksum = "405e63217a351c2f84a052e539d36f18d170842838d1acdc02723832f34c840e"
 dependencies = [
  "bumpalo",
  "fnv",
@@ -1082,9 +1082,9 @@ dependencies = [
 
 [[package]]
 name = "swc_common"
-version = "0.10.17"
+version = "0.10.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07760521aeef6e2dc3a06169916de60ab0e587666469366c2a0401cf84917ffc"
+checksum = "2061abb9f67dcef7abd6c874c72be6c90e8eca8b799fd769fd696c14af526929"
 dependencies = [
  "ast_node",
  "cfg-if 0.1.10",
@@ -1139,9 +1139,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms"
-version = "0.45.3"
+version = "0.47.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eea85e588c6583b084dfd1840c13c614f4b0c8f5f01db30154cbe9f1be5d90fa"
+checksum = "3494813dd593a7b354d33ddfcae468efb5f4e80bdde0c906e26e7d93121dc932"
 dependencies = [
  "swc_atoms",
  "swc_common",
@@ -1202,9 +1202,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecmascript"
-version = "0.31.4"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9148743bf5d6dcc482fd4db219968b216bff61a475c7838e0f60e00886cfa2b4"
+checksum = "fad428a7b5e0c493521bc18b9b4d943f42aa13f386b15e3c9535eeb65412d8b2"
 dependencies = [
  "swc_ecma_ast",
  "swc_ecma_parser",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,13 +20,13 @@ log = "0.4.14"
 serde = { version = "1.0.125", features = ["derive"] }
 serde_json = "1.0.64"
 swc_atoms = "0.2.6"
-swc_common = "0.10.17"
-swc_ecmascript = { version = "0.31.4", features = ["parser", "transforms", "utils", "visit"] }
+swc_common = "0.10.18"
+swc_ecmascript = { version = "0.33.0", features = ["parser", "transforms", "utils", "visit"] }
 regex = "=1.4.3"
 once_cell = "1.5.2"
 derive_more = { version = "0.99.13", features = ["display"] }
 anyhow = "1.0.40"
-dprint-swc-ecma-ast-view = "0.17.0"
+dprint-swc-ecma-ast-view = "0.19.0"
 if_chain = "1.0.1"
 
 [dev-dependencies]

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -465,7 +465,7 @@ pub trait Traverse: Handler {
   where
     N: NodeTrait<'a>,
   {
-    let node = node.into_node();
+    let node = node.as_node();
 
     // First, invoke a handler that does anything we want when _entering_ a node.
     self.on_enter_node(node, ctx);

--- a/src/rules/no_await_in_loop.rs
+++ b/src/rules/no_await_in_loop.rs
@@ -115,7 +115,7 @@ impl Handler for NoAwaitInLoopHandler {
       }
     }
 
-    if inside_loop(await_expr, await_expr.into_node()) {
+    if inside_loop(await_expr, await_expr.as_node()) {
       ctx.add_diagnostic_with_hint(await_expr.span(), CODE, MESSAGE, HINT);
     }
   }

--- a/src/rules/no_deprecated_deno_api.rs
+++ b/src/rules/no_deprecated_deno_api.rs
@@ -199,7 +199,7 @@ impl Handler for NoDeprecatedDenoApiHandler {
     ctx: &mut Context,
   ) {
     // Not check chained member expressions (e.g. `foo.bar.baz`)
-    if member_expr.parent.is::<AstView::MemberExpr>() {
+    if member_expr.parent().is::<AstView::MemberExpr>() {
       return;
     }
 

--- a/src/rules/no_namespace.rs
+++ b/src/rules/no_namespace.rs
@@ -58,7 +58,7 @@ impl Handler for NoNamespaceHandler {
       }
     }
 
-    if !inside_ambient_context(module_decl.into_node()) {
+    if !inside_ambient_context(module_decl.as_node()) {
       ctx.add_diagnostic(module_decl.span(), CODE, MESSAGE);
     }
   }

--- a/src/rules/no_setter_return.rs
+++ b/src/rules/no_setter_return.rs
@@ -65,7 +65,7 @@ impl Handler for NoSetterReturnHandler {
       }
     }
 
-    if inside_setter(return_stmt.into_node()) {
+    if inside_setter(return_stmt.as_node()) {
       ctx.add_diagnostic(return_stmt.span(), CODE, MESSAGE);
     }
   }

--- a/src/rules/no_this_before_super.rs
+++ b/src/rules/no_this_before_super.rs
@@ -155,7 +155,7 @@ impl SuperCallChecker {
 
 impl Handler for SuperCallChecker {
   fn this_expr(&mut self, this_expr: &AstView::ThisExpr, _ctx: &mut Context) {
-    if self.node_is_inside_function(this_expr.into_node()) {
+    if self.node_is_inside_function(this_expr.as_node()) {
       return;
     }
 
@@ -165,7 +165,7 @@ impl Handler for SuperCallChecker {
   }
 
   fn super_(&mut self, super_: &AstView::Super, _ctx: &mut Context) {
-    if self.node_is_inside_function(super_.into_node()) {
+    if self.node_is_inside_function(super_.as_node()) {
       return;
     }
 
@@ -175,13 +175,13 @@ impl Handler for SuperCallChecker {
   }
 
   fn call_expr(&mut self, call_expr: &AstView::CallExpr, ctx: &mut Context) {
-    if self.node_is_inside_function(call_expr.into_node()) {
+    if self.node_is_inside_function(call_expr.as_node()) {
       return;
     }
 
     // arguments are evaluated before the callee
     for arg in &call_expr.args {
-      self.traverse(arg.into_node(), ctx);
+      self.traverse(arg.as_node(), ctx);
     }
 
     if self.yet_appeared()

--- a/src/rules/no_unsafe_finally.rs
+++ b/src/rules/no_unsafe_finally.rs
@@ -107,7 +107,7 @@ struct NoUnsafeFinallyHandler;
 impl Handler for NoUnsafeFinallyHandler {
   fn break_stmt(&mut self, break_stmt: &AstView::BreakStmt, ctx: &mut Context) {
     let kind = StmtKind::Break(break_stmt.label);
-    if stmt_inside_finally(break_stmt.span(), kind, break_stmt.into_node()) {
+    if stmt_inside_finally(break_stmt.span(), kind, break_stmt.as_node()) {
       add_diagnostic_with_hint(ctx, break_stmt.span(), kind);
     }
   }
@@ -118,11 +118,8 @@ impl Handler for NoUnsafeFinallyHandler {
     ctx: &mut Context,
   ) {
     let kind = StmtKind::Continue(continue_stmt.label);
-    if stmt_inside_finally(
-      continue_stmt.span(),
-      kind,
-      continue_stmt.into_node(),
-    ) {
+    if stmt_inside_finally(continue_stmt.span(), kind, continue_stmt.as_node())
+    {
       add_diagnostic_with_hint(ctx, continue_stmt.span(), kind);
     }
   }
@@ -133,14 +130,14 @@ impl Handler for NoUnsafeFinallyHandler {
     ctx: &mut Context,
   ) {
     let kind = StmtKind::Return;
-    if stmt_inside_finally(return_stmt.span(), kind, return_stmt.into_node()) {
+    if stmt_inside_finally(return_stmt.span(), kind, return_stmt.as_node()) {
       add_diagnostic_with_hint(ctx, return_stmt.span(), kind);
     }
   }
 
   fn throw_stmt(&mut self, throw_stmt: &AstView::ThrowStmt, ctx: &mut Context) {
     let kind = StmtKind::Throw;
-    if stmt_inside_finally(throw_stmt.span(), kind, throw_stmt.into_node()) {
+    if stmt_inside_finally(throw_stmt.span(), kind, throw_stmt.as_node()) {
       add_diagnostic_with_hint(ctx, throw_stmt.span(), kind);
     }
   }


### PR DESCRIPTION
Upgrades `swc` and `dprint-swc-ecma-ast-view` and adjusts to the interface change in `dprint-swc-ecma-ast-view`.