### PR TITLE
chore: add GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/blank_issue.md
+++ b/.github/ISSUE_TEMPLATE/blank_issue.md
@@ -1,0 +1,4 @@
+---
+name: Blank Issue
+about: Create a blank issue.
+---

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,34 @@
+---
+name: Bug Report
+about: Create a bug report about a lint rule
+labels: bug
+---
+<!--
+Thank you for reporting a bug!
+Please write a short description of the bug.
+Reproducible snippet as minimal as possible would be much helpful.
+-->
+### Lint Name
+<!-- What lint rule do you want to report about? e.g. no-misused-new -->
+
+### Code Snippet
+
+```ts
+// put your code here
+```
+
+### Expected Result
+
+### Actual Result
+
+### Additional Info
+
+### Version
+
+<!--
+Paste the output from `deno --version`, e.g.
+
+deno 1.10.1 (release, x86_64-unknown-linux-gnu)
+v8 9.1.269.27
+typescript 4.2.2
+-->


### PR DESCRIPTION
This PR adds two GitHub issue templates, "Blank Issue" and "Bug Report".

Issue templates should be really helpful not only for visitors (especially first-time visitors) to easily file issues but also for developers because we will be able to get uniform, sufficient information from a filled-out template, which will allow us to debug and find the cause.