### PR TITLE
chore: upgrade `derive_more` to 0.99.14

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -261,9 +261,9 @@ dependencies = [
 
 [[package]]
 name = "derive_more"
-version = "0.99.13"
+version = "0.99.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f82b1b72f1263f214c0f823371768776c4f5841b942c9883aa8e5ec584fd0ba6"
+checksum = "5cc7b9cef1e351660e5443924e4f43ab25fbbed3e9a5f052df3677deb4d6b320"
 dependencies = [
  "convert_case",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ swc_common = "0.10.18"
 swc_ecmascript = { version = "0.33.0", features = ["parser", "transforms", "utils", "visit"] }
 regex = "=1.4.3"
 once_cell = "1.5.2"
-derive_more = { version = "0.99.13", features = ["display"] }
+derive_more = { version = "0.99.14", features = ["display"] }
 anyhow = "1.0.40"
 dprint-swc-ecma-ast-view = "0.19.0"
 if_chain = "1.0.1"


### PR DESCRIPTION
We are using `Display` macro from `derive_more` crate to easily
implement `std::fmt::Display` trait for each lint's message and hint.
This macro was a bit tricky; even if passed arguments are invalid format,
it _does_ compile, which results in getting unexpected diagnostic outputs.
This is why the issue #666 happened.

However, in `derive_more` v0.99.14, the macro has been refined so it now
rejects arguments in invalid format at compile-time. This is so useful
for us not to make a mistake.
Ref: https://github.com/JelteF/derive_more/pull/160