### PR TITLE
fix: show version from Cargo.toml

### DIFF
--- a/examples/dlint/main.rs
+++ b/examples/dlint/main.rs
@@ -25,6 +25,7 @@ mod js;
 
 fn create_cli_app<'a, 'b>() -> App<'a, 'b> {
   App::new("dlint")
+    .version(clap::crate_version!())
     .setting(AppSettings::SubcommandRequiredElseHelp)
     .subcommand(
       SubCommand::with_name("rules")


### PR DESCRIPTION
Before, `--version` is shown in the `--help` text, but the output doesn't list a version number.

```
$ dlint --version
dlint 
```

clap can pull the version from `Cargo.toml` [as shown here](https://github.com/clap-rs/clap/blob/master/examples/09_auto_version.rs). With this change, the version is shown as expected.

```
$ dlint --version
dlint 0.5.0
```