### PR TITLE
chore(ci): skip installing gnu-tar because it's already installed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,14 +47,6 @@ jobs:
         run: npm install --ci
         working-directory: benchmarks
 
-      # Work around https://github.com/actions/cache/issues/403 by using GNU tar
-      # instead of BSD tar.
-      - name: Install GNU tar
-        if: runner.os == 'macOS'
-        run: |
-          brew install gnu-tar
-          echo "/usr/local/opt/gnu-tar/libexec/gnubin" >> $GITHUB_PATH
-
       - name: Cache
         uses: actions/cache@v2
         with:


### PR DESCRIPTION
Same as https://github.com/denoland/deno/pull/10826