### PR TITLE
refactor(ban-types): reimplement with ast-view

### DIFF
--- a/src/rules/ban_types.rs
+++ b/src/rules/ban_types.rs
@@ -99,7 +99,7 @@ type and the misunderstood `Object` type.
 There are very few situations where primitive wrapper objects are desired and
 far more often a mistake was made with the case of the primitive type.  You also
 cannot assign a primitive wrapper object to a primitive leading to type issues
-down the line
+down the line.
 
 With `Function`, it is better to explicitly define the entire function
 signature rather than use the non-specific `Function` type which won't give you

--- a/src/rules/ban_types.rs
+++ b/src/rules/ban_types.rs
@@ -26,7 +26,7 @@ impl BannedType {
   fn as_message(&self) -> &'static str {
     use BannedType::*;
     match *self {
-      String | Boolean | Number | Symbol => "For consistency, it is recommended to use the lower-case primitive",
+      String | Boolean | Number | Symbol => "The corresponding lower-case primitive should be used",
       Function => "This provides no type safety because it represents all functions and classes",
       CapitalObject => "This type may be different from what you expect it to be",
       LowerObject => "This type is tricky to use so should be avoided if possible",
@@ -99,7 +99,10 @@ type and the misunderstood `Object` type.
 There are very few situations where primitive wrapper objects are desired and
 far more often a mistake was made with the case of the primitive type.  You also
 cannot assign a primitive wrapper object to a primitive leading to type issues
-down the line.
+down the line. For reference, [the TypeScript handbook] also says we shouldn't
+ever use these wrapper objects.
+
+[the TypeScript handbook]: https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html#number-string-boolean-symbol-and-object
 
 With `Function`, it is better to explicitly define the entire function
 signature rather than use the non-specific `Function` type which won't give you

--- a/src/rules/ban_types.rs
+++ b/src/rules/ban_types.rs
@@ -38,14 +38,14 @@ impl LintRule for BanTypes {
   }
 
   fn docs(&self) -> &'static str {
-    r#"Bans the use of primitive wrapper objects (e.g. `String` the object is a 
+    r#"Bans the use of primitive wrapper objects (e.g. `String` the object is a
 wrapper of `string` the primitive) in addition to the non-explicit `Function`
-type and the misunderstood `Object` type. 
+type and the misunderstood `Object` type.
 
 There are very few situations where primitive wrapper objects are desired and
-far more often a mistake was made with the case of the primitive type.  You also 
+far more often a mistake was made with the case of the primitive type.  You also
 cannot assign a primitive wrapper object to a primitive leading to type issues
-down the line.  
+down the line
 
 With `Function`, it is better to explicitly define the entire function
 signature rather than use the non-specific `Function` type which won't give you

--- a/src/rules/ban_types.rs
+++ b/src/rules/ban_types.rs
@@ -53,7 +53,7 @@ impl TryFrom<&str> for BannedType {
   type Error = ();
 
   fn try_from(value: &str) -> Result<Self, Self::Error> {
-    match value.as_ref() {
+    match value {
       "String" => Ok(Self::String),
       "Boolean" => Ok(Self::Boolean),
       "Number" => Ok(Self::Number),

--- a/src/rules/ban_types.rs
+++ b/src/rules/ban_types.rs
@@ -27,7 +27,7 @@ impl BannedType {
     use BannedType::*;
     match *self {
       String | Boolean | Number | Symbol => "For consistency, it is recommended to use the lower-case primitive",
-      Function => "This provides no type safety bacause it represents all functions and classes",
+      Function => "This provides no type safety because it represents all functions and classes",
       CapitalObject => "This type may be different from what you expect it to be",
       LowerObject => "This type is tricky to use so should be avoided if possible",
     }


### PR DESCRIPTION
Reimplements `ban-types` with ast-view, and adds hints.