### PR TITLE
refactor(ban-untagged-ignore): reimplement with ast-view

### DIFF
--- a/src/rules/ban_untagged_ignore.rs
+++ b/src/rules/ban_untagged_ignore.rs
@@ -19,7 +19,15 @@ impl LintRule for BanUntaggedIgnore {
     CODE
   }
 
-  fn lint_program(&self, context: &mut Context, _program: ProgramRef<'_>) {
+  fn lint_program(&self, _context: &mut Context, _program: ProgramRef<'_>) {
+    unreachable!();
+  }
+
+  fn lint_program_with_ast_view(
+    &self,
+    context: &mut Context,
+    _program: dprint_swc_ecma_ast_view::Program,
+  ) {
     let violated_spans: Vec<Span> = context
       .ignore_directives()
       .iter()

--- a/src/rules/ban_untagged_ignore.rs
+++ b/src/rules/ban_untagged_ignore.rs
@@ -4,6 +4,8 @@ use swc_common::Span;
 
 pub struct BanUntaggedIgnore;
 
+const CODE: &str = "ban-untagged-ignore";
+
 impl LintRule for BanUntaggedIgnore {
   fn new() -> Box<Self> {
     Box::new(BanUntaggedIgnore)
@@ -14,7 +16,7 @@ impl LintRule for BanUntaggedIgnore {
   }
 
   fn code(&self) -> &'static str {
-    "ban-untagged-ignore"
+    CODE
   }
 
   fn lint_program(&self, context: &mut Context, _program: ProgramRef<'_>) {
@@ -33,7 +35,7 @@ impl LintRule for BanUntaggedIgnore {
     for span in violated_spans {
       context.add_diagnostic_with_hint(
         span,
-        "ban-untagged-ignore",
+        CODE,
         "Ignore directive requires lint rule name(s)",
         "Add one or more lint rule names.  E.g. // deno-lint-ignore adjacent-overload-signatures",
       )


### PR DESCRIPTION
Reimplements `ban-untagged-ignore` with ast-view. It's very easy refactoring like #722 :)