### PR TITLE
chore: follow Rust naming convention

### DIFF
--- a/src/rules/no_unused_vars.rs
+++ b/src/rules/no_unused_vars.rs
@@ -432,12 +432,12 @@ impl<'a> IdentKind<'a> {
     }
   }
 
-  fn to_message(&self) -> NoUnusedVarsMessage {
+  fn to_message(self) -> NoUnusedVarsMessage {
     let ident = self.inner();
     NoUnusedVarsMessage::NeverUsed(ident.sym.to_string())
   }
 
-  fn to_hint(&self) -> NoUnusedVarsHint {
+  fn to_hint(self) -> NoUnusedVarsHint {
     let symbol = self.inner().sym.to_string();
     match self {
       IdentKind::NamedImport(_) => NoUnusedVarsHint::Alias(symbol),


### PR DESCRIPTION
Clippy complains about naming convention: https://github.com/denoland/deno_lint/runs/2865828573
This commit addresses it.

Blocks #715 