### PR TITLE
feat(dlint): print rule doc with syntax highlighting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,7 +81,7 @@ jobs:
 
       - name: Generate rules json
         if: contains(matrix.os, 'ubuntu')
-        run: target/release/examples/dlint rules --json --all > docs.json
+        run: target/release/examples/dlint rules --json > docs.json
 
       - name: Build website
         if: contains(matrix.os, 'ubuntu')

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -144,6 +144,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
 
 [[package]]
+name = "crossbeam"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ae5588f6b3c3cb05239e90bd110f257254aecd01e4635400391aeae07497845"
+dependencies = [
+ "cfg-if 1.0.0",
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-epoch",
+ "crossbeam-queue",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-channel"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -166,9 +180,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.3"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2584f639eb95fea8c798496315b297cf81b9b58b6d30ab066a75455333cf4b12"
+checksum = "4ec02e091aa634e2c3ada4a392989e7c3116673ef0ac5b72232439094d73b7fd"
 dependencies = [
  "cfg-if 1.0.0",
  "crossbeam-utils",
@@ -178,14 +192,48 @@ dependencies = [
 ]
 
 [[package]]
-name = "crossbeam-utils"
-version = "0.8.3"
+name = "crossbeam-queue"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7e9d99fa91428effe99c5c6d4634cdeba32b8cf784fc428a2a687f61a952c49"
+checksum = "9b10ddc024425c88c2ad148c1b0fd53f4c6d38db9697c9f1588381212fa657c9"
 dependencies = [
- "autocfg",
+ "cfg-if 1.0.0",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d82cfc11ce7f2c3faef78d8a684447b40d503d9681acebed6cb728d45940c4db"
+dependencies = [
  "cfg-if 1.0.0",
  "lazy_static",
+]
+
+[[package]]
+name = "crossterm"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0ebde6a9dd5e331cd6c6f48253254d117642c31653baa475e394657c59c1f7d"
+dependencies = [
+ "bitflags",
+ "crossterm_winapi",
+ "libc",
+ "mio",
+ "parking_lot",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a6966607622438301997d3dac0d2f6e9a90c68bb6bc1785ea98456ab93c0507"
+dependencies = [
+ "winapi",
 ]
 
 [[package]]
@@ -250,6 +298,7 @@ dependencies = [
  "annotate-snippets",
  "anyhow",
  "clap",
+ "crossterm",
  "deno_core",
  "derive_more",
  "dprint-swc-ecma-ast-view",
@@ -265,6 +314,7 @@ dependencies = [
  "swc_atoms",
  "swc_common",
  "swc_ecmascript",
+ "termimad",
 ]
 
 [[package]]
@@ -571,6 +621,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "instant"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61124eeebbd69b8190558df225adf7e4caafce0d743919e5d6b19652314ec5ec"
+dependencies = [
+ "cfg-if 1.0.0",
+]
+
+[[package]]
 name = "is-macro"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -625,6 +684,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9385f66bf6105b241aa65a61cb923ef20efc665cb9f9bb50ac2f0c4b7f378d41"
 
 [[package]]
+name = "lock_api"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0382880606dff6d15c9476c416d18690b72742aa7b605bb6dd6ec9030fbf07eb"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -655,10 +723,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "minimad"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8957f240ecb82a4e699bcf4db189fe8a7f5aa68b9e6d5abf829c62a9ee4630ed"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "mio"
+version = "0.7.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c2bdb6314ec10835cd3293dd268473a835c02b7b352e788be788b3c6ca6bb16"
+dependencies = [
+ "libc",
+ "log",
+ "miow",
+ "ntapi",
+ "winapi",
+]
+
+[[package]]
+name = "miow"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9f1c5b025cda876f66ef43a113f91ebc9f4ccef34843000e0adf6ebbab84e21"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "new_debug_unreachable"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4a24736216ec316047a1fc4252e27dabb04218aa4a3f37c6e7ddbf1f9782b54"
+
+[[package]]
+name = "ntapi"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f6bb902e437b6d86e03cce10a7e2af662292c5dfef23b65899ea3ac9354ad44"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "num-bigint"
@@ -714,6 +822,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ff55baddef9e4ad00f88b6c743a2a8062d4c6ade126c2a528644b8e444d52ce"
 dependencies = [
  "stable_deref_trait",
+]
+
+[[package]]
+name = "parking_lot"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d7744ac029df22dca6284efe4e898991d28e3085c706c972bcd7da4a27a15eb"
+dependencies = [
+ "instant",
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7a782938e745763fe6907fc6ba86946d72f49fe7e21de074e08128a99fb018"
+dependencies = [
+ "cfg-if 1.0.0",
+ "instant",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "winapi",
 ]
 
 [[package]]
@@ -928,6 +1061,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ab49abadf3f9e1c4bc499e8845e152ad87d2ad2d30371841171169e9d75feee"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "regex"
 version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1025,6 +1167,36 @@ checksum = "9e6669e0b20b450bceffdcc000eb51a7b9c528a828a6baabfa8e738935dccdc1"
 dependencies = [
  "rusty_v8",
  "serde",
+]
+
+[[package]]
+name = "signal-hook"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "470c5a6397076fae0094aaf06a08e6ba6f37acb77d3b1b91ea92b4d6c8650c39"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-mio"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29fd5867f1c4f2c5be079aee7a2adf1152ebb04a4bc4d341f504b7dece607ed4"
+dependencies = [
+ "libc",
+ "mio",
+ "signal-hook",
+]
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e51e73328dc4ac0c7ccbda3a494dfa03df1de2f46018127f60c693f2648455b0"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -1320,12 +1492,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "termimad"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "048ecd125577e1dfc10123052e92e457988c6761b7ceff74bf9e8e8c5d44808c"
+dependencies = [
+ "crossbeam",
+ "crossterm",
+ "minimad",
+ "thiserror",
+ "unicode-width",
+]
+
+[[package]]
 name = "textwrap"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 dependencies = [
  "unicode-width",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa6f76457f59514c7eeb4e59d891395fab0b2fd1d40723ae737d64153392e9c6"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a36768c0fbf1bb15eca10defa29526bda730a2376c2ab4393ccfa16fb1a318d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -41,6 +41,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ansi_term"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -128,7 +137,7 @@ version = "2.33.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37e58ac78573c40708d45522f0d80fa2f01cc4f9b4e2bf749807255454312002"
 dependencies = [
- "ansi_term",
+ "ansi_term 0.11.0",
  "atty",
  "bitflags",
  "strsim 0.8.0",
@@ -142,20 +151,6 @@ name = "convert_case"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
-
-[[package]]
-name = "crossbeam"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ae5588f6b3c3cb05239e90bd110f257254aecd01e4635400391aeae07497845"
-dependencies = [
- "cfg-if 1.0.0",
- "crossbeam-channel",
- "crossbeam-deque",
- "crossbeam-epoch",
- "crossbeam-queue",
- "crossbeam-utils",
-]
 
 [[package]]
 name = "crossbeam-channel"
@@ -192,16 +187,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crossbeam-queue"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b10ddc024425c88c2ad148c1b0fd53f4c6d38db9697c9f1588381212fa657c9"
-dependencies = [
- "cfg-if 1.0.0",
- "crossbeam-utils",
-]
-
-[[package]]
 name = "crossbeam-utils"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -209,31 +194,6 @@ checksum = "d82cfc11ce7f2c3faef78d8a684447b40d503d9681acebed6cb728d45940c4db"
 dependencies = [
  "cfg-if 1.0.0",
  "lazy_static",
-]
-
-[[package]]
-name = "crossterm"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0ebde6a9dd5e331cd6c6f48253254d117642c31653baa475e394657c59c1f7d"
-dependencies = [
- "bitflags",
- "crossterm_winapi",
- "libc",
- "mio",
- "parking_lot",
- "signal-hook",
- "signal-hook-mio",
- "winapi",
-]
-
-[[package]]
-name = "crossterm_winapi"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a6966607622438301997d3dac0d2f6e9a90c68bb6bc1785ea98456ab93c0507"
-dependencies = [
- "winapi",
 ]
 
 [[package]]
@@ -296,9 +256,9 @@ name = "deno_lint"
 version = "0.7.0"
 dependencies = [
  "annotate-snippets",
+ "ansi_term 0.12.1",
  "anyhow",
  "clap",
- "crossterm",
  "deno_core",
  "derive_more",
  "dprint-swc-ecma-ast-view",
@@ -306,6 +266,7 @@ dependencies = [
  "globwalk",
  "if_chain",
  "log",
+ "markdown",
  "once_cell",
  "rayon",
  "regex",
@@ -314,7 +275,6 @@ dependencies = [
  "swc_atoms",
  "swc_common",
  "swc_ecmascript",
- "termimad",
 ]
 
 [[package]]
@@ -621,15 +581,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "instant"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61124eeebbd69b8190558df225adf7e4caafce0d743919e5d6b19652314ec5ec"
-dependencies = [
- "cfg-if 1.0.0",
-]
-
-[[package]]
 name = "is-macro"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -684,21 +635,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9385f66bf6105b241aa65a61cb923ef20efc665cb9f9bb50ac2f0c4b7f378d41"
 
 [[package]]
-name = "lock_api"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0382880606dff6d15c9476c416d18690b72742aa7b605bb6dd6ec9030fbf07eb"
-dependencies = [
- "scopeguard",
-]
-
-[[package]]
 name = "log"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
 dependencies = [
  "cfg-if 1.0.0",
+]
+
+[[package]]
+name = "markdown"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef3aab6a1d529b112695f72beec5ee80e729cb45af58663ec902c8fac764ecdd"
+dependencies = [
+ "lazy_static",
+ "pipeline",
+ "regex",
 ]
 
 [[package]]
@@ -723,50 +676,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "minimad"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8957f240ecb82a4e699bcf4db189fe8a7f5aa68b9e6d5abf829c62a9ee4630ed"
-dependencies = [
- "once_cell",
-]
-
-[[package]]
-name = "mio"
-version = "0.7.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c2bdb6314ec10835cd3293dd268473a835c02b7b352e788be788b3c6ca6bb16"
-dependencies = [
- "libc",
- "log",
- "miow",
- "ntapi",
- "winapi",
-]
-
-[[package]]
-name = "miow"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9f1c5b025cda876f66ef43a113f91ebc9f4ccef34843000e0adf6ebbab84e21"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "new_debug_unreachable"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4a24736216ec316047a1fc4252e27dabb04218aa4a3f37c6e7ddbf1f9782b54"
-
-[[package]]
-name = "ntapi"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f6bb902e437b6d86e03cce10a7e2af662292c5dfef23b65899ea3ac9354ad44"
-dependencies = [
- "winapi",
-]
 
 [[package]]
 name = "num-bigint"
@@ -822,31 +735,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ff55baddef9e4ad00f88b6c743a2a8062d4c6ade126c2a528644b8e444d52ce"
 dependencies = [
  "stable_deref_trait",
-]
-
-[[package]]
-name = "parking_lot"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d7744ac029df22dca6284efe4e898991d28e3085c706c972bcd7da4a27a15eb"
-dependencies = [
- "instant",
- "lock_api",
- "parking_lot_core",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7a782938e745763fe6907fc6ba86946d72f49fe7e21de074e08128a99fb018"
-dependencies = [
- "cfg-if 1.0.0",
- "instant",
- "libc",
- "redox_syscall",
- "smallvec",
- "winapi",
 ]
 
 [[package]]
@@ -930,6 +818,12 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "pipeline"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d15b6607fa632996eb8a17c9041cb6071cb75ac057abd45dece578723ea8c7c0"
 
 [[package]]
 name = "pmutil"
@@ -1061,15 +955,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "redox_syscall"
-version = "0.2.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ab49abadf3f9e1c4bc499e8845e152ad87d2ad2d30371841171169e9d75feee"
-dependencies = [
- "bitflags",
-]
-
-[[package]]
 name = "regex"
 version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1167,36 +1052,6 @@ checksum = "9e6669e0b20b450bceffdcc000eb51a7b9c528a828a6baabfa8e738935dccdc1"
 dependencies = [
  "rusty_v8",
  "serde",
-]
-
-[[package]]
-name = "signal-hook"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "470c5a6397076fae0094aaf06a08e6ba6f37acb77d3b1b91ea92b4d6c8650c39"
-dependencies = [
- "libc",
- "signal-hook-registry",
-]
-
-[[package]]
-name = "signal-hook-mio"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29fd5867f1c4f2c5be079aee7a2adf1152ebb04a4bc4d341f504b7dece607ed4"
-dependencies = [
- "libc",
- "mio",
- "signal-hook",
-]
-
-[[package]]
-name = "signal-hook-registry"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e51e73328dc4ac0c7ccbda3a494dfa03df1de2f46018127f60c693f2648455b0"
-dependencies = [
- "libc",
 ]
 
 [[package]]
@@ -1492,45 +1347,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "termimad"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "048ecd125577e1dfc10123052e92e457988c6761b7ceff74bf9e8e8c5d44808c"
-dependencies = [
- "crossbeam",
- "crossterm",
- "minimad",
- "thiserror",
- "unicode-width",
-]
-
-[[package]]
 name = "textwrap"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 dependencies = [
  "unicode-width",
-]
-
-[[package]]
-name = "thiserror"
-version = "1.0.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa6f76457f59514c7eeb4e59d891395fab0b2fd1d40723ae737d64153392e9c6"
-dependencies = [
- "thiserror-impl",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "1.0.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a36768c0fbf1bb15eca10defa29526bda730a2376c2ab4393ccfa16fb1a318d"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -258,6 +258,7 @@ dependencies = [
  "annotate-snippets",
  "ansi_term 0.12.1",
  "anyhow",
+ "atty",
  "clap",
  "deno_core",
  "derive_more",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,10 +31,10 @@ if_chain = "1.0.1"
 
 [dev-dependencies]
 annotate-snippets = { version = "0.9.0", features = ["color"] }
+ansi_term = "0.12.1"
 clap = "2.33.3"
-crossterm = "0.20.0"
 deno_core = "0.84.0"
 env_logger = "0.8.3"
 globwalk = "0.8.1"
+markdown = "0.3.0"
 rayon = "1.5.0"
-termimad = "0.12.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,9 @@ if_chain = "1.0.1"
 [dev-dependencies]
 annotate-snippets = { version = "0.9.0", features = ["color"] }
 clap = "2.33.3"
+crossterm = "0.20.0"
 deno_core = "0.84.0"
 env_logger = "0.8.3"
 globwalk = "0.8.1"
 rayon = "1.5.0"
+termimad = "0.12.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ if_chain = "1.0.1"
 [dev-dependencies]
 annotate-snippets = { version = "0.9.0", features = ["color"] }
 ansi_term = "0.12.1"
+atty = "0.2.14"
 clap = "2.33.3"
 deno_core = "0.84.0"
 env_logger = "0.8.3"

--- a/examples/dlint/color.rs
+++ b/examples/dlint/color.rs
@@ -35,7 +35,7 @@ impl Colorize for markdown::Block {
         // TODO(magurotuna) syntax highlight
         content
           .split('\n')
-          .map(|line| format!("{}", line).indent(4))
+          .map(|line| line.to_string().indent(4))
           .join_by("\n")
           .linebreak()
       }

--- a/examples/dlint/color.rs
+++ b/examples/dlint/color.rs
@@ -1,0 +1,146 @@
+pub trait Colorize {
+  fn colorize(self) -> String;
+}
+
+impl Colorize for markdown::Block {
+  fn colorize(self) -> String {
+    use markdown::Block::*;
+    match self {
+      Header(spans, level) if level == 1 => {
+        let style = ansi_term::Style::new()
+          .bold()
+          .underline()
+          .italic()
+          .fg(ansi_term::Color::Purple);
+        style.paint(spans.colorize()).to_string().linebreak()
+      }
+      Header(spans, _level) => {
+        let style = ansi_term::Style::new()
+          .bold()
+          .underline()
+          .fg(ansi_term::Color::Purple);
+        style.paint(spans.colorize()).to_string().linebreak()
+      }
+      Paragraph(spans) => spans.colorize().linebreak(),
+      Blockquote(blocks) => {
+        let style = ansi_term::Style::new().dimmed();
+        style.paint(blocks.colorize()).to_string().linebreak()
+      }
+      CodeBlock(info, content)
+        if matches!(
+          info.as_deref(),
+          Some("javascript" | "typescript" | "js" | "ts" | "jsx" | "tsx")
+        ) =>
+      {
+        // TODO(magurotuna) syntax highlight
+        content
+          .split('\n')
+          .map(|line| format!("{}", line).indent(4))
+          .join_by("\n")
+          .linebreak()
+      }
+      CodeBlock(_info, content) => {
+        content.split('\n').map(|line| line.indent(4)).join_by("\n")
+      }
+      OrderedList(list_items, _list_type) => list_items
+        .into_iter()
+        .enumerate()
+        .map(|(idx, li)| format!("{}. {}", idx, li.colorize()).indent(2))
+        .join_by("\n")
+        .linebreak(),
+      UnorderedList(list_items) => list_items
+        .into_iter()
+        .map(|li| format!("• {}", li.colorize()).indent(2))
+        .join_by("\n")
+        .linebreak(),
+      Raw(content) => content,
+      Hr => "-".repeat(80),
+    }
+  }
+}
+
+impl Colorize for Vec<markdown::Block> {
+  fn colorize(self) -> String {
+    self.into_iter().map(Colorize::colorize).join_by("\n")
+  }
+}
+
+impl Colorize for markdown::Span {
+  fn colorize(self) -> String {
+    use markdown::Span::*;
+    match self {
+      Break => "\n".to_string(),
+      Text(text) => text,
+      Code(code) => ansi_term::Color::Green.paint(code).to_string(), // todo
+      Link(label, url, _title) => {
+        format!("[{label}]({url})", label = label, url = url)
+      }
+      Image(alt, url, _title) => {
+        format!("![{alt}]({url})", alt = alt, url = url)
+      }
+      Emphasis(spans) => {
+        let style = ansi_term::Style::new().italic();
+        style.paint(spans.colorize()).to_string()
+      }
+      Strong(spans) => {
+        let style = ansi_term::Style::new().bold();
+        style.paint(spans.colorize()).to_string()
+      }
+    }
+  }
+}
+
+impl Colorize for Vec<markdown::Span> {
+  fn colorize(self) -> String {
+    self.into_iter().map(Colorize::colorize).join_by("")
+  }
+}
+
+impl Colorize for markdown::ListItem {
+  fn colorize(self) -> String {
+    use markdown::ListItem::*;
+    match self {
+      Simple(spans) => spans.colorize(),
+      Paragraph(blocks) => blocks.colorize(),
+    }
+  }
+}
+
+trait Linebreak {
+  fn linebreak(self) -> String;
+}
+
+impl Linebreak for String {
+  fn linebreak(self) -> String {
+    format!("{}\n", self)
+  }
+}
+
+trait Indent {
+  fn indent(self, width: usize) -> String;
+}
+
+impl Indent for String {
+  fn indent(self, width: usize) -> String {
+    format!("{}{}", " ".repeat(width), self)
+  }
+}
+
+impl Indent for &str {
+  fn indent(self, width: usize) -> String {
+    format!("{}{}", " ".repeat(width), self)
+  }
+}
+
+trait JoinBy {
+  fn join_by(self, sep: &str) -> String;
+}
+
+impl<I> JoinBy for I
+where
+  I: Iterator<Item = String>,
+{
+  fn join_by(self, sep: &str) -> String {
+    self.collect::<Vec<_>>().join(sep)
+  }
+}

--- a/examples/dlint/color.rs
+++ b/examples/dlint/color.rs
@@ -71,7 +71,7 @@ impl Colorize for markdown::Span {
     match self {
       Break => "\n".to_string(),
       Text(text) => text,
-      Code(code) => ansi_term::Color::Green.paint(code).to_string(), // todo
+      Code(code) => ansi_term::Color::Green.paint(code).to_string(),
       Link(label, url, _title) => {
         format!("[{label}]({url})", label = label, url = url)
       }

--- a/examples/dlint/color.rs
+++ b/examples/dlint/color.rs
@@ -1,3 +1,4 @@
+// Copyright 2020-2021 the Deno authors. All rights reserved. MIT license.
 use crate::lexer::{lex, MediaType, TokenOrComment};
 use std::convert::TryFrom;
 use swc_ecmascript::parser::token::{Token, Word};

--- a/examples/dlint/color.rs
+++ b/examples/dlint/color.rs
@@ -116,8 +116,11 @@ impl Colorize for markdown::Block {
         .map(|li| format!("• {}", li.colorize()).indent(2))
         .join_by("\n")
         .linebreak(),
-      Raw(content) => content,
-      Hr => "-".repeat(80),
+      Raw(content) => content.linebreak(),
+      Hr => ansi_term::Color::Fixed(8)
+        .paint("-".repeat(80))
+        .to_string()
+        .linebreak(),
     }
   }
 }

--- a/examples/dlint/lexer.rs
+++ b/examples/dlint/lexer.rs
@@ -1,0 +1,149 @@
+//! This module is mostly brought from https://github.com/denoland/deno/blob/96d05829002ef065b8fc84fe70de062cff0e95b3/cli/ast/mod.rs
+
+use std::convert::TryFrom;
+use std::ops::Range;
+use swc_common::comments::{Comment, CommentKind, SingleThreadedComments};
+use swc_common::{FileName, SourceMap, Span};
+use swc_ecmascript::parser::lexer::Lexer;
+use swc_ecmascript::parser::token::Token;
+use swc_ecmascript::parser::{
+  EsConfig, JscTarget, StringInput, Syntax, TsConfig,
+};
+
+static TARGET: JscTarget = JscTarget::Es2020;
+
+pub fn lex(source: &str, media_type: MediaType) -> Vec<LexedItem> {
+  let source_map = SourceMap::default();
+  let source_file = source_map.new_source_file(
+    FileName::Custom(format!("anonymous.{}", media_type.ext())),
+    source.to_string(),
+  );
+  let comments = SingleThreadedComments::default();
+  let lexer = Lexer::new(
+    media_type.syntax(),
+    TARGET,
+    StringInput::from(source_file.as_ref()),
+    Some(&comments),
+  );
+
+  let mut tokens: Vec<LexedItem> = lexer
+    .map(|token| LexedItem {
+      span: token.span,
+      inner: TokenOrComment::Token(token.token),
+    })
+    .collect();
+
+  tokens.extend(flatten_comments(comments).map(|comment| LexedItem {
+    span: comment.span,
+    inner: TokenOrComment::Comment {
+      kind: comment.kind,
+      text: comment.text,
+    },
+  }));
+
+  tokens.sort_by_key(|item| item.span.lo.0);
+
+  tokens
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum MediaType {
+  JavaScript,
+  TypeScript,
+  Jsx,
+  Tsx,
+  Dts,
+}
+
+impl TryFrom<&str> for MediaType {
+  type Error = ();
+
+  fn try_from(value: &str) -> Result<Self, Self::Error> {
+    match value {
+      "javascript" => Ok(Self::JavaScript),
+      "typescript" => Ok(Self::TypeScript),
+      "jsx" => Ok(Self::Jsx),
+      "tsx" => Ok(Self::Tsx),
+      "dts" => Ok(Self::Dts),
+      _ => Err(()),
+    }
+  }
+}
+
+impl MediaType {
+  fn ext(&self) -> &'static str {
+    use MediaType::*;
+    match *self {
+      JavaScript => "js",
+      TypeScript => "ts",
+      Jsx => "jsx",
+      Tsx => "tsx",
+      Dts => "d.ts",
+    }
+  }
+
+  fn syntax(&self) -> Syntax {
+    fn get_es_config(jsx: bool) -> EsConfig {
+      EsConfig {
+        class_private_methods: true,
+        class_private_props: true,
+        class_props: true,
+        dynamic_import: true,
+        export_default_from: true,
+        export_namespace_from: true,
+        import_meta: true,
+        jsx,
+        nullish_coalescing: true,
+        num_sep: true,
+        optional_chaining: true,
+        top_level_await: true,
+        ..EsConfig::default()
+      }
+    }
+    fn get_ts_config(tsx: bool, dts: bool) -> TsConfig {
+      TsConfig {
+        decorators: true,
+        dts,
+        dynamic_import: true,
+        tsx,
+        ..TsConfig::default()
+      }
+    }
+
+    use MediaType::*;
+    match *self {
+      JavaScript => Syntax::Es(get_es_config(false)),
+      TypeScript => Syntax::Typescript(get_ts_config(false, false)),
+      Jsx => Syntax::Es(get_es_config(true)),
+      Tsx => Syntax::Typescript(get_ts_config(true, false)),
+      Dts => Syntax::Typescript(get_ts_config(false, true)),
+    }
+  }
+}
+
+#[derive(Debug)]
+pub enum TokenOrComment {
+  Token(Token),
+  Comment { kind: CommentKind, text: String },
+}
+
+#[derive(Debug)]
+pub struct LexedItem {
+  pub span: Span,
+  pub inner: TokenOrComment,
+}
+
+impl LexedItem {
+  pub fn span_as_range(&self) -> Range<usize> {
+    self.span.lo.0 as usize..self.span.hi.0 as usize
+  }
+}
+
+fn flatten_comments(
+  comments: SingleThreadedComments,
+) -> impl Iterator<Item = Comment> {
+  let (leading, trailing) = comments.take_all();
+  let mut comments = (*leading).clone().into_inner();
+  comments.extend((*trailing).clone().into_inner());
+  comments.into_iter().flat_map(|el| el.1)
+}

--- a/examples/dlint/lexer.rs
+++ b/examples/dlint/lexer.rs
@@ -1,3 +1,5 @@
+// Copyright 2020-2021 the Deno authors. All rights reserved. MIT license.
+
 //! This module is mostly brought from https://github.com/denoland/deno/blob/96d05829002ef065b8fc84fe70de062cff0e95b3/cli/ast/mod.rs
 
 use std::convert::TryFrom;

--- a/examples/dlint/main.rs
+++ b/examples/dlint/main.rs
@@ -24,6 +24,7 @@ use swc_ecmascript::parser::{EsConfig, Syntax, TsConfig};
 mod color;
 mod config;
 mod js;
+mod lexer;
 mod rules;
 
 fn create_cli_app<'a, 'b>() -> App<'a, 'b> {

--- a/examples/dlint/main.rs
+++ b/examples/dlint/main.rs
@@ -21,6 +21,7 @@ use std::sync::{Arc, Mutex};
 use swc_common::BytePos;
 use swc_ecmascript::parser::{EsConfig, Syntax, TsConfig};
 
+mod color;
 mod config;
 mod js;
 mod rules;

--- a/examples/dlint/rules.rs
+++ b/examples/dlint/rules.rs
@@ -1,0 +1,85 @@
+use deno_lint::rules::get_all_rules;
+use serde::Serialize;
+
+#[derive(Clone, Copy, Serialize)]
+pub struct Rule {
+  code: &'static str,
+  docs: &'static str,
+  tags: &'static [&'static str],
+}
+
+pub fn get_all_rules_metadata() -> Vec<Rule> {
+  get_all_rules()
+    .into_iter()
+    .map(|rule| Rule {
+      code: rule.code(),
+      docs: rule.docs(),
+      tags: rule.tags(),
+    })
+    .collect()
+}
+
+pub fn get_specific_rule_metadata(rule_name: &str) -> Vec<Rule> {
+  get_all_rules_metadata()
+    .into_iter()
+    .filter(|r| r.code == rule_name)
+    .collect()
+}
+
+pub fn print_rules<F: RuleFormatter>(mut rules: Vec<Rule>) {
+  match F::format(&mut rules) {
+    Err(e) => {
+      eprintln!("{}", e);
+      std::process::exit(1);
+    }
+    Ok(text) => {
+      println!("{}", text);
+    }
+  }
+}
+
+pub enum JsonFormatter {}
+pub enum PrettyFormatter {}
+
+pub trait RuleFormatter {
+  fn format(rules: &mut [Rule]) -> Result<String, &'static str>;
+}
+
+impl RuleFormatter for JsonFormatter {
+  fn format(rules: &mut [Rule]) -> Result<String, &'static str> {
+    if rules.is_empty() {
+      return Err("Rule not found!");
+    }
+    serde_json::to_string_pretty(rules).map_err(|_| "failed to format!")
+  }
+}
+
+impl RuleFormatter for PrettyFormatter {
+  fn format(rules: &mut [Rule]) -> Result<String, &'static str> {
+    if rules.is_empty() {
+      return Err("Rule not found!");
+    }
+
+    if rules.len() == 1 {
+      let rule = &rules[0];
+      let docs = if rule.docs.is_empty() {
+        "documentation not available"
+      } else {
+        rule.docs
+      };
+      return Ok(format!("- {code}\n\n{docs}", code = rule.code, docs = docs));
+    }
+
+    rules.sort_by_key(|r| r.code);
+    let mut list = Vec::with_capacity(1 + rules.len());
+    list.push("Available rules (trailing ✔️ mark indicates it is included in the recommended rule set):".to_string());
+    list.extend(rules.iter().map(|r| {
+      let mut s = format!(" - {}", r.code);
+      if r.tags.contains(&"recommended") {
+        s += " ✔️";
+      }
+      s
+    }));
+    Ok(list.join("\n"))
+  }
+}

--- a/examples/dlint/rules.rs
+++ b/examples/dlint/rules.rs
@@ -1,3 +1,4 @@
+use crate::color::Colorize;
 use deno_lint::rules::get_all_rules;
 use serde::Serialize;
 
@@ -37,7 +38,6 @@ pub fn print_rules<F: RuleFormatter>(mut rules: Vec<Rule>) {
     }
   }
 }
-
 pub enum JsonFormatter {}
 pub enum PrettyFormatter {}
 
@@ -54,21 +54,6 @@ impl RuleFormatter for JsonFormatter {
   }
 }
 
-fn make_skin() -> termimad::MadSkin {
-  use crossterm::style::Attribute;
-  use crossterm::style::Color;
-  let mut skin = termimad::MadSkin::default();
-  skin.headers[0].set_fg(Color::Blue);
-  skin.headers[0].align = termimad::Alignment::Left;
-  skin.headers[0].add_attr(Attribute::Bold);
-  skin.headers[2].set_fg(Color::Red);
-  skin.headers[2].add_attr(Attribute::Bold);
-  skin.inline_code.set_fg(Color::Green);
-  // this doesn't work...
-  //skin.code_block.set_bg(Color::Yellow);
-  skin
-}
-
 impl RuleFormatter for PrettyFormatter {
   fn format(rules: &mut [Rule]) -> Result<String, &'static str> {
     match rules {
@@ -78,24 +63,14 @@ impl RuleFormatter for PrettyFormatter {
       // Certain rule name is specified.
       // Print its documentation richly.
       [rule] => {
-        let skin = make_skin();
-        let res = if rule.docs.is_empty() {
-          skin
-            .term_text(&format!(
-              "documentation for `{}` not available",
-              rule.code
-            ))
-            .to_string()
+        let md = if rule.docs.is_empty() {
+          format!("documentation for `{}` is not available", rule.code)
         } else {
-          skin
-            .term_text(&format!(
-              "# {code}\n\n{docs}",
-              code = rule.code,
-              docs = rule.docs
-            ))
-            .to_string()
+          format!("# {code}\n\n{docs}", code = rule.code, docs = rule.docs)
         };
-        Ok(res)
+        let md_tokens = markdown::tokenize(&md);
+
+        Ok(md_tokens.colorize())
       }
 
       // No rule name is specified.

--- a/examples/dlint/rules.rs
+++ b/examples/dlint/rules.rs
@@ -69,9 +69,13 @@ impl RuleFormatter for PrettyFormatter {
         } else {
           format!("# {code}\n\n{docs}", code = rule.code, docs = rule.docs)
         };
-        let md_tokens = markdown::tokenize(&md);
 
-        Ok(md_tokens.colorize())
+        if atty::is(atty::Stream::Stdout) {
+          let md_tokens = markdown::tokenize(&md);
+          Ok(md_tokens.colorize())
+        } else {
+          Ok(md)
+        }
       }
 
       // No rule name is specified.

--- a/examples/dlint/rules.rs
+++ b/examples/dlint/rules.rs
@@ -29,6 +29,9 @@ pub fn get_specific_rule_metadata(rule_name: &str) -> Vec<Rule> {
 }
 
 pub fn print_rules<F: RuleFormatter>(mut rules: Vec<Rule>) {
+  #[cfg(windows)]
+  ansi_term::enable_ansi_support().expect("Failed to enable ANSI support");
+
   match F::format(&mut rules) {
     Err(e) => {
       eprintln!("{}", e);

--- a/examples/dlint/rules.rs
+++ b/examples/dlint/rules.rs
@@ -54,6 +54,21 @@ impl RuleFormatter for JsonFormatter {
   }
 }
 
+fn make_skin() -> termimad::MadSkin {
+  use crossterm::style::Attribute;
+  use crossterm::style::Color;
+  let mut skin = termimad::MadSkin::default();
+  skin.headers[0].set_fg(Color::Blue);
+  skin.headers[0].align = termimad::Alignment::Left;
+  skin.headers[0].add_attr(Attribute::Bold);
+  skin.headers[2].set_fg(Color::Red);
+  skin.headers[2].add_attr(Attribute::Bold);
+  skin.inline_code.set_fg(Color::Green);
+  // this doesn't work...
+  //skin.code_block.set_bg(Color::Yellow);
+  skin
+}
+
 impl RuleFormatter for PrettyFormatter {
   fn format(rules: &mut [Rule]) -> Result<String, &'static str> {
     match rules {
@@ -63,12 +78,24 @@ impl RuleFormatter for PrettyFormatter {
       // Certain rule name is specified.
       // Print its documentation richly.
       [rule] => {
-        let docs = if rule.docs.is_empty() {
-          "documentation not available"
+        let skin = make_skin();
+        let res = if rule.docs.is_empty() {
+          skin
+            .term_text(&format!(
+              "documentation for `{}` not available",
+              rule.code
+            ))
+            .to_string()
         } else {
-          rule.docs
+          skin
+            .term_text(&format!(
+              "# {code}\n\n{docs}",
+              code = rule.code,
+              docs = rule.docs
+            ))
+            .to_string()
         };
-        Ok(format!("- {code}\n\n{docs}", code = rule.code, docs = docs))
+        Ok(res)
       }
 
       // No rule name is specified.

--- a/examples/dlint/rules.rs
+++ b/examples/dlint/rules.rs
@@ -1,3 +1,4 @@
+// Copyright 2020-2021 the Deno authors. All rights reserved. MIT license.
 use crate::color::Colorize;
 use deno_lint::rules::get_all_rules;
 use serde::Serialize;

--- a/examples/dlint/rules.rs
+++ b/examples/dlint/rules.rs
@@ -56,30 +56,36 @@ impl RuleFormatter for JsonFormatter {
 
 impl RuleFormatter for PrettyFormatter {
   fn format(rules: &mut [Rule]) -> Result<String, &'static str> {
-    if rules.is_empty() {
-      return Err("Rule not found!");
-    }
+    match rules {
+      // Unknown rule name is specified.
+      [] => Err("Rule not found!"),
 
-    if rules.len() == 1 {
-      let rule = &rules[0];
-      let docs = if rule.docs.is_empty() {
-        "documentation not available"
-      } else {
-        rule.docs
-      };
-      return Ok(format!("- {code}\n\n{docs}", code = rule.code, docs = docs));
-    }
-
-    rules.sort_by_key(|r| r.code);
-    let mut list = Vec::with_capacity(1 + rules.len());
-    list.push("Available rules (trailing ✔️ mark indicates it is included in the recommended rule set):".to_string());
-    list.extend(rules.iter().map(|r| {
-      let mut s = format!(" - {}", r.code);
-      if r.tags.contains(&"recommended") {
-        s += " ✔️";
+      // Certain rule name is specified.
+      // Print its documentation richly.
+      [rule] => {
+        let docs = if rule.docs.is_empty() {
+          "documentation not available"
+        } else {
+          rule.docs
+        };
+        Ok(format!("- {code}\n\n{docs}", code = rule.code, docs = docs))
       }
-      s
-    }));
-    Ok(list.join("\n"))
+
+      // No rule name is specified.
+      // Print the list of all rules.
+      rules => {
+        rules.sort_by_key(|r| r.code);
+        let mut list = Vec::with_capacity(1 + rules.len());
+        list.push("Available rules (trailing ✔️ mark indicates it is included in the recommended rule set):".to_string());
+        list.extend(rules.iter().map(|r| {
+          let mut s = format!(" - {}", r.code);
+          if r.tags.contains(&"recommended") {
+            s += " ✔️";
+          }
+          s
+        }));
+        Ok(list.join("\n"))
+      }
+    }
   }
 }

--- a/src/rules/no_deprecated_deno_api.rs
+++ b/src/rules/no_deprecated_deno_api.rs
@@ -52,12 +52,12 @@ removed from the namespace in the future.
 - `Deno.iter`
 - `Deno.iterSync`
 
-**Custom Inspector API**
-- `Deno.customInspect`
-
 The IO APIs are already available in `std/io`, so replace these deprecated ones
 with alternatives from `std/io`.
 For more detail, see [the tracking issue](https://github.com/denoland/deno/issues/9795).
+
+**Custom Inspector API**
+- `Deno.customInspect`
 
 `Deno.customInspect` was deprecated in favor of
 `Symbol.for("Deno.customInspect")`. Replace the usages with this symbol

--- a/src/rules/no_deprecated_deno_api.rs
+++ b/src/rules/no_deprecated_deno_api.rs
@@ -65,6 +65,7 @@ expression. See [deno#9294](https://github.com/denoland/deno/issues/9294)
 for more details.
 
 ### Invalid:
+
 ```typescript
 // buffer
 const a = Deno.Buffer();
@@ -90,6 +91,7 @@ class A {
 ```
 
 ### Valid:
+
 ```typescript
 // buffer
 import { Buffer } from "https://deno.land/std/io/buffer.ts";


### PR DESCRIPTION
This PR adds a feature that each rule documentation is printed to the terminal with syntax highlight. If this turns out to work fine, we'll add it to `deno lint` as well (https://github.com/denoland/deno/issues/8227).

Current screenshot:
![image](https://user-images.githubusercontent.com/23649474/123664241-2004f800-d872-11eb-941c-adfd8e633f27.png)

- [x] use the same colorings as `deno repl` and `deno doc` (ref: https://github.com/denoland/deno/blob/main/cli/tools/repl.rs#L251)
- [x] add syntax highlight to JS/TS code
- [x] check if it's tty