### PR TITLE
refactor docs to be rendered much better

### DIFF
--- a/examples/dlint/color.rs
+++ b/examples/dlint/color.rs
@@ -73,7 +73,10 @@ impl Colorize for markdown::Block {
                           ansi_term::Color::Yellow
                             .paint(&line[span])
                             .to_string()
-                        } else if ident == *"async" || ident == *"of" {
+                        } else if matches!(
+                          ident.as_ref(),
+                          "async" | "of" | "enum" | "type" | "interface"
+                        ) {
                           ansi_term::Color::Cyan.paint(&line[span]).to_string()
                         } else {
                           line[span].to_string()

--- a/examples/dlint/color.rs
+++ b/examples/dlint/color.rs
@@ -11,7 +11,7 @@ impl Colorize for markdown::Block {
   fn colorize(self) -> String {
     use markdown::Block::*;
     match self {
-      Header(spans, level) if level == 1 => {
+      Header(spans, 1) => {
         let style = ansi_term::Style::new()
           .bold()
           .underline()
@@ -19,11 +19,19 @@ impl Colorize for markdown::Block {
           .fg(ansi_term::Color::Purple);
         style.paint(spans.colorize()).to_string().linebreak()
       }
-      Header(spans, _level) => {
+      Header(spans, 2 | 3) => {
         let style = ansi_term::Style::new()
           .bold()
           .underline()
           .fg(ansi_term::Color::Purple);
+        style.paint(spans.colorize()).to_string().linebreak()
+      }
+      Header(spans, 4) => {
+        let style = ansi_term::Style::new().bold().fg(ansi_term::Color::Purple);
+        style.paint(spans.colorize()).to_string().linebreak()
+      }
+      Header(spans, _level) => {
+        let style = ansi_term::Style::new().fg(ansi_term::Color::Purple);
         style.paint(spans.colorize()).to_string().linebreak()
       }
       Paragraph(spans) => spans.colorize().linebreak(),

--- a/src/rules/adjacent_overload_signatures.rs
+++ b/src/rules/adjacent_overload_signatures.rs
@@ -53,7 +53,7 @@ impl LintRule for AdjacentOverloadSignatures {
 Overloaded signatures which are not next to each other can lead to code which is hard to read and maintain.
 
 ### Invalid:
-(bar is declared in-between foo overloads)
+(`bar` is declared in-between `foo` overloads)
 ```typescript
 type FooType = {
   foo(s: string): void;
@@ -85,7 +85,7 @@ export function bar(): void {}
 export function foo(sn: string | number): void {}
 ```
 ### Valid:
-(bar is declared after foo)
+(`bar` is declared after `foo`)
 ```typescript
 type FooType = {
   foo(s: string): void;

--- a/src/rules/ban_untagged_todo.rs
+++ b/src/rules/ban_untagged_todo.rs
@@ -45,7 +45,7 @@ impl LintRule for BanUntaggedTodo {
   }
 
   fn docs(&self) -> &'static str {
-    r#"Requires TODOs to be annotated with either a user tag (@user) or an issue reference (#issue).
+    r#"Requires TODOs to be annotated with either a user tag (`@user`) or an issue reference (`#issue`).
 
 TODOs without reference to a user or an issue become stale with no easy way to get more information.
 

--- a/src/rules/camelcase.rs
+++ b/src/rules/camelcase.rs
@@ -49,13 +49,17 @@ impl LintRule for Camelcase {
 
 Consistency in a code base is key for readability and maintainability.  This rule
 enforces variable declarations and object property names which you create to be
-in camelCase.  Of note:
+in camelCase.
+
+Of note:
+
 * `_` is allowed at the start or end of a variable
 * All uppercase variable names (e.g. constants) may have `_` in their name
 * If you have to use a snake_case key in an object for some reasons, wrap it in quotation mark
 * This rule also applies to variables imported or exported via ES modules, but not to object properties of those variables
-    
+
 ### Invalid:
+
 ```typescript
 let first_name = "Ichigo";
 const obj1 = { last_name: "Hoshimiya" };
@@ -79,6 +83,7 @@ interface snake_case_interface { some_property: number; }
 ```
 
 ### Valid:
+
 ```typescript
 let firstName = "Ichigo";
 const FIRST_NAME = "Ichigo";

--- a/src/rules/default_param_last.rs
+++ b/src/rules/default_param_last.rs
@@ -56,12 +56,14 @@ which is confusing and error prone.  Specifying them last allows them to be left
 out without changing the semantics of the other parameters.
 
 ### Invalid:
+
 ```typescript
 function f(a = 2, b) {}
 function f(a = 5, b, c = 5) {}
 ```
-    
+
 ### Valid:
+
 ```typescript
 function f() {}
 function f(a) {}

--- a/src/rules/eqeqeq.rs
+++ b/src/rules/eqeqeq.rs
@@ -53,16 +53,18 @@ instead of the more error prone `==` and `!=` operators.
 
 `===` and `!==` ensure the comparators are of the same type as well as the same
 value.  On the other hand `==` and `!=` do type coercion before value checking
-which can lead to unexpected results.  For example `5 == "5"` is true, while
-`5 === "5"` is false.
+which can lead to unexpected results.  For example `5 == "5"` is `true`, while
+`5 === "5"` is `false`.
 
 ### Invalid:
+
 ```typescript
 if (a == 5) {}
 if ("hello world" != input) {}
 ```
 
 ### Valid:
+
 ```typescript
 if (a === 5) {}
 if ("hello world" !== input) {}

--- a/src/rules/explicit_function_return_type.rs
+++ b/src/rules/explicit_function_return_type.rs
@@ -46,18 +46,20 @@ impl LintRule for ExplicitFunctionReturnType {
     r#"Requires all functions to have explicit return types.
 
 Explicit return types have a number of advantages including easier to understand
-code and better type safety.  It is clear from the signature what the return 
+code and better type safety.  It is clear from the signature what the return
 type of the function (if any) will be.
 
 ### Invalid:
+
 ```typescript
 function someCalc() { return 2*2; }
 function anotherCalc() { return; }
 ```
-    
+
 ### Valid:
+
 ```typescript
-function someCalc(): number { return 2*2; }
+function someCalc(): number { return 2 * 2; }
 function anotherCalc(): void { return; }
 ```
 "#

--- a/src/rules/explicit_module_boundary_types.rs
+++ b/src/rules/explicit_module_boundary_types.rs
@@ -63,12 +63,13 @@ it very clear to any users of the module how to supply inputs and handle
 outputs in a type safe manner.
 
 ### Invalid:
+
 ```typescript
 // Missing return type (e.g. void)
 export function printDoc(doc: string, doubleSided: boolean) { return; }
 
 // Missing argument type (e.g. `arg` is of type string)
-export var arrowFn = (arg): string => `hello ${arg}`;
+export const arrowFn = (arg): string => `hello ${arg}`;
 
 // Missing return type (e.g. boolean)
 export function isValid() {
@@ -77,12 +78,13 @@ export function isValid() {
 ```
 
 ### Valid:
+
 ```typescript
 // Typed input parameters and return value
 export function printDoc(doc: string, doubleSided: boolean): void { return; }
 
 // Input of type string and a return value of type string
-export var arrowFn = (arg: string): string => `hello ${arg}`;
+export const arrowFn = (arg: string): string => `hello ${arg}`;
 
 // Though lacking a return type, this is valid as it is not exported
 function isValid() {

--- a/src/rules/for_direction.rs
+++ b/src/rules/for_direction.rs
@@ -47,15 +47,17 @@ impl LintRule for ForDirection {
 
 Incrementing `for` loop control variables in the wrong direction leads to infinite
 loops.  This can occur through incorrect initialization, bad continuation step logic
-or wrong direction incrementing of the loop control variable.  
+or wrong direction incrementing of the loop control variable.
 
 ### Invalid:
+
 ```typescript
 // Infinite loop
 for(let i = 0; i < 2; i--) {}
 ```
 
 ### Valid:
+
 ```typescript
 for(let i = 0; i < 2; i++) {}
 ```

--- a/src/rules/getter_return.rs
+++ b/src/rules/getter_return.rs
@@ -65,27 +65,29 @@ Getter functions return the value of a property.  If the function returns no
 value then this contract is broken.
 
 ### Invalid:
+
 ```typescript
-let foo = { 
+let foo = {
   get bar() {}
 };
 
-class Person { 
+class Person {
   get name() {}
 }
 ```
-    
+
 ### Valid:
+
 ```typescript
-let foo = { 
-  get bar() { 
-    return true; 
+let foo = {
+  get bar() {
+    return true;
   }
 };
 
-class Person { 
-  get name() { 
-    return "alice"; 
+class Person {
+  get name() {
+    return "alice";
   }
 }
 ```

--- a/src/rules/no_array_constructor.rs
+++ b/src/rules/no_array_constructor.rs
@@ -42,8 +42,8 @@ impl LintRule for NoArrayConstructor {
     r#"Enforce conventional usage of array construction
 
 Array construction is conventionally done via literal notation such as `[]` or
-`[1,2,3]`.  Using the `new Array()` is discouraged as is `new Array(1,2,3)`. There
-are two reasons for this.  The first is that a single supplied argument defines
+`[1, 2, 3]`.  Using the `new Array()` is discouraged as is `new Array(1, 2, 3)`.
+There are two reasons for this.  The first is that a single supplied argument defines
 the array length, while multiple arguments instead populate the array of no fixed
 size.  This confusion is avoided when pre-populated arrays are only created using
 literal notation.  The second argument to avoiding the `Array` constructor is that
@@ -53,18 +53,20 @@ The one exception to this rule is when creating a new array of fixed size, e.g.
 `new Array(6)`.  This is the conventional way to create arrays of fixed length.
 
 ### Invalid:
+
 ```typescript
 // This is 4 elements, not a size 100 array of 3 elements
 const a = new Array(100, 1, 2, 3);
 
 const b = new Array(); // use [] instead
 ```
-    
+
 ### Valid:
+
 ```typescript
 const a = new Array(100);
 const b = [];
-const c = [1,2,3];
+const c = [1, 2, 3];
 ```
 "#
   }

--- a/src/rules/no_async_promise_executor.rs
+++ b/src/rules/no_async_promise_executor.rs
@@ -41,7 +41,7 @@ impl LintRule for NoAsyncPromiseExecutor {
   fn docs(&self) -> &'static str {
     r#"Requires that async promise executor functions are not used
 
-Promise constructors take an executor function as an argument with `resolve` and 
+Promise constructors take an executor function as an argument with `resolve` and
 `reject` parameters that can be used to control the state of the created Promise.
 This function is allowed to be async but this is generally not a good idea for
 several reasons:
@@ -55,12 +55,14 @@ Promise constructor can be reduced, extracting the async code and changing it to
 be synchronous.
 
 ### Invalid:
+
 ```typescript
 new Promise(async function(resolve, reject) {});
 new Promise(async (resolve, reject) => {});
 ```
-    
+
 ### Valid:
+
 ```typescript
 new Promise(function(resolve, reject) {});
 new Promise((resolve, reject) => {});

--- a/src/rules/no_case_declarations.rs
+++ b/src/rules/no_case_declarations.rs
@@ -51,41 +51,43 @@ errors.  The solution is to ensure each `case` or `default` block is wrapped in
 brackets to scope limit the declarations.
 
 ### Invalid:
+
 ```typescript
 switch (choice) {
   // `let`, `const`, `function` and `class` are scoped the entire switch statement here
   case 1:
-      let a = "choice 1";
-      break;
+    let a = "choice 1";
+    break;
   case 2:
-      const b = "choice 2";
-      break;
+    const b = "choice 2";
+    break;
   case 3:
-      function f() { return "choice 3"; }
-      break;
+    function f() { return "choice 3"; }
+    break;
   default:
-      class C {}
+    class C {}
 }
 ```
 
 ### Valid:
+
 ```typescript
 switch (choice) {
   // The following `case` and `default` clauses are wrapped into blocks using brackets
   case 1: {
-      let a = "choice 1";
-      break;
+    let a = "choice 1";
+    break;
   }
   case 2: {
-      const b = "choice 2";
-      break;
+    const b = "choice 2";
+    break;
   }
   case 3: {
-      function f() { return "choice 3"; }
-      break;
+    function f() { return "choice 3"; }
+    break;
   }
   default: {
-      class C {}
+    class C {}
   }
 }
 ```
@@ -160,7 +162,7 @@ switch (foo) {
   }
   case 4: {
     class Foobar {
-      
+
     }
     break;
   }
@@ -269,7 +271,7 @@ switch (fncase) {
 switch (classcase) {
   case 1:
     class Cl {
-      
+
     }
     break;
 }
@@ -285,7 +287,7 @@ switch (classcase) {
 switch (classcase) {
   default:
     class Cl {
-      
+
     }
     break;
 }

--- a/src/rules/no_class_assign.rs
+++ b/src/rules/no_class_assign.rs
@@ -41,7 +41,7 @@ impl LintRule for NoClassAssign {
   fn docs(&self) -> &'static str {
     r#"Disallows modifying variables of class declarations
 
-Declaring a class such as `class A{}`, creates a variable `A`.  Like any variable
+Declaring a class such as `class A {}`, creates a variable `A`.  Like any variable
 this can be modified or reassigned. In most cases this is a mistake and not what
 was intended.
 
@@ -50,7 +50,7 @@ was intended.
 class A {}
 A = 0;  // reassigning the class variable itself
 ```
-    
+
 ### Valid:
 ```typescript
 class A{}

--- a/src/rules/no_compare_neg_zero.rs
+++ b/src/rules/no_compare_neg_zero.rs
@@ -58,11 +58,13 @@ impl LintRule for NoCompareNegZero {
 Comparing a value directly against negative may not work as expected as it will also pass for non-negative zero (i.e. `0` and `+0`). Explicit comparison with negative zero can be performed using `Object.is`.
 
 ### Invalid:
+
 ```typescript
 if (x === -0) {}
 ```
 
 ### Valid:
+
 ```typescript
 if (x === 0) {}
 

--- a/src/rules/no_cond_assign.rs
+++ b/src/rules/no_cond_assign.rs
@@ -57,12 +57,14 @@ impl LintRule for NoCondAssign {
 Use of the assignment operator within a conditional statement is often the result of mistyping the equality operator, `==`. If an assignment within a conditional statement is required then this rule allows it by wrapping the assignment in parentheses.
 
 ### Invalid:
+
 ```typescript
-var x;
+let x;
 if (x = 0) {
-  var b = 1;
+  let b = 1;
 }
 ```
+
 ```typescript
 function setHeight(someNode) {
   do {
@@ -72,12 +74,14 @@ function setHeight(someNode) {
 ```
 
 ### Valid:
+
 ```typescript
-var x;
+let x;
 if (x === 0) {
-  var b = 1;
+  let b = 1;
 }
 ```
+
 ```typescript
 function setHeight(someNode) {
   do {

--- a/src/rules/no_const_assign.rs
+++ b/src/rules/no_const_assign.rs
@@ -56,6 +56,7 @@ impl LintRule for NoConstAssign {
 Modifying a variable declared as `const` will result in a runtime error.
 
 ### Invalid:
+
 ```typescript
 const a = 0;
 a = 1;
@@ -65,6 +66,7 @@ a++;
 ```
 
 ### Valid:
+
 ```typescript
 const a = 0;
 const b = a + 1;

--- a/src/rules/no_constant_condition.rs
+++ b/src/rules/no_constant_condition.rs
@@ -56,6 +56,7 @@ Using a constant expression in a conditional test is often either a mistake or a
 temporary situation introduced during development and is not ready for production.
 
 ### Invalid:
+
 ```typescript
 if (true) {}
 if (2) {}
@@ -63,6 +64,7 @@ do {} while (x = 2);  // infinite loop
 ```
 
 ### Valid:
+
 ```typescript
 if (x) {}
 if (x === 0) {}

--- a/src/rules/no_control_regex.rs
+++ b/src/rules/no_control_regex.rs
@@ -62,8 +62,9 @@ impl LintRule for NoControlRegex {
 Control characters are invisible characters in the ASCII range of 0-31.  It is
 uncommon to use these in a regular expression and more often it is a mistake
 in the regular expression.
-    
+
 ### Invalid:
+
 ```typescript
 // Examples using ASCII (31) Carriage Return (hex x0d)
 const pattern1 = /\x0d/;
@@ -73,6 +74,7 @@ const pattern4 = new RegExp("\\u000d");
 ```
 
 ### Valid:
+
 ```typescript
 // Examples using ASCII (32) Space (hex x20)
 const pattern1 = /\x20/;

--- a/src/rules/no_debugger.rs
+++ b/src/rules/no_debugger.rs
@@ -54,8 +54,9 @@ impl LintRule for NoDebugger {
 environment and start the debugger at the statement.  Modern debuggers and tooling
 no longer need this statement and leaving it in can cause the execution of your
 code to stop in production.
-    
+
 ### Invalid:
+
 ```typescript
 function isLongString(x: string) {
   debugger;
@@ -64,6 +65,7 @@ function isLongString(x: string) {
 ```
 
 ### Valid:
+
 ```typescript
 function isLongString(x: string) {
   return x.length > 100;  // set breakpoint here instead

--- a/src/rules/no_delete_var.rs
+++ b/src/rules/no_delete_var.rs
@@ -53,25 +53,27 @@ impl LintRule for NoDeleteVar {
     r#"Disallows the deletion of variables
 
 `delete` is used to remove a property from an object.  Variables declared via
-`var`, `let` and `const` cannot be deleted (`delete` will return false).  Setting
+`var`, `let` and `const` cannot be deleted (`delete` will return `false`).  Setting
 `strict` mode on will raise a syntax error when attempting to delete a variable.
-    
+
 ### Invalid:
+
 ```typescript
 const a = 1;
 let b = 2;
-var c = 3;
+let c = 3;
 delete a; // would return false
 delete b; // would return false
 delete c; // would return false
 ```
 
 ### Valid:
+
 ```typescript
-var obj = {
+let obj = {
   a: 1,
 };
-delete obj.a; // returns true;
+delete obj.a; // return true
 ```
 "#
   }

--- a/src/rules/no_dupe_args.rs
+++ b/src/rules/no_dupe_args.rs
@@ -58,8 +58,9 @@ impl LintRule for NoDupeArgs {
 
 If you supply multiple arguments of the same name to a function, the last instance
 will shadow the preceding one(s).  This is most likely an unintentional typo.
-    
+
 ### Invalid:
+
 ```typescript
 function withDupes(a, b, a) {
   console.log("I'm the value of the second a:", a);
@@ -67,6 +68,7 @@ function withDupes(a, b, a) {
 ```
 
 ### Valid:
+
 ```typescript
 function withoutDupes(a, b, c) {
   console.log("I'm the value of the first (and only) a:", a);

--- a/src/rules/no_dupe_class_members.rs
+++ b/src/rules/no_dupe_class_members.rs
@@ -56,8 +56,9 @@ impl LintRule for NoDupeClassMembers {
 
 Declaring a function of the same name twice in a class will cause the previous
 declaration(s) to be overwritten, causing unexpected behaviors.
-    
+
 ### Invalid:
+
 ```typescript
 class Foo {
   bar() {}
@@ -66,6 +67,7 @@ class Foo {
 ```
 
 ### Valid:
+
 ```typescript
 class Foo {
   bar() {}

--- a/src/rules/no_dupe_else_if.rs
+++ b/src/rules/no_dupe_else_if.rs
@@ -58,8 +58,9 @@ impl LintRule for NoDupeElseIf {
 When you reuse a condition in an `if`/`else if` statement, the duplicate condition
 will never be reached (without unusual side-effects) meaning this is almost always
 a bug.
-    
+
 ### Invalid:
+
 ```typescript
 if (a) {}
 else if (b) {}
@@ -71,6 +72,7 @@ else if (a === 5) {} // duplicate of condition above
 ```
 
 ### Valid:
+
 ```typescript
 if (a) {}
 else if (b) {}

--- a/src/rules/no_dupe_keys.rs
+++ b/src/rules/no_dupe_keys.rs
@@ -58,29 +58,34 @@ impl LintRule for NoDupeKeys {
 Setting the same key multiple times in an object literal will override other assignments to that key and can cause unexpected behaviour.
 
 ### Invalid:
+
 ```typescript
 const foo = {
   bar: "baz",
-  bar: "qux"
+  bar: "qux",
 };
 ```
+
 ```typescript
 const foo = {
   "bar": "baz",
-  bar: "qux"
+  bar: "qux",
 };
 ```
+
 ```typescript
 const foo = {
   0x1: "baz",
-  1: "qux"
+  1: "qux",
 };
 ```
+
 ### Valid:
+
 ```typescript
-var foo = {
+const foo = {
   bar: "baz",
-  quxx: "qux"
+  quxx: "qux",
 };
 ```"#
   }

--- a/src/rules/no_duplicate_case.rs
+++ b/src/rules/no_duplicate_case.rs
@@ -54,16 +54,17 @@ impl LintRule for NoDuplicateCase {
 
 When you reuse a case test expression in a `switch` statement, the duplicate case will
 never be reached meaning this is almost always a bug.
-    
+
 ### Invalid:
+
 ```typescript
 const someText = "a";
 switch (someText) {
-  case "a":
+  case "a": // (1)
     break;
   case "b":
     break;
-  case "a": // duplicate test expression
+  case "a": // duplicate of (1)
     break;
   default:
     break;
@@ -71,6 +72,7 @@ switch (someText) {
 ```
 
 ### Valid:
+
 ```typescript
 const someText = "a";
 switch (someText) {

--- a/src/rules/no_empty.rs
+++ b/src/rules/no_empty.rs
@@ -40,47 +40,37 @@ impl LintRule for NoEmpty {
 Empty block statements are legal but often represent that something was missed and can make code less readable. This rule ignores block statements that only contain comments. This rule also ignores empty constructors and function bodies (including arrow functions), which are covered by the `no-empty-function` rule.
 
 ### Invalid:
+
 ```typescript
-if (foo) {
-}
-```
-```typescript
-while (foo) {
-}
-```
-```typescript
-switch(foo) {
-}
-```
-```typescript
+if (foo) {}
+
+while (foo) {}
+
+switch(foo) {}
+
 try {
   doSomething();
-} catch(ex) {
-
-} finally {
-
-}
+} catch(e) {}
+finally {}
 ```
 
 ### Valid:
+
 ```typescript
 if (foo) {
   // empty
 }
-```
-```typescript
+
 while (foo) {
   /* empty */
 }
-```
-```typescript
+
 try {
   doSomething();
-} catch (ex) {
+} catch (e) {
   // continue regardless of error
 }
-```
-```typescript
+
 try {
   doSomething();
 } finally {

--- a/src/rules/no_empty_character_class.rs
+++ b/src/rules/no_empty_character_class.rs
@@ -44,14 +44,16 @@ impl LintRule for NoEmptyCharacterClass {
 Regular expression character classes are a series of characters in brackets, e.g. `[abc]`.
 if nothing is supplied in the brackets it will not match anything which is likely
 a typo or mistake.
-    
+
 ### Invalid:
+
 ```typescript
 /^abc[]/.test("abcdefg");  // false, as `d` does not match an empty character class
 "abcdefg".match(/^abc[]/); // null
 ```
 
 ### Valid:
+
 ```typescript
 // Without a character class
 /^abc/.test("abcdefg"); // true
@@ -59,7 +61,8 @@ a typo or mistake.
 
 // With a valid character class
 /^abc[a-z]/.test("abcdefg"); // true
-"abcdefg".match(/^abc[a-z]/); // ["abcd"]```
+"abcdefg".match(/^abc[a-z]/); // ["abcd"]
+```
 "#
   }
 }

--- a/src/rules/no_empty_interface.rs
+++ b/src/rules/no_empty_interface.rs
@@ -62,14 +62,16 @@ another interface, in which case the supertype can be used, or it does not
 extend a supertype in which case it is the equivalent to an empty object.  This
 rule will capture these situations as either unnecessary code or a mistaken
 empty implementation.
-    
+
 ### Invalid:
+
 ```typescript
 interface Foo {}
 interface Foo extends Bar {}
 ```
 
 ### Valid:
+
 ```typescript
 interface Foo {
   name: string;

--- a/src/rules/no_empty_pattern.rs
+++ b/src/rules/no_empty_pattern.rs
@@ -38,14 +38,15 @@ impl LintRule for NoEmptyPattern {
   }
 
   fn docs(&self) -> &'static str {
-    r#"Disallows the use of empty patterns in destructuring 
+    r#"Disallows the use of empty patterns in destructuring
 
 In destructuring, it is possible to use empty patterns such as `{}` or `[]` which
 have no effect, most likely not what the author intended.
-    
+
 ### Invalid:
+
 ```typescript
-// In these examples below, {} and [] are not object literals or empty arrays, 
+// In these examples below, {} and [] are not object literals or empty arrays,
 // but placeholders for destructured variable names
 const {} = someObj;
 const [] = someArray;
@@ -56,6 +57,7 @@ function myFunc([]) {}
 ```
 
 ### Valid:
+
 ```typescript
 const {a} = someObj;
 const [a] = someArray;

--- a/src/rules/no_eval.rs
+++ b/src/rules/no_eval.rs
@@ -39,13 +39,14 @@ impl LintRule for NoEval {
   }
 
   fn docs(&self) -> &'static str {
-    r#"Disallows the use of `eval` 
+    r#"Disallows the use of `eval`
 
 `eval` is a potentially dangerous function which can open your code to a number
 of security vulnerabilities.  In addition to being slow, `eval` is also often
 unnecessary with better solutions available.
-    
+
 ### Invalid:
+
 ```typescript
 const obj = { x: "foo" };
 const key = "x",
@@ -53,6 +54,7 @@ const value = eval("obj." + key);
 ```
 
 ### Valid:
+
 ```typescript
 const obj = { x: "foo" };
 const value = obj[x];

--- a/src/rules/no_ex_assign.rs
+++ b/src/rules/no_ex_assign.rs
@@ -48,12 +48,13 @@ impl LintRule for NoExAssign {
   }
 
   fn docs(&self) -> &'static str {
-    r#"Disallows the reassignment of exception parameters 
+    r#"Disallows the reassignment of exception parameters
 
 There is generally no good reason to reassign an exception parameter.  Once
 reassigned the code from that point on has no reference to the error anymore.
-    
+
 ### Invalid:
+
 ```typescript
 try {
   someFunc();
@@ -64,6 +65,7 @@ try {
 ```
 
 ### Valid:
+
 ```typescript
 try {
   someFunc();

--- a/src/rules/no_explicit_any.rs
+++ b/src/rules/no_explicit_any.rs
@@ -36,22 +36,24 @@ impl LintRule for NoExplicitAny {
   }
 
   fn docs(&self) -> &'static str {
-    r#"Disallows use of the `any` type 
+    r#"Disallows use of the `any` type
 
 Use of the `any` type disables the type check system around that variable,
 defeating the purpose of Typescript which is to provide type safe code.
 Additionally, the use of `any` hinders code readability, since it is not
 immediately clear what type of value is being referenced.  It is better to be
-explicit about all types.  For a more type-safe alternative to `any`, use 
+explicit about all types.  For a more type-safe alternative to `any`, use
 `unknown` if you are unable to choose a more specific type.
 
 ### Invalid:
+
 ```typescript
 const someNumber: any = "two";
 function foo(): any { return undefined; }
 ```
 
 ### Valid:
+
 ```typescript
 const someNumber: string = "two";
 function foo(): undefined { return undefined; }

--- a/src/rules/no_extra_boolean_cast.rs
+++ b/src/rules/no_extra_boolean_cast.rs
@@ -56,7 +56,7 @@ impl LintRule for NoExtraBooleanCast {
   }
 
   fn docs(&self) -> &'static str {
-    r#"Disallows unnecessary boolean casts 
+    r#"Disallows unnecessary boolean casts
 
 In certain contexts, such as `if`, `while` or `for` statements, expressions are
 automatically coerced into a boolean.  Therefore, techniques such as double
@@ -64,18 +64,20 @@ negation (`!!foo`) or casting (`Boolean(foo)`) are unnecessary and produce the
 same result as without the negation or casting.
 
 ### Invalid:
+
 ```typescript
 if (!!foo) {}
 if (Boolean(foo)) {}
-while(!!foo) {}
-for(;Boolean(foo);) {}
+while (!!foo) {}
+for (;Boolean(foo);) {}
 ```
 
 ### Valid:
+
 ```typescript
 if (foo) {}
-while(foo) {}
-for(;foo;) {}
+while (foo) {}
+for (;foo;) {}
 ```
 "#
   }

--- a/src/rules/no_extra_non_null_assertion.rs
+++ b/src/rules/no_extra_non_null_assertion.rs
@@ -53,14 +53,15 @@ impl LintRule for NoExtraNonNullAssertion {
   fn docs(&self) -> &'static str {
     r#"Disallows unnecessary non-null assertions
 
-Non-null assertions are specified with an `!` saying to the compiler that you 
+Non-null assertions are specified with an `!` saying to the compiler that you
 know this value is not null.  Specifying this operator more than once in a row,
 or in combination with the optional chaining operator (`?`) is confusing and
 unnecessary.
 
 ### Invalid:
+
 ```typescript
-const foo: { str: string } | null = null; 
+const foo: { str: string } | null = null;
 const bar = foo!!.str;
 
 function myFunc(bar: undefined | string) { return bar!!; }
@@ -68,8 +69,9 @@ function anotherFunc(bar?: { str: string }) { return bar!?.str; }
 ```
 
 ### Valid:
+
 ```typescript
-const foo: { str: string } | null = null; 
+const foo: { str: string } | null = null;
 const bar = foo!.str;
 
 function myFunc(bar: undefined | string) { return bar!; }

--- a/src/rules/no_extra_semi.rs
+++ b/src/rules/no_extra_semi.rs
@@ -53,7 +53,7 @@ impl LintRule for NoExtraSemi {
 
 Extra (and unnecessary) semi-colons can cause confusion when reading the code as
 well as making the code less clean.
-    
+
 ### Invalid:
 ```typescript
 const x = 5;;
@@ -62,6 +62,7 @@ function foo() {};
 ```
 
 ### Valid:
+
 ```typescript
 const x = 5;
 

--- a/src/rules/no_fallthrough.rs
+++ b/src/rules/no_fallthrough.rs
@@ -62,8 +62,9 @@ an explicit comment that fallthrough was intentional.  The fallthrough comment
 must contain one of `fallthrough`, `falls through` or `fall through`.
 
 ### Invalid:
+
 ```typescript
-switch(myVar) {
+switch (myVar) {
   case 1:
     console.log('1');
 
@@ -74,8 +75,9 @@ switch(myVar) {
 ```
 
 ### Valid:
+
 ```typescript
-switch(myVar) {
+switch (myVar) {
   case 1:
     console.log('1');
     break;
@@ -86,7 +88,7 @@ switch(myVar) {
 }
 // If myVar = 1, outputs only `1`
 
-switch(myVar) {
+switch (myVar) {
   case 1:
     console.log('1');
     /* falls through */

--- a/src/rules/no_func_assign.rs
+++ b/src/rules/no_func_assign.rs
@@ -56,8 +56,9 @@ impl LintRule for NoFuncAssign {
 Javascript allows for the reassignment of a function definition.  This is
 generally a mistake on the developers part, or poor coding practice as code
 readability and maintainability will suffer.
-    
+
 ### Invalid:
+
 ```typescript
 function foo() {}
 foo = bar;
@@ -71,6 +72,7 @@ function myFunc() {}
 ```
 
 ### Valid:
+
 ```typescript
 function foo() {}
 const someVar = foo;

--- a/src/rules/no_global_assign.rs
+++ b/src/rules/no_global_assign.rs
@@ -68,8 +68,9 @@ impl LintRule for NoGlobalAssign {
 In Javascript, `String` and `Object` for example are native objects.  Like any
 object, they can be reassigned, but it is almost never wise to do so as this
 can lead to unexpected results and difficult to track down bugs.
-    
+
 ### Invalid:
+
 ```typescript
 Object = null;
 undefined = true;

--- a/src/rules/no_import_assign.rs
+++ b/src/rules/no_import_assign.rs
@@ -67,8 +67,9 @@ during code execution will likely result in runtime errors.  It also makes for
 poor code readability and difficult maintenance.
 
 ### Invalid:
+
 ```typescript
-import defaultMod, { namedMod } from './mod.js'; 
+import defaultMod, { namedMod } from './mod.js';
 import * as modNameSpace from './mod2.js';
 
 defaultMod = 0;
@@ -78,8 +79,9 @@ modNameSpace = {};
 ```
 
 ### Valid:
+
 ```typescript
-import defaultMod, { namedMod } from './mod.js'; 
+import defaultMod, { namedMod } from './mod.js';
 import * as modNameSpace from './mod2.js';
 
 // properties of bound imports may be set

--- a/src/rules/no_inferrable_types.rs
+++ b/src/rules/no_inferrable_types.rs
@@ -53,12 +53,13 @@ impl LintRule for NoInferrableTypes {
   fn docs(&self) -> &'static str {
     r#"Disallows easily inferrable types
 
-Variable initializations to javascript primitives (and null) are obvious
+Variable initializations to JavaScript primitives (and `null`) are obvious
 in their type.  Specifying their type can add additional verbosity to the code.
 For example, with `const x: number = 5`, specifying `number` is unnecessary as
 it is obvious that `5` is a number.
-    
+
 ### Invalid:
+
 ```typescript
 const a: bigint = 10n;
 const b: bigint = BigInt(10);
@@ -87,6 +88,7 @@ function fn(s: number = 5, t: boolean = true) {}
 ```
 
 ### Valid:
+
 ```typescript
 const a = 10n;
 const b = BigInt(10);

--- a/src/rules/no_inner_declarations.rs
+++ b/src/rules/no_inner_declarations.rs
@@ -67,19 +67,20 @@ impl LintRule for NoInnerDeclarations {
   fn docs(&self) -> &'static str {
     r#"Disallows variable or function definitions in nested blocks
 
-Function declarations in nested blocks can lead to less readable code and 
-potentially unexpected results due to compatibility issues in different javascript
-runtimes.  This does not apply to named or anonymous functions which are valid
-in a nested block context.
+Function declarations in nested blocks can lead to less readable code and
+potentially unexpected results due to compatibility issues in different
+JavaScript runtimes.  This does not apply to named or anonymous functions which
+are valid in a nested block context.
 
 Variables declared with `var` in nested blocks can also lead to less readable
-code.  Because these variables are hoisted to the module root, it is best to 
+code.  Because these variables are hoisted to the module root, it is best to
 declare them there for clarity.  Note that variables declared with `let` or
 `const` are block scoped and therefore this rule does not apply to them.
-    
+
 ### Invalid:
+
 ```typescript
-if (someBool) { 
+if (someBool) {
   function doSomething() {}
 }
 
@@ -91,6 +92,7 @@ function someFunc(someVal:number): void {
 ```
 
 ### Valid:
+
 ```typescript
 function doSomething() {}
 if (someBool) {}

--- a/src/rules/no_invalid_regexp.rs
+++ b/src/rules/no_invalid_regexp.rs
@@ -45,13 +45,15 @@ impl LintRule for NoInvalidRegexp {
 Specifying an invalid regular expression literal will result in a SyntaxError at
 compile time, however specifying an invalid regular expression string in the RegExp
 constructor will only be discovered at runtime.
-    
+
 ### Invalid:
+
 ```typescript
 const invalidRegExp = new RegExp(')');
 ```
 
 ### Valid:
+
 ```typescript
 const goodRegExp = new RegExp('.');
 ```

--- a/src/rules/no_irregular_whitespace.rs
+++ b/src/rules/no_irregular_whitespace.rs
@@ -108,11 +108,12 @@ impl LintRule for NoIrregularWhitespace {
     r#"Disallows the use of non-space or non-tab whitespace characters
 
 Non-space or non-tab whitespace characters can be very difficult to spot in your
-code as editors will often render them invisibly.  These invisible characters can 
+code as editors will often render them invisibly.  These invisible characters can
 cause issues or unexpected behaviors.  Sometimes these characters are added
 inadvertently through copy/paste or incorrect keyboard shortcuts.
 
 The following characters are disallowed:
+
 ```
 \u000B - Line Tabulation (\v) - <VT>
 \u000C - Form Feed (\f) - <FF>

--- a/src/rules/no_misused_new.rs
+++ b/src/rules/no_misused_new.rs
@@ -59,12 +59,13 @@ impl LintRule for NoMisusedNew {
   }
 
   fn docs(&self) -> &'static str {
-    r#"Disallows defining constructors for interfaces or new for classes
+    r#"Disallows defining `constructor`s for interfaces or `new` for classes
 
-Specifying a constructor for an interface or defining a `new` method for a class
+Specifying a `constructor` for an interface or defining a `new` method for a class
 is incorrect and should be avoided.
-    
+
 ### Invalid:
+
 ```typescript
 class C {
   new(): C;
@@ -76,6 +77,7 @@ interface I {
 ```
 
 ### Valid:
+
 ```typescript
 class C {
   constructor() {}
@@ -216,12 +218,12 @@ mod tests {
     export class Fnv32a extends Fnv32Base<Fnv32a> {
       write(data: Uint8Array): Fnv32a {
         let hash = this.sum32();
-    
+
         data.forEach((c) => {
           hash ^= c;
           hash = mul32(hash, prime32);
         });
-    
+
         this._updateState(hash);
         return this;
       }

--- a/src/rules/no_namespace.rs
+++ b/src/rules/no_namespace.rs
@@ -57,35 +57,31 @@ cases:
 ["ambient" namespaces]: https://www.typescriptlang.org/docs/handbook/namespaces.html#ambient-namespaces
 
 ### Invalid:
+
 ```typescript
 // foo.ts
-
 module mod {}
 namespace ns {}
 ```
 
-```typescript
+```dts
 // bar.d.ts
-
-// all usage of `module` and `namespace` keywords are allowed here
+// all usage of `module` and `namespace` keywords are allowed in `.d.ts`
 ```
 
 ### Valid:
 ```typescript
 // foo.ts
-
 declare global {}
 declare module mod1 {}
 declare module "mod2" {}
 declare namespace ns {}
 ```
 
-```typescript
+```dts
 // bar.d.ts
-
 module mod1 {}
 namespace ns1 {}
-
 declare global {}
 declare module mod2 {}
 declare module "mod3" {}

--- a/src/rules/no_unreachable.rs
+++ b/src/rules/no_unreachable.rs
@@ -42,6 +42,7 @@ impl LintRule for NoUnreachable {
 Because the control flow statements (`return`, `throw`, `break` and `continue`) unconditionally exit a block of code, any statements after them cannot be executed.
 
 ### Invalid:
+
 ```typescript
 function foo() {
   return true;
@@ -93,7 +94,8 @@ function foo() {
     return 1;
   }
 }
-```"#
+```
+"#
   }
 }
 

--- a/src/rules/no_unsafe_finally.rs
+++ b/src/rules/no_unsafe_finally.rs
@@ -65,40 +65,45 @@ impl LintRule for NoUnsafeFinally {
 Use of the control flow statements (`return`, `throw`, `break` and `continue`) overrides the usage of any control flow statements that might have been used in the `try` or `catch` blocks, which is usually not the desired behaviour.
 
 ### Invalid:
+
 ```typescript
 let foo = function() {
   try {
     return 1;
-  } catch(err) {
+  } catch (err) {
     return 2;
   } finally {
     return 3;
   }
 };
 ```
+
 ```typescript
 let foo = function() {
   try {
     return 1;
-  } catch(err) {
+  } catch (err) {
     return 2;
   } finally {
     throw new Error;
   }
 };
 ```
+
 ### Valid:
+
 ```typescript
 let foo = function() {
   try {
     return 1;
-  } catch(err) {
+  } catch (err) {
     return 2;
   } finally {
     console.log("hola!");
   }
 };
-```"#
+```
+"#
   }
 }
 

--- a/src/rules/no_unsafe_negation.rs
+++ b/src/rules/no_unsafe_negation.rs
@@ -48,7 +48,7 @@ impl LintRule for NoUnsafeNegation {
 relational operators.
 
 `!` operators appearing in the left operand of the following operators will
-sometimes cause an unexpected behavior because of the operator precedence: 
+sometimes cause an unexpected behavior because of the operator precedence:
 
 - `in` operator
 - `instanceof` operator
@@ -59,12 +59,14 @@ behaves like `(!key) in someObject`.
 This lint rule warns such usage of `!` operator so it will be less confusing.
 
 ### Invalid:
+
 ```typescript
 if (!key in object) {}
 if (!foo instanceof Foo) {}
 ```
 
 ### Valid:
+
 ```typescript
 if (!(key in object)) {}
 if (!(foo instanceof Foo)) {}

--- a/src/rules/no_unused_labels.rs
+++ b/src/rules/no_unused_labels.rs
@@ -50,6 +50,7 @@ that label is meant to be used, then write a code so that it will be used.
 Otherwise, remove the label.
 
 ### Invalid:
+
 ```typescript
 LABEL1: while (true) {
   console.log(42);
@@ -65,6 +66,7 @@ LABEL3: for (const x of xs) {
 ```
 
 ### Valid:
+
 ```typescript
 LABEL1: while (true) {
   console.log(42);

--- a/src/rules/no_var.rs
+++ b/src/rules/no_var.rs
@@ -38,11 +38,13 @@ impl LintRule for NoVar {
 `const` and `let` keywords ensure the variables defined using these keywords are not accessible outside their block scope. On the other hand, variables defined using `var` keyword are only limited by their function scope.
 
 ### Invalid:
+
 ```typescript
 var foo = "bar";
 ```
 
 ### Valid:
+
 ```typescript
 const foo = 1;
 let bar = 2;

--- a/src/rules/no_with.rs
+++ b/src/rules/no_with.rs
@@ -42,9 +42,10 @@ and compatibility issues. For more details, see [with - JavaScript | MDN].
 [with - JavaScript | MDN]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/with
 
 ### Invalid:
+
 ```typescript
 with (someVar) {
-  console.log('foo');
+  console.log("foo");
 }
 ```
 "#

--- a/src/rules/require_await.rs
+++ b/src/rules/require_await.rs
@@ -67,6 +67,7 @@ In general, the primary reason to use async functions is to use await expression
 If an async function has no await expression, it is most likely an unintentional mistake.
 
 ### Invalid:
+
 ```typescript
 async function f1() {
   doSomething();
@@ -92,6 +93,7 @@ class MyClass {
 ```
 
 ### Valid:
+
 ```typescript
 await asyncFunction();
 

--- a/src/rules/require_yield.rs
+++ b/src/rules/require_yield.rs
@@ -134,7 +134,7 @@ mod tests {
       RequireYield,
       r#"
 function foo() {}
-function* bar() { 
+function* bar() {
   yield "bar";
 }
 function* emptyBar() {}

--- a/src/rules/use_isnan.rs
+++ b/src/rules/use_isnan.rs
@@ -55,32 +55,27 @@ impl LintRule for UseIsNaN {
 
 Because `NaN` is unique in JavaScript by not being equal to anything, including itself, the results of comparisons to `NaN` are confusing:
 
-- `NaN === NaN` or `NaN == NaN` evaluate to false
-- `NaN !== NaN` or `NaN != NaN` evaluate to true
+- `NaN === NaN` or `NaN == NaN` evaluate to `false`
+- `NaN !== NaN` or `NaN != NaN` evaluate to `true`
 
 Therefore, this rule makes you use the `isNaN()` or `Number.isNaN()` to judge the value is `NaN` or not.
 
 ### Invalid:
+
 ```typescript
 if (foo == NaN) {
   // ...
 }
-```
 
-```typescript
 if (foo != NaN) {
   // ...
 }
-```
 
-```typescript
 switch (NaN) {
   case foo:
     // ...
 }
-```
 
-```
 switch (foo) {
   case NaN:
     // ...
@@ -88,17 +83,17 @@ switch (foo) {
 ```
 
 ### Valid:
+
 ```typescript
 if (isNaN(foo)) {
   // ...
 }
-```
 
-```typescript
 if (!isNaN(foo)) {
   // ...
 }
-```"#
+```
+"#
   }
 }
 

--- a/src/rules/valid_typeof.rs
+++ b/src/rules/valid_typeof.rs
@@ -39,6 +39,7 @@ impl LintRule for ValidTypeof {
     r#"Restricts the use of the `typeof` operator to a specific set of string literals.
 
 When used with a value the `typeof` operator returns one of the following strings:
+
 - `"undefined"`
 - `"object"`
 - `"boolean"`
@@ -51,44 +52,30 @@ When used with a value the `typeof` operator returns one of the following string
 This rule disallows comparison with anything other than one of these string literals when using the `typeof` operator, as this likely represents a typing mistake in the string. The rule also disallows comparing the result of a `typeof` operation with any non-string literal value, such as `undefined`, which can represent an inadvertent use of a keyword instead of a string. This includes comparing against string variables even if they contain one of the above values as this cannot be guaranteed. An exception to this is comparing the results of two `typeof` operations as these are both guaranteed to return on of the above strings.
 
 ### Invalid:
+
 ```typescript
-typeof foo === "strnig"
-```
-```typescript
-typeof foo == "undefimed"
-```
-```typescript
-typeof bar != "nunber"
-```
-```typescript
-typeof bar !== "fucntion"
-```
-```typescript
-typeof foo === undefined
-```
-```typescript
-typeof bar == Object
-```
-```typescript
-typeof baz === anotherVariable
-```
-```typescript
-typeof foo == 5
+// typo
+typeof foo === "strnig";
+typeof foo == "undefimed";
+typeof bar != "nunber";
+typeof bar !== "fucntion";
+
+// compare with non-string literals
+typeof foo === undefined;
+typeof bar == Object;
+typeof baz === anotherVariable;
+typeof foo == 5;
 ```
 
 ### Valid:
+
 ```typescript
-typeof foo === "undefined"
+typeof foo === "undefined";
+typeof bar == "object";
+typeof baz === "string";
+typeof bar === typeof qux;
 ```
-```typescript
-typeof bar == "object"
-```
-```typescript
-typeof baz === "string"
-```
-```typescript
-typeof bar === typeof qux
-```"#
+"#
   }
 }
 


### PR DESCRIPTION
This PR refactors the existing documentation so that they are rendered much better in the terminal.

I looked through how they were rendered in the terminal, and I found:

- some of them were kind of poorly rendered because of extra whitespaces etc.
- some examples adopted unnecessarily inappropriate styles (for example using `var` without a good reason)

In this PR I fixed these things.