### PR TITLE
docs(no-new-symbol): add doc

### DIFF
--- a/src/rules/no_new_symbol.rs
+++ b/src/rules/no_new_symbol.rs
@@ -34,6 +34,32 @@ impl LintRule for NoNewSymbol {
       ProgramRef::Script(ref s) => s.visit_all_with(&DUMMY_NODE, &mut visitor),
     }
   }
+
+  fn docs(&self) -> &'static str {
+    r#"Disallows the use of `new` operators with built-in `Symbol`s
+
+`Symbol`s are created by being called as a function, but we sometimes call it
+with the `new` operator by mistake. This rule detects such wrong usage of the
+`new` operator.
+
+### Invalid:
+
+```typescript
+const foo = new Symbol("foo");
+```
+
+### Valid:
+
+```typescript
+const foo = Symbol("foo");
+
+function func(Symbol: typeof SomeClass) {
+  // This `Symbol` is not built-in one
+  const bar = new Symbol();
+}
+```
+"#
+  }
 }
 
 struct NoNewSymbolVisitor<'c, 'view> {


### PR DESCRIPTION
This commit adds documentation for the `no-new-symbol` rule and fixes behavior for an edge case where `Symbol` is not built-in one but user-defined. 