### PR TITLE
docs(no-obj-calls): add doc

### DIFF
--- a/src/rules/no_obj_calls.rs
+++ b/src/rules/no_obj_calls.rs
@@ -93,14 +93,14 @@ impl<'c, 'view> NoObjCallsVisitor<'c, 'view> {
   }
 
   fn check_callee(&mut self, callee: &Ident, span: Span) {
-    if matches!(callee.sym.as_ref(), "Math" | "JSON" | "Reflect" | "Atomics") {
-      if self.context.scope().var(&callee.to_id()).is_none() {
-        self.context.add_diagnostic(
-          span,
-          "no-obj-calls",
-          get_message(callee.sym.as_ref()),
-        );
-      }
+    if matches!(callee.sym.as_ref(), "Math" | "JSON" | "Reflect" | "Atomics")
+      && self.context.scope().var(&callee.to_id()).is_none()
+    {
+      self.context.add_diagnostic(
+        span,
+        "no-obj-calls",
+        get_message(callee.sym.as_ref()),
+      );
     }
   }
 }

--- a/src/rules/no_obj_calls.rs
+++ b/src/rules/no_obj_calls.rs
@@ -41,6 +41,50 @@ impl LintRule for NoObjCalls {
       ProgramRef::Script(ref s) => visitor.visit_script(s, &DUMMY_NODE),
     }
   }
+
+  fn docs(&self) -> &'static str {
+    r#"Disallows calling built-in global objects like functions
+
+The following built-in objects should not be invoked like functions, even though
+they look like constructors:
+
+- `Math`
+- `JSON`
+- `Reflect`
+- `Atomics`
+
+Calling these as functions would result in runtime errors. This rule statically
+prevents such wrong usage of them.
+
+### Invalid:
+
+```typescript
+const math = Math();
+const newMath = new Math();
+
+const json = JSON();
+const newJSON = new JSON();
+
+const reflect = Reflect();
+const newReflect = new Reflect();
+
+const atomics = Atomics();
+const newAtomics = new Atomics();
+```
+
+### Valid:
+
+```typescript
+const area = (radius: number): number => Math.PI * radius * radius;
+
+const parsed = JSON.parse("{ foo: 42 }");
+
+const x = Reflect.get({ x: 1, y: 2 }, "x");
+
+const first = Atomics.load(foo, 0);
+```
+"#
+  }
 }
 
 struct NoObjCallsVisitor<'c, 'view> {


### PR DESCRIPTION
This commit adds documentation for the `no-obj-calls` rule and fixes behavior for an edge case where target built-in objects are shadowed by users.