### PR TITLE
BREAKING: always enable `ban-unknown-rule-code` and `ban-unused-ignore` & add these docs

### DIFF
--- a/examples/dlint/main.rs
+++ b/examples/dlint/main.rs
@@ -189,9 +189,7 @@ fn run_linter(
 
       let mut linter_builder = LinterBuilder::default()
         .rules(rules)
-        .syntax(determine_syntax(file_path))
-        .lint_unknown_rules(true)
-        .lint_unused_ignore_directives(true);
+        .syntax(determine_syntax(file_path));
 
       for plugin_path in &plugin_paths {
         let js_runner = js::JsRuleRunner::new(plugin_path);

--- a/src/context.rs
+++ b/src/context.rs
@@ -150,6 +150,9 @@ impl<'view> Context<'view> {
     filtered
   }
 
+  /// Lint rule implementation for `ban-unused-ignore`.
+  /// This should be run after all normal rules have been finished because this
+  /// works for diagnostics reported by other rules.
   pub(crate) fn ban_unused_ignore(
     &self,
     specified_rules: &[Box<dyn LintRule>],
@@ -211,6 +214,10 @@ impl<'view> Context<'view> {
     diagnostics
   }
 
+  /// Lint rule implementation for `ban-unknown-rule-code`.
+  /// This should be run after all normal rules have been finished because
+  /// currently we collect the rule codes of plugins as they are run and thus
+  /// there's no way of knowing what are the "known" rule codes beforehand.
   pub(crate) fn ban_unknown_rule_code(&self) -> Vec<LintDiagnostic> {
     let builtin_all_rule_codes: HashSet<&'static str> =
       get_all_rules().into_iter().map(|r| r.code()).collect();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -245,8 +245,13 @@ const _foo = 42;
       src, false, true, // enables `ban-unused-ignore`
     );
 
-    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics.len(), 2);
+
+    // Both `no-explicit-any` and `ban-unused-ignore` are considered "unused"
+    // ignore directives in this case. Remember that `ban-unused-ignore`, if
+    // it's ignored at a line level, doesn't have any effect.
     assert_diagnostic(&diagnostics[0], "ban-unused-ignore", 2, 0, src);
+    assert_diagnostic(&diagnostics[1], "ban-unused-ignore", 2, 0, src);
   }
 
   #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,17 +36,8 @@ mod lint_tests {
   use swc_common::SourceMap;
   use swc_ecmascript::ast::Program;
 
-  fn lint(
-    source: &str,
-    unknown_rules: bool,
-    unused_dir: bool,
-    rules: Vec<Box<dyn LintRule>>,
-  ) -> Vec<LintDiagnostic> {
-    let linter = LinterBuilder::default()
-      .lint_unknown_rules(unknown_rules)
-      .lint_unused_ignore_directives(unused_dir)
-      .rules(rules)
-      .build();
+  fn lint(source: &str, rules: Vec<Box<dyn LintRule>>) -> Vec<LintDiagnostic> {
+    let linter = LinterBuilder::default().rules(rules).build();
 
     let (_, diagnostics) = linter
       .lint("lint_test.ts".to_string(), source.to_string())
@@ -59,15 +50,9 @@ mod lint_tests {
     comments: SingleThreadedComments,
     source_map: Rc<SourceMap>,
     tokens: Vec<TokenAndSpan>,
-    unknown_rules: bool,
-    unused_dir: bool,
     rules: Vec<Box<dyn LintRule>>,
   ) -> Vec<LintDiagnostic> {
-    let linter = LinterBuilder::default()
-      .lint_unknown_rules(unknown_rules)
-      .lint_unused_ignore_directives(unused_dir)
-      .rules(rules)
-      .build();
+    let linter = LinterBuilder::default().rules(rules).build();
 
     let (_, diagnostics) = linter
       .lint_with_ast(
@@ -81,12 +66,8 @@ mod lint_tests {
     diagnostics
   }
 
-  fn lint_recommended_rules(
-    source: &str,
-    unknown_rules: bool,
-    unused_dir: bool,
-  ) -> Vec<LintDiagnostic> {
-    lint(source, unknown_rules, unused_dir, get_recommended_rules())
+  fn lint_recommended_rules(source: &str) -> Vec<LintDiagnostic> {
+    lint(source, get_recommended_rules())
   }
 
   fn lint_recommended_rules_with_ast(
@@ -94,36 +75,24 @@ mod lint_tests {
     comments: SingleThreadedComments,
     source_map: Rc<SourceMap>,
     tokens: Vec<TokenAndSpan>,
-    unknown_rules: bool,
-    unused_dir: bool,
   ) -> Vec<LintDiagnostic> {
-    lint_with_ast(
-      ast,
-      comments,
-      source_map,
-      tokens,
-      unknown_rules,
-      unused_dir,
-      get_recommended_rules(),
-    )
+    lint_with_ast(ast, comments, source_map, tokens, get_recommended_rules())
   }
 
   fn lint_specified_rule<T: LintRule + 'static>(
     source: &str,
-    unknown_rules: bool,
-    unused_dir: bool,
   ) -> Vec<LintDiagnostic> {
-    lint(source, unknown_rules, unused_dir, vec![T::new()])
+    lint(source, vec![T::new()])
   }
 
   #[test]
   fn empty_file() {
-    let diagnostics = lint_recommended_rules("", true, false);
+    let diagnostics = lint_recommended_rules("");
     assert!(diagnostics.is_empty());
   }
 
   #[test]
-  fn warn_unknown_rules() {
+  fn ban_unknown_rule_code() {
     let src = r#"
  // deno-lint-ignore some-rule
  function _foo() {
@@ -131,26 +100,10 @@ mod lint_tests {
    let _bar_foo = true
  }
       "#;
-    let diagnostics = lint_recommended_rules(src, true, false);
+    let diagnostics = lint_recommended_rules(src);
 
     assert_diagnostic(&diagnostics[0], "ban-unknown-rule-code", 2, 1, src);
     assert_diagnostic(&diagnostics[1], "ban-unknown-rule-code", 4, 3, src);
-  }
-
-  #[test]
-  fn ignore_unknown_rules() {
-    let diagnostics = lint_recommended_rules(
-      r#"
- // deno-lint-ignore some-rule
- function _foo() {
-   // pass
- }
-      "#,
-      false,
-      false,
-    );
-
-    assert_eq!(diagnostics.len(), 0);
   }
 
   #[test]
@@ -161,15 +114,13 @@ mod lint_tests {
 // deno-lint-ignore no-explicit-any
 const fooBar: any = 42;
       "#,
-      true,
-      false,
     );
 
     assert!(diagnostics.is_empty());
   }
 
   #[test]
-  fn ban_unused_ignore_enabled() {
+  fn ban_unused_ignore() {
     let src = r#"
  // deno-lint-ignore no-explicit-any
  function _bar(_p: boolean) {
@@ -178,29 +129,11 @@ const fooBar: any = 42;
  }
       "#;
 
-    let diagnostics = lint_recommended_rules(
-      src, false, true, // enables `ban-unused-ignore`
-    );
+    let diagnostics = lint_recommended_rules(src);
 
     assert_eq!(diagnostics.len(), 2);
     assert_diagnostic(&diagnostics[0], "ban-unused-ignore", 2, 1, src);
     assert_diagnostic(&diagnostics[1], "ban-unused-ignore", 4, 3, src);
-  }
-
-  #[test]
-  fn ban_unused_ignore_disabled() {
-    let diagnostics = lint_recommended_rules(
-      r#"
- // deno-lint-ignore no-explicit-any
- function _bar(_p: boolean) {
-   // pass
- }
-      "#,
-      false,
-      false, // disables `ban-unused-ignore`
-    );
-
-    assert_eq!(diagnostics.len(), 0);
   }
 
   #[test]
@@ -211,8 +144,6 @@ const fooBar: any = 42;
 // deno-lint-ignore no-explicit-any
 const _fooBar = 42;
       "#,
-      false,
-      true, // enables `ban-unused-ignore`
     );
 
     assert!(diagnostics.is_empty());
@@ -227,8 +158,6 @@ const _fooBar = 42;
 // deno-lint-ignore no-explicit-any
 const _foo = 42;
       "#,
-      false,
-      true, // enables `ban-unused-ignore`
     );
 
     assert!(diagnostics.is_empty());
@@ -241,9 +170,7 @@ const _foo = 42;
 // deno-lint-ignore no-explicit-any ban-unused-ignore
 const _foo = 42;
       "#;
-    let diagnostics = lint_recommended_rules(
-      src, false, true, // enables `ban-unused-ignore`
-    );
+    let diagnostics = lint_recommended_rules(src);
 
     assert_eq!(diagnostics.len(), 2);
 
@@ -264,8 +191,6 @@ const _foo = 42;
    // pass
  }
       "#,
-      false,
-      false,
     );
 
     assert_eq!(diagnostics.len(), 0);
@@ -280,9 +205,7 @@ const _foo = 42;
    // pass
  }
       "#;
-    let diagnostics = lint_recommended_rules(
-      src, false, true, // enables `ban-unused-ignore`
-    );
+    let diagnostics = lint_recommended_rules(src);
 
     assert_eq!(diagnostics.len(), 1);
     assert_diagnostic(&diagnostics[0], "ban-unused-ignore", 2, 1, src);
@@ -298,7 +221,7 @@ const _foo = 42;
    // pass
  }
       "#;
-    let diagnostics = lint_recommended_rules(src, false, true);
+    let diagnostics = lint_recommended_rules(src);
 
     assert_eq!(diagnostics.len(), 1);
     assert_diagnostic(&diagnostics[0], "ban-unused-ignore", 4, 1, src);
@@ -307,9 +230,8 @@ const _foo = 42;
   #[test]
   fn empty_file_with_ast() {
     let (ast, comments, source_map, tokens) = parse("");
-    let diagnostics = lint_recommended_rules_with_ast(
-      ast, comments, source_map, tokens, true, false,
-    );
+    let diagnostics =
+      lint_recommended_rules_with_ast(ast, comments, source_map, tokens);
     assert!(diagnostics.is_empty());
   }
 }

--- a/src/rules.rs
+++ b/src/rules.rs
@@ -8,6 +8,7 @@ pub mod ban_types;
 pub mod ban_unknown_rule_code;
 pub mod ban_untagged_ignore;
 pub mod ban_untagged_todo;
+pub mod ban_unused_ignore;
 pub mod camelcase;
 pub mod constructor_super;
 pub mod default_param_last;
@@ -148,6 +149,7 @@ pub fn get_all_rules() -> Vec<Box<dyn LintRule>> {
     ban_unknown_rule_code::BanUnknownRuleCode::new(),
     ban_untagged_ignore::BanUntaggedIgnore::new(),
     ban_untagged_todo::BanUntaggedTodo::new(),
+    ban_unused_ignore::BanUnusedIgnore::new(),
     camelcase::Camelcase::new(),
     constructor_super::ConstructorSuper::new(),
     default_param_last::DefaultParamLast::new(),

--- a/src/rules.rs
+++ b/src/rules.rs
@@ -5,6 +5,7 @@ use dprint_swc_ecma_ast_view::Program as ProgramView;
 pub mod adjacent_overload_signatures;
 pub mod ban_ts_comment;
 pub mod ban_types;
+pub mod ban_unknown_rule_code;
 pub mod ban_untagged_ignore;
 pub mod ban_untagged_todo;
 pub mod camelcase;
@@ -144,6 +145,7 @@ pub fn get_all_rules() -> Vec<Box<dyn LintRule>> {
     adjacent_overload_signatures::AdjacentOverloadSignatures::new(),
     ban_ts_comment::BanTsComment::new(),
     ban_types::BanTypes::new(),
+    ban_unknown_rule_code::BanUnknownRuleCode::new(),
     ban_untagged_ignore::BanUntaggedIgnore::new(),
     ban_untagged_todo::BanUntaggedTodo::new(),
     camelcase::Camelcase::new(),

--- a/src/rules/ban_unknown_rule_code.rs
+++ b/src/rules/ban_unknown_rule_code.rs
@@ -1,0 +1,70 @@
+use super::{Context, LintRule, ProgramRef};
+
+/// This is a dummy struct just for having the docs.
+/// The actual implementation resides in [`Context`].
+pub struct BanUnknownRuleCode;
+
+impl LintRule for BanUnknownRuleCode {
+  fn new() -> Box<Self> {
+    Box::new(BanUnknownRuleCode)
+  }
+
+  fn tags(&self) -> &'static [&'static str] {
+    &["recommended"]
+  }
+
+  fn code(&self) -> &'static str {
+    "ban-unknown-rule-code"
+  }
+
+  fn lint_program(&self, _context: &mut Context, _program: ProgramRef<'_>) {
+    unreachable!();
+  }
+
+  fn lint_program_with_ast_view(
+    &self,
+    _context: &mut Context,
+    _program: dprint_swc_ecma_ast_view::Program<'_>,
+  ) {
+    // noop
+  }
+
+  fn docs(&self) -> &'static str {
+    r#"Warns the usage of unknown rule codes in ignore directives
+
+We sometimes have to suppress and ignore lint errors for some reasons. We can do
+so using [ignore directives](https://lint.deno.land/ignoring-rules) with rule
+names that should be ignored like so:
+
+```typescript
+// deno-lint-ignore no-explicit-any no-unused-vars
+const foo: any = 42;
+```
+
+This rule checks for the validity of the specified rule names (i.e. whether
+`deno_lint` provides the rule or not).
+
+### Invalid:
+
+```typescript
+// typo
+// deno-lint-ignore no-extra-sem
+export const a = 42;;
+
+// unknown rule name
+// deno-lint-ignore UNKNOWN_RULE_NAME
+const b = "b";
+```
+
+### Valid:
+
+```typescript
+// deno-lint-ignore no-extra-semi
+export const a = 42;;
+
+// deno-lint-ignore no-unused-vars
+const b = "b";
+```
+"#
+  }
+}

--- a/src/rules/ban_untagged_ignore.rs
+++ b/src/rules/ban_untagged_ignore.rs
@@ -76,27 +76,23 @@ mod tests {
   use super::*;
 
   #[test]
-  fn ban_ts_ignore_valid() {
+  fn ban_untagged_ignore_valid() {
     assert_lint_ok! {
       BanUntaggedIgnore,
       r#"
-// deno-lint-ignore some-code some-code-2
-function bar() {
-  // pass
-}
+// deno-lint-ignore no-explicit-any
+export const foo: any = 42;
     "#,
     };
   }
 
   #[test]
-  fn ban_ts_ignore_invalid() {
+  fn ban_untagged_ignore_invalid() {
     assert_lint_err! {
       BanUntaggedIgnore,
       r#"
 // deno-lint-ignore
-function foo() {
-  // pass
-}
+export const foo: any = 42;
       "#: [
         {
           line: 2,

--- a/src/rules/ban_unused_ignore.rs
+++ b/src/rules/ban_unused_ignore.rs
@@ -1,0 +1,60 @@
+use super::{Context, LintRule, ProgramRef};
+
+/// This is a dummy struct just for having the docs.
+/// The actual implementation resides in [`Context`].
+pub struct BanUnusedIgnore;
+
+impl LintRule for BanUnusedIgnore {
+  fn new() -> Box<Self> {
+    Box::new(BanUnusedIgnore)
+  }
+
+  fn tags(&self) -> &'static [&'static str] {
+    &["recommended"]
+  }
+
+  fn code(&self) -> &'static str {
+    "ban-unused-ignore"
+  }
+
+  fn lint_program(&self, _context: &mut Context, _program: ProgramRef<'_>) {
+    unreachable!();
+  }
+
+  fn lint_program_with_ast_view(
+    &self,
+    _context: &mut Context,
+    _program: dprint_swc_ecma_ast_view::Program<'_>,
+  ) {
+    // noop
+  }
+
+  fn docs(&self) -> &'static str {
+    r#"Warns unused ignore directives
+
+We sometimes have to suppress and ignore lint errors for some reasons and we can
+do so using [ignore directives](https://lint.deno.land/ignoring-rules).
+
+In some cases, however, like after refactoring, we may end up having ignore
+directives that are no longer necessary. Such superfluous ignore directives are
+likely to confuse future code readers, and to make matters worse, might hide
+future lint errors unintentionally. To prevent such situations, this rule
+detects unused, superfluous ignore directives.
+
+### Invalid:
+
+```typescript
+// Actually this line is valid since `export` means "used",
+// so this directive is superfluous
+// deno-lint-ignore no-unused-vars
+export const foo = 42;
+```
+
+### Valid:
+
+```typescript
+export const foo = 42;
+```
+"#
+  }
+}

--- a/src/test_util.rs
+++ b/src/test_util.rs
@@ -234,8 +234,6 @@ fn lint(
   filename: &str,
 ) -> Vec<LintDiagnostic> {
   let linter = LinterBuilder::default()
-    .lint_unused_ignore_directives(false)
-    .lint_unknown_rules(false)
     .syntax(if filename.ends_with(".tsx") {
       get_ts_config_with_tsx()
     } else {


### PR DESCRIPTION
This PR contains a breaking change for the public interface on `LinterBuilder`. Currently `ban-unknown-rule-code` and `ban-unused-ignore` can be opted out by a downstream user via `LinterBuilder`, but this PR will always enable both of them. Accordingly, `lint_unknown_rules(bool)` and `lint_unused_ignore_directives(bool)` on the `LinterBuilder` are removed.

In addition, docs for these two rules are added so that we can see them on https://lint.deno.land.