### PR TITLE
refactor: removing redundancy by creating new macro for asserting (#425)

### DIFF
--- a/src/rules/ban_ts_comment.rs
+++ b/src/rules/ban_ts_comment.rs
@@ -181,92 +181,85 @@ console.log('hello');
 
   #[test]
   fn ban_ts_comment_invalid() {
+    //@ts-expect-error
     assert_lint_err! {
       BanTsComment,
-      r#"// @ts-expect-error"#: [
-            {
-              col: 0,
-              message: DirectiveKind::ExpectError.as_message(),
-              hint: DirectiveKind::ExpectError.as_hint(),
-            }
-          ],
-      r#"/// @ts-expect-error"#: [
-            {
-              col: 0,
-              message: DirectiveKind::ExpectError.as_message(),
-              hint: DirectiveKind::ExpectError.as_hint(),
-            }
-          ],
-      r#"//@ts-expect-error"#: [
-            {
-              col: 0,
-              message: DirectiveKind::ExpectError.as_message(),
-              hint: DirectiveKind::ExpectError.as_hint(),
-            }
-          ],
-      r#"// @ts-expect-error    "#: [
+      DirectiveKind::ExpectError.as_message(),
+      DirectiveKind::ExpectError.as_hint(),
+      r#"// @ts-expect-error"# : [
         {
-          col: 0,
-          message: DirectiveKind::ExpectError.as_message(),
-          hint: DirectiveKind::ExpectError.as_hint(),
+          col: 0
         }
       ],
-    r#"// @ts-ignore"#: [
-            {
-              col: 0,
-              message: DirectiveKind::Ignore.as_message(),
-              hint: DirectiveKind::Ignore.as_hint(),
-            }
-          ],
-    r#"/// @ts-ignore"#: [
-            {
-              col: 0,
-              message: DirectiveKind::Ignore.as_message(),
-              hint: DirectiveKind::Ignore.as_hint(),
-            }
-          ],
-    r#"//@ts-ignore"#: [
-            {
-              col: 0,
-              message: DirectiveKind::Ignore.as_message(),
-              hint: DirectiveKind::Ignore.as_hint(),
-            }
-          ],
-    r#"// @ts-ignore    "#: [
-      {
-        col: 0,
-        message: DirectiveKind::Ignore.as_message(),
-        hint: DirectiveKind::Ignore.as_hint(),
-      }
-          ],
-    r#"// @ts-nocheck"#: [
-            {
-              col: 0,
-              message: DirectiveKind::Nocheck.as_message(),
-              hint: DirectiveKind::Nocheck.as_hint(),
-            }
-          ],
-    r#"/// @ts-nocheck"#: [
-            {
-              col: 0,
-              message: DirectiveKind::Nocheck.as_message(),
-              hint: DirectiveKind::Nocheck.as_hint(),
-            }
-          ],
-    r#"//@ts-nocheck"#: [
-            {
-              col: 0,
-              message: DirectiveKind::Nocheck.as_message(),
-              hint: DirectiveKind::Nocheck.as_hint(),
-            }
-          ],
-    r#"// @ts-nocheck    "#: [
-      {
-        col: 0,
-        message: DirectiveKind::Nocheck.as_message(),
-        hint: DirectiveKind::Nocheck.as_hint(),
-      }
-          ],
-    };
+      r#"/// @ts-expect-error"# : [
+        {
+          col: 0
+        }
+      ] ,
+      r#"/// @ts-expect-error"# : [
+        {
+          col: 0
+        }
+      ],
+      r#"// @ts-expect-error    "# : [
+        {
+          col: 0
+        }
+      ]
+    }
+
+    //@ts-ignore
+    assert_lint_err! {
+      BanTsComment,
+      DirectiveKind::Ignore.as_message(),
+      DirectiveKind::Ignore.as_hint(),
+      r#"// @ts-ignore"# : [
+        {
+          col: 0
+        }
+      ],
+      r#"/// @ts-ignore"# : [
+        {
+          col: 0
+        }
+      ] ,
+      r#"//@ts-ignore"# : [
+        {
+          col: 0
+        }
+      ],
+      r#"// @ts-ignore    "# : [
+        {
+          col: 0
+        }
+      ]
+    }
+
+    //@ts-nocheck
+    assert_lint_err! {
+      BanTsComment,
+      DirectiveKind::Nocheck.as_message(),
+      DirectiveKind::Nocheck.as_hint(),
+      r#"// @ts-nocheck"# : [
+        {
+          col: 0
+        }
+      ],
+      r#"/// @ts-nocheck"# : [
+        {
+          col: 0
+        }
+      ] ,
+      r#"//@ts-nocheck"# : [
+        {
+          col: 0
+        }
+      ],
+      r#"// @ts-nocheck    "# : [
+        {
+          col: 0
+        }
+      ]
+    }
   }
 }

--- a/src/rules/no_await_in_loop.rs
+++ b/src/rules/no_await_in_loop.rs
@@ -229,6 +229,8 @@ for (let thing in await things) {
   fn no_await_in_loop_invalid() {
     assert_lint_err! {
       NoAwaitInLoop,
+      MESSAGE,
+      HINT,
       r#"
 async function foo(things) {
   const results = [];
@@ -237,57 +239,57 @@ async function foo(things) {
   }
   return baz(results);
 }
-      "#: [{ line: 5, col: 17, message: MESSAGE, hint: HINT }],
+      "#: [{ line: 5, col: 17 }],
       r#"
 for (const thing of things) {
   results.push(await foo(thing));
 }
-      "#: [{ line: 3, col: 15, message: MESSAGE, hint: HINT }],
+      "#: [{ line: 3, col: 15 }],
       r#"
 for (let i = 0; i < await foo(); i++) {
   bar();
 }
-      "#: [{ line: 2, col: 20, message: MESSAGE, hint: HINT }],
+      "#: [{ line: 2, col: 20 }],
       r#"
 for (let i = 0; i < 42; await foo(i)) {
   bar();
 }
-      "#: [{ line: 2, col: 24, message: MESSAGE, hint: HINT }],
+      "#: [{ line: 2, col: 24 }],
       r#"
 for (let i = 0; i < 42; i++) {
   await bar();
 }
-      "#: [{ line: 3, col: 2, message: MESSAGE, hint: HINT }],
+      "#: [{ line: 3, col: 2 }],
       r#"
 for (const thing in things) {
   await foo(thing);
 }
-      "#: [{ line: 3, col: 2, message: MESSAGE, hint: HINT }],
+      "#: [{ line: 3, col: 2 }],
       r#"
 while (await foo()) {
   bar();
 }
-      "#: [{ line: 2, col: 7, message: MESSAGE, hint: HINT }],
+      "#: [{ line: 2, col: 7 }],
       r#"
 while (true) {
   await foo();
 }
-      "#: [{ line: 3, col: 2, message: MESSAGE, hint: HINT }],
+      "#: [{ line: 3, col: 2 }],
       r#"
 while (true) {
   await foo();
 }
-      "#: [{ line: 3, col: 2, message: MESSAGE, hint: HINT }],
+      "#: [{ line: 3, col: 2 }],
       r#"
 do {
   foo();
 } while (await bar());
-      "#: [{ line: 4, col: 9, message: MESSAGE, hint: HINT }],
+      "#: [{ line: 4, col: 9 }],
       r#"
 do {
   await foo();
 } while (true);
-      "#: [{ line: 3, col: 2, message: MESSAGE, hint: HINT }],
+      "#: [{ line: 3, col: 2 }],
       r#"
 for await (const thing of things) {
   async function foo() {
@@ -297,7 +299,7 @@ for await (const thing of things) {
   }
   await baz();
 }
-      "#: [{ line: 5, col: 6, message: MESSAGE, hint: HINT }],
+      "#: [{ line: 5, col: 6 }],
 
       r#"
 function foo() {
@@ -307,7 +309,7 @@ function foo() {
     }
   }
 }
-      "#: [{ line: 5, col: 6, message: MESSAGE, hint: HINT }],
+      "#: [{ line: 5, col: 6 }],
       r#"
 async function foo() {
   for (const thing of things) {
@@ -317,7 +319,7 @@ async function foo() {
     }
   }
 }
-      "#: [{ line: 6, col: 6, message: MESSAGE, hint: HINT }],
+      "#: [{ line: 6, col: 6 }]
     }
   }
 }

--- a/src/test_util.rs
+++ b/src/test_util.rs
@@ -61,6 +61,40 @@ macro_rules! assert_lint_err {
       $($src: $test,)*
     }
   };
+
+  (
+    $rule: ty,
+    $message: expr,
+    $hint: expr,
+    filename: $filename:literal,
+    $($src:literal : $test:tt),+
+    $(,)?
+  ) => {
+      $(
+      let errors = parse_err_test!($message, $hint, $test);
+      let tester = $crate::test_util::LintErrTester::<$rule>::new(
+        $src,
+        errors,
+        $filename,
+      );
+      tester.run();
+    )*
+  };
+  (
+    $rule: ty,
+    $message: expr,
+    $hint: expr,
+    $($src:literal : $test:tt),+
+    $(,)?
+  ) => {
+      assert_lint_err! {
+        $rule,
+        $message,
+        $hint,
+        filename: "deno_lint_err_test.ts",
+        $($src: $test,)*
+      }
+  };
 }
 
 #[macro_export]
@@ -98,6 +132,7 @@ macro_rules! parse_err_test {
     )*
     errors
   }};
+
   (
     {
       filename : $filename:literal,
@@ -106,6 +141,33 @@ macro_rules! parse_err_test {
   ) => {{
     let (errors, _) = parse_err_test!($errors);
     (errors, $filename)
+  }};
+
+  (
+    $message: expr,
+    $hint: expr,
+    [
+      $(
+        {
+          $($field:ident : $value:expr),* $(,)?
+        }
+      ),* $(,)?
+    ]
+  ) => {{
+    let errors = parse_err_test!(
+      $(
+        [
+          {
+            message: $message,
+            hint: $hint,
+            $(
+              $field: $value,
+            )*
+          },
+        ]
+      )*
+    );
+    errors
   }};
 }
 


### PR DESCRIPTION
In this PR, I have created two more rules for macro assert_err_lint to reduce the repetitions of the message and hint.

Tests Done:
1. I have pulled all the latest changes.
2. cargo build --all-targets
3. cargo test

Follow up work:
1. Need to reuse this macro rule in other places.