### PR TITLE
feat(no-var): add "recommended" tag to `no-var`

### DIFF
--- a/src/rules/no_var.rs
+++ b/src/rules/no_var.rs
@@ -17,6 +17,10 @@ impl LintRule for NoVar {
     Box::new(NoVar)
   }
 
+  fn tags(&self) -> &'static [&'static str] {
+    &["recommended"]
+  }
+
   fn code(&self) -> &'static str {
     CODE
   }


### PR DESCRIPTION
This PR adds `no-var` to the recommended set of rules.

`no-var` is currently not in the recommended set simply because ESLint's recommended set doesn't include the rule either. Not really sure why ESLint doesn't, but given that this rule is considered to be always useful when writing TypeScript/JavaScript in modern fashion, we should probably make it "recommended". 