### PR TITLE
fix(tools): handle input with two or more hyphens correctly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,9 @@ jobs:
         run: cargo build --locked --release --all-targets --all-features
 
       - name: Test
-        run: cargo test --locked --release --all-targets --all-features
+        run: |
+          cargo test --locked --release --all-targets --all-features
+          deno test ./tools
 
       - name: Lint
         run: deno run --allow-run ./tools/lint.ts --release

--- a/tools/scaffold.ts
+++ b/tools/scaffold.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env -S deno run --allow-write=. --allow-read=.
 // Copyright 2020-2021 the Deno authors. All rights reserved. MIT license.
 
-import { green, red } from "https://deno.land/std@0.106.0/fmt/colors.ts";
+import { cyan, green, red } from "https://deno.land/std@0.106.0/fmt/colors.ts";
 import { fromFileUrl, join } from "https://deno.land/std@0.106.0/path/mod.ts";
 
 if (Deno.args.length !== 1) {
@@ -31,13 +31,25 @@ await Promise.all([
 
 console.log(
   green("SUCCESS"),
-  `finished to scaffold for \`${kebabCasedLintName}\`!`,
+  `finished to scaffold for ${cyan(kebabCasedLintName)}!`,
 );
 console.log(
-  `Next, open \`docs/rules/${snakeCasedLintName}.md\` and \`src/rules/${snakeCasedLintName}.rs\` in your editor and implement the rule.`,
+  `Next, open ${cyan(`docs/rules/${snakeCasedLintName}.md`)} and ${
+    cyan(
+      `src/rules/${snakeCasedLintName}.rs`,
+    )
+  } in your editor and implement the rule.`,
 );
 console.log(
-  "Also, don't forget to manually add a new lint rule to `get_all_rules` function in `src/rules.rs` so that the rule will get to be run actually.",
+  `Also, don't forget to manually add a new lint rule to ${
+    cyan(
+      "get_all_rules",
+    )
+  } function in ${
+    cyan(
+      "src/rules.rs",
+    )
+  } so that the rule will get to be run actually.`,
 );
 
 async function createMarkdown(mdPath: string) {

--- a/tools/scaffold.ts
+++ b/tools/scaffold.ts
@@ -10,11 +10,14 @@ if (Deno.args.length !== 1) {
   Deno.exit(1);
 }
 
-const snakeCasedLintName = Deno.args[0].replace("-", "_");
-const kebabCasedLintName = snakeCasedLintName.replace("_", "-");
+const snakeCasedLintName = Deno.args[0].replaceAll("-", "_");
+const kebabCasedLintName = snakeCasedLintName.replaceAll("_", "-");
 const pascalCasedLintName = snakeCasedLintName
   .replace(/^(\w)/, (_match, firstChar) => firstChar.toUpperCase())
-  .replace(/_(\w)/, (_match, afterUnderscore) => afterUnderscore.toUpperCase());
+  .replace(
+    /_(\w)/g,
+    (_match, afterUnderscore) => afterUnderscore.toUpperCase(),
+  );
 const thisPath = fromFileUrl(import.meta.url);
 const mdPath = join(thisPath, "../../docs/rules", `${snakeCasedLintName}.md`);
 const rsPath = join(thisPath, "../../src/rules", `${snakeCasedLintName}.rs`);

--- a/tools/scaffold.ts
+++ b/tools/scaffold.ts
@@ -30,16 +30,22 @@ if (import.meta.main) {
 
   console.log(green("SUCCESS"), `finished to scaffold for ${cyan(kebab)}!`);
   console.log(
-    `Next, open ${cyan(`docs/rules/${snake}.md`)} and ${cyan(
-      `src/rules/${snake}.rs`
-    )} in your editor and implement the rule.`
+    `Next, open ${cyan(`docs/rules/${snake}.md`)} and ${
+      cyan(
+        `src/rules/${snake}.rs`,
+      )
+    } in your editor and implement the rule.`,
   );
   console.log(
-    `Also, don't forget to manually add a new lint rule to ${cyan(
-      "get_all_rules"
-    )} function in ${cyan(
-      "src/rules.rs"
-    )} so that the rule will get to be run actually.`
+    `Also, don't forget to manually add a new lint rule to ${
+      cyan(
+        "get_all_rules",
+      )
+    } function in ${
+      cyan(
+        "src/rules.rs",
+      )
+    } so that the rule will get to be run actually.`,
   );
 }
 
@@ -52,8 +58,9 @@ export function convert(input: string): {
   const kebab = snake.replaceAll("_", "-");
   const pascal = snake
     .replace(/^(\w)/, (_match, firstChar) => firstChar.toUpperCase())
-    .replace(/_(\w)/g, (_match, afterUnderscore) =>
-      afterUnderscore.toUpperCase()
+    .replace(
+      /_(\w)/g,
+      (_match, afterUnderscore) => afterUnderscore.toUpperCase(),
     );
   return {
     snake,
@@ -86,7 +93,7 @@ export function genRustContent(
   now: Date,
   pascalCasedLintName: string,
   kebabCasedLintName: string,
-  snakeCasedLintName: string
+  snakeCasedLintName: string,
 ): string {
   return `// Copyright 2020-${now.getFullYear()} the Deno authors. All rights reserved. MIT license.
 use super::{Context, LintRule};

--- a/tools/tests/scaffold_test.ts
+++ b/tools/tests/scaffold_test.ts
@@ -1,0 +1,232 @@
+import {
+  convert,
+  genPubMod,
+  genMarkdownContent,
+  genRustContent,
+} from "../scaffold.ts";
+import { assertEquals } from "https://deno.land/std@0.106.0/testing/asserts.ts";
+
+Deno.test(
+  "the conversion of input rule name into snake_case, kebab-case, and PascalCase",
+  () => {
+    const tests = [
+      {
+        input: "foo",
+        expected: {
+          snake: "foo",
+          kebab: "foo",
+          pascal: "Foo",
+        },
+      },
+      {
+        input: "foo-bar",
+        expected: {
+          snake: "foo_bar",
+          kebab: "foo-bar",
+          pascal: "FooBar",
+        },
+      },
+      {
+        input: "foo_bar",
+        expected: {
+          snake: "foo_bar",
+          kebab: "foo-bar",
+          pascal: "FooBar",
+        },
+      },
+      {
+        input: "foo-bar-baz",
+        expected: {
+          snake: "foo_bar_baz",
+          kebab: "foo-bar-baz",
+          pascal: "FooBarBaz",
+        },
+      },
+      {
+        input: "foo_bar-baz",
+        expected: {
+          snake: "foo_bar_baz",
+          kebab: "foo-bar-baz",
+          pascal: "FooBarBaz",
+        },
+      },
+    ];
+
+    for (const test of tests) {
+      const got = convert(test.input);
+      assertEquals(got.snake, test.expected.snake);
+      assertEquals(got.kebab, test.expected.kebab);
+      assertEquals(got.pascal, test.expected.pascal);
+    }
+  }
+);
+
+Deno.test("the content of .md", () => {
+  const actual = genMarkdownContent("foo-bar-baz");
+  const expected = `[Summary of foo-bar-baz rule]
+
+[Detail description of what this lint rule attempts to detect and/or why it's
+considered to be a warning]
+
+### Invalid:
+
+\`\`\`typescript
+// provide examples that trigger foo-bar-baz
+\`\`\`
+
+### Valid:
+
+\`\`\`typescript
+// provide examples that don't trigger foo-bar-baz
+\`\`\`
+`;
+  assertEquals(expected, actual);
+});
+
+Deno.test("the content of .rs", () => {
+  const now = new Date("2022-08-10T14:48:00");
+  const actual = genRustContent(now, "FooBarBaz", "foo-bar-baz", "foo_bar_baz");
+  const expected = `// Copyright 2020-2022 the Deno authors. All rights reserved. MIT license.
+use super::{Context, LintRule};
+use crate::handler::{Handler, Traverse};
+use crate::{Program, ProgramRef};
+
+pub struct FooBarBaz;
+
+const CODE: &str = "foo-bar-baz";
+const MESSAGE: &str = "";
+const HINT: &str = "";
+
+impl LintRule for FooBarBaz {
+  fn new() -> Box<Self> {
+    Box::new(FooBarBaz)
+  }
+
+  fn code(&self) -> &'static str {
+    CODE
+  }
+
+  fn lint_program(&self, _context: &mut Context, _program: ProgramRef<'_>) {
+    unreachable!();
+  }
+
+  fn lint_program_with_ast_view(
+    &self,
+    context: &mut Context,
+    program: Program<'_>,
+  ) {
+    FooBarBazHandler.traverse(program, context);
+  }
+
+  #[cfg(feature = "docs")]
+  fn docs(&self) -> &'static str {
+    include_str!("../../docs/rules/foo_bar_baz.md")
+  }
+}
+
+struct FooBarBazHandler;
+
+impl Handler for FooBarBazHandler {
+  // implement some methods to achieve the goal of this lint
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn foo_bar_baz_valid() {
+    assert_lint_ok! {
+      FooBarBaz,
+      r#"// put a valid case here"#,
+    };
+  }
+
+  #[test]
+  fn foo_bar_baz_invalid() {
+    assert_lint_err! {
+      FooBarBaz,
+      MESSAGE,
+      HINT,
+      r#"
+// put a TypeScript/JavaScript snippet that is expected to trigger this lint
+      "#: [
+        {
+          line: 0,
+          col: 0,
+        },
+      ],
+    };
+  }
+}
+`;
+  assertEquals(expected, actual);
+});
+
+Deno.test("the updated content of src/rules.rs", () => {
+  const original = `// Copyright 2020-2021 the Deno authors. All rights reserved. MIT license.
+use crate::context::Context;
+use crate::Program;
+use crate::ProgramRef;
+use std::collections::HashSet;
+
+pub mod adjacent_overload_signatures;
+pub mod ban_ts_comment;
+pub mod ban_types;
+pub mod ban_unknown_rule_code;
+pub mod ban_untagged_ignore;
+pub mod ban_untagged_todo;
+pub mod ban_unused_ignore;
+pub mod camelcase;
+pub mod constructor_super;
+pub mod default_param_last;
+
+pub trait LintRule {}
+
+pub fn get_all_rules() -> Vec<Box<dyn LintRule>> {
+  vec![]
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn recommended_rules_sorted_alphabetically() {}
+}
+`;
+  const actual = genPubMod(original, "foo_bar_baz");
+  const expected = `// Copyright 2020-2021 the Deno authors. All rights reserved. MIT license.
+use crate::context::Context;
+use crate::Program;
+use crate::ProgramRef;
+use std::collections::HashSet;
+
+pub mod foo_bar_baz;
+pub mod adjacent_overload_signatures;
+pub mod ban_ts_comment;
+pub mod ban_types;
+pub mod ban_unknown_rule_code;
+pub mod ban_untagged_ignore;
+pub mod ban_untagged_todo;
+pub mod ban_unused_ignore;
+pub mod camelcase;
+pub mod constructor_super;
+pub mod default_param_last;
+
+pub trait LintRule {}
+
+pub fn get_all_rules() -> Vec<Box<dyn LintRule>> {
+  vec![]
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn recommended_rules_sorted_alphabetically() {}
+}
+`;
+  assertEquals(expected, actual);
+});

--- a/tools/tests/scaffold_test.ts
+++ b/tools/tests/scaffold_test.ts
@@ -1,7 +1,7 @@
 import {
   convert,
-  genPubMod,
   genMarkdownContent,
+  genPubMod,
   genRustContent,
 } from "../scaffold.ts";
 import { assertEquals } from "https://deno.land/std@0.106.0/testing/asserts.ts";
@@ -58,7 +58,7 @@ Deno.test(
       assertEquals(got.kebab, test.expected.kebab);
       assertEquals(got.pascal, test.expected.pascal);
     }
-  }
+  },
 );
 
 Deno.test("the content of .md", () => {
@@ -86,7 +86,8 @@ considered to be a warning]
 Deno.test("the content of .rs", () => {
   const now = new Date("2022-08-10T14:48:00");
   const actual = genRustContent(now, "FooBarBaz", "foo-bar-baz", "foo_bar_baz");
-  const expected = `// Copyright 2020-2022 the Deno authors. All rights reserved. MIT license.
+  const expected =
+    `// Copyright 2020-2022 the Deno authors. All rights reserved. MIT license.
 use super::{Context, LintRule};
 use crate::handler::{Handler, Traverse};
 use crate::{Program, ProgramRef};
@@ -164,7 +165,8 @@ mod tests {
 });
 
 Deno.test("the updated content of src/rules.rs", () => {
-  const original = `// Copyright 2020-2021 the Deno authors. All rights reserved. MIT license.
+  const original =
+    `// Copyright 2020-2021 the Deno authors. All rights reserved. MIT license.
 use crate::context::Context;
 use crate::Program;
 use crate::ProgramRef;
@@ -196,7 +198,8 @@ mod tests {
 }
 `;
   const actual = genPubMod(original, "foo_bar_baz");
-  const expected = `// Copyright 2020-2021 the Deno authors. All rights reserved. MIT license.
+  const expected =
+    `// Copyright 2020-2021 the Deno authors. All rights reserved. MIT license.
 use crate::context::Context;
 use crate::Program;
 use crate::ProgramRef;


### PR DESCRIPTION
This PR fixes the scaffold script so it can handle input lint names with two or more hyphens like `foo-bar-baz` correctly.