### PR TITLE
test(tools): add integration test for scaffold

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,7 @@ jobs:
       - name: Test
         run: |
           cargo test --locked --release --all-targets --all-features
-          deno test ./tools
+          deno test --unstable --allow-read=. --allow-write=. --allow-run ./tools
 
       - name: Lint
         run: deno run --allow-run ./tools/lint.ts --release

--- a/tools/scaffold.ts
+++ b/tools/scaffold.ts
@@ -99,6 +99,7 @@ export function genRustContent(
 use super::{Context, LintRule};
 use crate::handler::{Handler, Traverse};
 use crate::{Program, ProgramRef};
+use swc_common::Spanned;
 
 pub struct ${pascalCasedLintName};
 
@@ -137,6 +138,11 @@ struct ${pascalCasedLintName}Handler;
 
 impl Handler for ${pascalCasedLintName}Handler {
   // implement some methods to achieve the goal of this lint
+
+  // This is an example
+  fn with_stmt(&mut self, with_stmt: &ast_view::WithStmt, ctx: &mut Context) {
+    ctx.add_diagnostic_with_hint(with_stmt.span(), CODE, MESSAGE, HINT);
+  }
 }
 
 #[cfg(test)]

--- a/tools/tests/scaffold_integration_test.ts
+++ b/tools/tests/scaffold_integration_test.ts
@@ -1,0 +1,62 @@
+import { exists } from "https://deno.land/std@0.106.0/fs/mod.ts";
+import { assertEquals } from "https://deno.land/std@0.106.0/testing/asserts.ts";
+
+Deno.test(
+  "Check if the files created by tools/scaffold.ts pass `cargo check`",
+  async () => {
+    const name = "dummy-lint-rule-for-testing";
+    const filename = name.replaceAll("-", "_");
+    const rulesPath = "./src/rules.rs";
+
+    // Preserve the original content of src/rules.rs
+    const rulesRs = await Deno.readTextFile(rulesPath);
+
+    try {
+      console.log(`Run the scaffold script to create ${name} rule`);
+      const p1 = Deno.run({
+        cmd: [
+          "deno",
+          "run",
+          "--allow-write=.",
+          "--allow-read=.",
+          "./tools/scaffold.ts",
+          name,
+        ],
+      });
+      const s1 = await p1.status();
+      p1.close();
+
+      assertEquals(s1.code, 0);
+      console.log("Scaffold succeeded");
+
+      // Check if `cargo check` passes
+      console.log("Run `cargo check`");
+      const p2 = Deno.run({
+        cmd: ["cargo", "check", "--all-targets", "--all-features"],
+      });
+      const s2 = await p2.status();
+      p2.close();
+
+      assertEquals(s2.code, 0);
+      console.log("`cargo check` succeeded");
+    } finally {
+      console.log("Start cleanup...");
+      console.log("Restoring src/rules.rs...");
+      await Deno.writeTextFile(rulesPath, rulesRs);
+
+      console.log(`Deleting src/rules/${filename}.rs...`);
+      const rsPath = `./src/rules/${filename}.rs`;
+      if (await exists(rsPath)) {
+        await Deno.remove(rsPath);
+      }
+
+      console.log(`Deleting docs/rules/${filename}.md...`);
+      const mdPath = `./docs/rules/${filename}.md`;
+      if (await exists(mdPath)) {
+        await Deno.remove(mdPath);
+      }
+
+      console.log("Cleanup finished");
+    }
+  },
+);

--- a/tools/tests/scaffold_test.ts
+++ b/tools/tests/scaffold_test.ts
@@ -91,6 +91,7 @@ Deno.test("the content of .rs", () => {
 use super::{Context, LintRule};
 use crate::handler::{Handler, Traverse};
 use crate::{Program, ProgramRef};
+use swc_common::Spanned;
 
 pub struct FooBarBaz;
 
@@ -129,6 +130,11 @@ struct FooBarBazHandler;
 
 impl Handler for FooBarBazHandler {
   // implement some methods to achieve the goal of this lint
+
+  // This is an example
+  fn with_stmt(&mut self, with_stmt: &ast_view::WithStmt, ctx: &mut Context) {
+    ctx.add_diagnostic_with_hint(with_stmt.span(), CODE, MESSAGE, HINT);
+  }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This PR adds an integration test for the scaffold script. Specifically, it checks if the created files pass `cargo check`.

I kind of hesitated to add this because running the script has side effects. But after further thought, actually we should have it in order to keep the files created by the scaffold scripts up-to-date and able to compile. 