### PR TITLE
chore(ci): only run lint on ubuntu and improve scaffold integration test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,7 @@ jobs:
           deno test --unstable --allow-read=. --allow-write=. --allow-run ./tools
 
       - name: Lint
+        if: contains(matrix.os, 'ubuntu')
         run: deno run --allow-run ./tools/lint.ts --release
 
       - name: Benchmarks

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,7 @@ jobs:
       - name: Test
         run: |
           cargo test --locked --release --all-targets --all-features
-          deno test --unstable --allow-read=. --allow-write=. --allow-run ./tools
+          deno test --unstable --allow-read=. --allow-write=. --allow-run --allow-env ./tools
 
       - name: Lint
         if: contains(matrix.os, 'ubuntu')

--- a/tools/tests/scaffold_integration_test.ts
+++ b/tools/tests/scaffold_integration_test.ts
@@ -35,7 +35,7 @@ Deno.test(
       if (Deno.env.get("GH_ACTIONS") === "1") {
         // do a release build on GitHub actions since the other
         // cargo builds are also release
-        args.push("--release")
+        args.push("--release");
       }
       const p2 = Deno.run({
         cmd: ["cargo", ...args],

--- a/tools/tests/scaffold_integration_test.ts
+++ b/tools/tests/scaffold_integration_test.ts
@@ -31,8 +31,14 @@ Deno.test(
 
       // Check if `cargo check` passes
       console.log("Run `cargo check`");
+      const args = ["check", "--all-targets", "--all-features", "--locked"];
+      if (Deno.env.get("GH_ACTIONS") === "1") {
+        // do a release build on GitHub actions since the other
+        // cargo builds are also release
+        args.push("--release")
+      }
       const p2 = Deno.run({
-        cmd: ["cargo", "check", "--all-targets", "--all-features"],
+        cmd: ["cargo", ...args],
       });
       const s2 = await p2.status();
       p2.close();


### PR DESCRIPTION
I don't think it's worth it to run the linter on every platform given that there is basically zero platform specific code.

Additionally, closes #841.