### PR TITLE
fix: 'no-invalid-triple-slash-referecence' for JavaScript files

### DIFF
--- a/docs/rules/no_invalid_triple_slash_reference.md
+++ b/docs/rules/no_invalid_triple_slash_reference.md
@@ -23,7 +23,6 @@ the `types` directive.
 
 ```javascript
 /// <reference path="./mod.d.ts" />
-/// <reference lib="es2017.string" />
 /// <reference no-default-lib="true" />
 /// <reference foo="bar" />
 
@@ -44,6 +43,7 @@ the `types` directive.
 
 ```javascript
 /// <reference types="./mod.d.ts" />
+/// <reference lib="es2017.string" />
 
 // ... the rest of the JavaScript ...
 ```

--- a/src/rules/no_invalid_triple_slash_reference.rs
+++ b/src/rules/no_invalid_triple_slash_reference.rs
@@ -132,7 +132,7 @@ fn check_comment(comment: &Comment, is_js_like: bool) -> Option<ReportKind> {
   }
 
   if is_js_like {
-    // In JavaScript, only the `types` directives are allowed
+    // In JavaScript, only the `lib` and `types` directives are allowed
     if is_types_ref(&comment.text) || is_lib_ref(&comment.text) {
       None
     } else {


### PR DESCRIPTION
This commit allows to use `/// <reference lib="lib" />` in JavaScript files.

Fixes https://github.com/denoland/deno_lint/issues/854

