### PR TITLE
feat(prefer-ascii): print character's unicode code point in hint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,9 +34,9 @@ dependencies = [
 
 [[package]]
 name = "annotate-snippets"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c96c3d1062ea7101741480185a6a1275eab01cbe8b20e378d1311bc056d2e08"
+checksum = "c3b9d411ecbaf79885c6df4d75fff75858d5995ff25385657a28af47e82f9c36"
 dependencies = [
  "unicode-width",
  "yansi-term",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,11 +32,7 @@ anyhow = "1.0.40"
 if_chain = "1.0.1"
 
 [dev-dependencies]
-annotate-snippets = { version = "0.9.0", features = ["color"] }
-# TODO(@magurotuna): This branch contains a patch that fixes how double-width
-# characters in diagnostic annotations are displayed. Once it lands, we'll
-# upgrade it.
-# annotate-snippets = { git = "https://github.com/magurotuna/annotate-snippets-rs", branch = "check-display-width", features = ["color"] }
+annotate-snippets = { version = "0.9.1", features = ["color"] }
 ansi_term = "0.12.1"
 atty = "0.2.14"
 clap = "2.33.3"

--- a/src/rules/prefer_ascii.rs
+++ b/src/rules/prefer_ascii.rs
@@ -10,7 +10,10 @@ const CODE: &str = "prefer-ascii";
 const MESSAGE: &str = "Non-ASCII characters are not allowed";
 
 fn hint(c: char) -> String {
-  format!("`{}` is not an ASCII. Consider replacing it", c)
+  format!(
+    "`{}` is \\u{{{:04x}}} and this is not an ASCII. Consider replacing it with an ASCII character",
+    c, c as u32
+  )
 }
 
 impl LintRule for PreferAscii {


### PR DESCRIPTION
This PR adds a character's unicode code point to hint, and upgrades annotate-snippets to 0.9.1 so that diagnostics point to the right position when the target character is double-width.

Closes #852

### Before

![image](https://user-images.githubusercontent.com/23649474/132954886-9fd9c96f-815e-46e9-b7a3-4e0986de0ad1.png)

### After
![image](https://user-images.githubusercontent.com/23649474/132954872-f58dfbca-9065-4415-ab63-dae5cb203c1d.png)
