### PR TITLE
docs: Fix sample code for invalid "no-extra-semi"

### DIFF
--- a/docs/rules/no_extra_semi.md
+++ b/docs/rules/no_extra_semi.md
@@ -7,8 +7,8 @@ well as making the code less clean.
 
 ```typescript
 const x = 5;
-
-function foo() {}
+;
+function foo() {};
 ```
 
 ### Valid:

--- a/docs/rules/no_extra_semi.md
+++ b/docs/rules/no_extra_semi.md
@@ -1,3 +1,5 @@
+<!-- deno-fmt-ignore-file -->
+
 Disallows the use of unnecessary semi-colons
 
 Extra (and unnecessary) semi-colons can cause confusion when reading the code as
@@ -6,8 +8,8 @@ well as making the code less clean.
 ### Invalid:
 
 ```typescript
-const x = 5;
-;
+const x = 5;;
+
 function foo() {};
 ```
 


### PR DESCRIPTION
The invalid and valid samples look identical.
To my best guess the invalid sample might contain a semicolon at an empty line and at { }.

This is tested with a deno.json config file with and without exclude:"no-extra-semi" option.
```
	"lint": {
		"files": {
			"include": ["./"]
		},
		"rules": {
			"tags": ["recommended"],
			"exclude": ["no-extra-semi"]
		}
	},
```