### PR TITLE
Fix no_extra_semi docs

### DIFF
--- a/docs/rules/no_extra_semi.md
+++ b/docs/rules/no_extra_semi.md
@@ -6,9 +6,9 @@ well as making the code less clean.
 ### Invalid:
 
 ```typescript
-const x = 5;
+const x = 5;;
 
-function foo() {}
+function foo() {};
 ```
 
 ### Valid:


### PR DESCRIPTION
In https://github.com/denoland/deno_lint/pull/787, the docs for no_extra_semi appear to have had the `valid` case copied to both the `invalid` and `valid` examples. This restores the `invalid` example to the original prior to #787.