### PR TITLE
refactor: store LintRule in an Arc instead of Box

### DIFF
--- a/examples/dlint/config.rs
+++ b/examples/dlint/config.rs
@@ -30,7 +30,7 @@ pub struct Config {
 }
 
 impl Config {
-  pub fn get_rules(&self) -> Arc<Vec<Box<dyn LintRule>>> {
+  pub fn get_rules(&self) -> Vec<Arc<dyn LintRule>> {
     get_filtered_rules(
       Some(self.rules.tags.clone()),
       Some(self.rules.exclude.clone()),
@@ -158,7 +158,7 @@ mod tests {
     }}
   }
 
-  fn into_codes(rules: Arc<Vec<Box<dyn LintRule>>>) -> HashSet<&'static str> {
+  fn into_codes(rules: Vec<Arc<dyn LintRule>>) -> HashSet<&'static str> {
     rules.iter().map(|rule| rule.code()).collect()
   }
 

--- a/examples/dlint/js.rs
+++ b/examples/dlint/js.rs
@@ -16,6 +16,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::{HashMap, HashSet};
 use std::rc::Rc;
+use std::sync::Arc;
 
 #[derive(Deserialize)]
 struct DiagnosticsFromJs {
@@ -109,8 +110,8 @@ pub struct PluginRunner {
 }
 
 impl PluginRunner {
-  pub fn new(plugin_path: &str) -> Box<Self> {
-    Box::new(Self {
+  pub fn new(plugin_path: &str) -> Arc<Self> {
+    Arc::new(Self {
       plugin_path: plugin_path.to_string(),
     })
   }

--- a/examples/dlint/main.rs
+++ b/examples/dlint/main.rs
@@ -93,12 +93,10 @@ fn run_linter(
   } else {
     get_recommended_rules()
   };
-  let plugins = Arc::new(
-    plugin_paths
-      .into_iter()
-      .map(|p| js::PluginRunner::new(p) as Box<dyn Plugin>)
-      .collect::<Vec<_>>(),
-  );
+  let plugins = plugin_paths
+    .into_iter()
+    .map(|p| js::PluginRunner::new(p) as Arc<dyn Plugin>)
+    .collect::<Vec<_>>();
 
   let file_diagnostics = Arc::new(Mutex::new(BTreeMap::new()));
   paths
@@ -113,8 +111,8 @@ fn run_linter(
       }
 
       let linter_builder = LinterBuilder::default()
-        .rules(Arc::clone(&rules))
-        .plugins(Arc::clone(&plugins))
+        .rules(rules.clone())
+        .plugins(plugins.clone())
         .syntax(determine_syntax(file_path));
 
       let linter = linter_builder.build();

--- a/src/context.rs
+++ b/src/context.rs
@@ -11,6 +11,7 @@ use deno_ast::swc::common::{Span, SyntaxContext};
 use deno_ast::view as ast_view;
 use deno_ast::view::{BytePos, RootNode, SourceFile};
 use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
 use std::time::Instant;
 
 /// `Context` stores data needed while performing all lint rules to a file.
@@ -199,7 +200,7 @@ impl<'view> Context<'view> {
   /// works for diagnostics reported by other rules.
   pub(crate) fn ban_unused_ignore(
     &self,
-    specified_rules: &[Box<dyn LintRule>],
+    specified_rules: &[Arc<dyn LintRule>],
   ) -> Vec<LintDiagnostic> {
     const CODE: &str = "ban-unused-ignore";
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,10 +34,7 @@ mod lint_tests {
   use deno_ast::ParsedSource;
   use std::sync::Arc;
 
-  fn lint(
-    source: &str,
-    rules: Arc<Vec<Box<dyn LintRule>>>,
-  ) -> Vec<LintDiagnostic> {
+  fn lint(source: &str, rules: Vec<Arc<dyn LintRule>>) -> Vec<LintDiagnostic> {
     let linter = LinterBuilder::default().rules(rules).build();
 
     let (_, diagnostics) = linter
@@ -48,7 +45,7 @@ mod lint_tests {
 
   fn lint_with_ast(
     parsed_source: &ParsedSource,
-    rules: Arc<Vec<Box<dyn LintRule>>>,
+    rules: Vec<Arc<dyn LintRule>>,
   ) -> Vec<LintDiagnostic> {
     let linter = LinterBuilder::default().rules(rules).build();
 
@@ -68,7 +65,7 @@ mod lint_tests {
   fn lint_specified_rule<T: LintRule + 'static>(
     source: &str,
   ) -> Vec<LintDiagnostic> {
-    lint(source, Arc::new(vec![T::new()]))
+    lint(source, vec![T::new()])
   }
 
   #[test]

--- a/src/linter.rs
+++ b/src/linter.rs
@@ -24,8 +24,8 @@ pub struct LinterBuilder {
   ignore_file_directive: String,
   ignore_diagnostic_directive: String,
   syntax: deno_ast::swc::parser::Syntax,
-  rules: Arc<Vec<Box<dyn LintRule>>>,
-  plugins: Arc<Vec<Box<dyn Plugin>>>,
+  rules: Vec<Arc<dyn LintRule>>,
+  plugins: Vec<Arc<dyn Plugin>>,
 }
 
 impl LinterBuilder {
@@ -63,12 +63,12 @@ impl LinterBuilder {
     self
   }
 
-  pub fn rules(mut self, rules: Arc<Vec<Box<dyn LintRule>>>) -> Self {
+  pub fn rules(mut self, rules: Vec<Arc<dyn LintRule>>) -> Self {
     self.rules = rules;
     self
   }
 
-  pub fn plugins(mut self, plugins: Arc<Vec<Box<dyn Plugin>>>) -> Self {
+  pub fn plugins(mut self, plugins: Vec<Arc<dyn Plugin>>) -> Self {
     self.plugins = plugins;
     self
   }
@@ -79,8 +79,8 @@ pub struct Linter {
   ignore_file_directive: String,
   ignore_diagnostic_directive: String,
   syntax: Syntax,
-  rules: Arc<Vec<Box<dyn LintRule>>>,
-  plugins: Arc<Vec<Box<dyn Plugin>>>,
+  rules: Vec<Arc<dyn LintRule>>,
+  plugins: Vec<Arc<dyn Plugin>>,
 }
 
 impl Linter {
@@ -88,8 +88,8 @@ impl Linter {
     ignore_file_directive: String,
     ignore_diagnostic_directive: String,
     syntax: Syntax,
-    rules: Arc<Vec<Box<dyn LintRule>>>,
-    plugins: Arc<Vec<Box<dyn Plugin>>>,
+    rules: Vec<Arc<dyn LintRule>>,
+    plugins: Vec<Arc<dyn Plugin>>,
   ) -> Self {
     Linter {
       ast_parser: AstParser::new(),

--- a/src/rules/adjacent_overload_signatures.rs
+++ b/src/rules/adjacent_overload_signatures.rs
@@ -7,6 +7,7 @@ use deno_ast::view as ast_view;
 use deno_ast::view::Spanned;
 use derive_more::Display;
 use std::collections::HashSet;
+use std::sync::Arc;
 
 #[derive(Debug)]
 pub struct AdjacentOverloadSignatures;
@@ -26,8 +27,8 @@ enum AdjacentOverloadSignaturesHint {
 }
 
 impl LintRule for AdjacentOverloadSignatures {
-  fn new() -> Box<Self> {
-    Box::new(AdjacentOverloadSignatures)
+  fn new() -> Arc<Self> {
+    Arc::new(AdjacentOverloadSignatures)
   }
 
   fn tags(&self) -> &'static [&'static str] {

--- a/src/rules/ban_ts_comment.rs
+++ b/src/rules/ban_ts_comment.rs
@@ -6,6 +6,7 @@ use deno_ast::swc::common::comments::CommentKind;
 use deno_ast::swc::common::Span;
 use once_cell::sync::Lazy;
 use regex::Regex;
+use std::sync::Arc;
 
 /// This rule differs from typescript-eslint. In typescript-eslint the following
 /// defaults apply:
@@ -61,8 +62,8 @@ impl BanTsComment {
 }
 
 impl LintRule for BanTsComment {
-  fn new() -> Box<Self> {
-    Box::new(BanTsComment)
+  fn new() -> Arc<Self> {
+    Arc::new(BanTsComment)
   }
 
   fn tags(&self) -> &'static [&'static str] {

--- a/src/rules/ban_types.rs
+++ b/src/rules/ban_types.rs
@@ -6,6 +6,7 @@ use deno_ast::view as ast_view;
 use deno_ast::view::{Spanned, TsEntityName, TsKeywordTypeKind};
 use if_chain::if_chain;
 use std::convert::TryFrom;
+use std::sync::Arc;
 
 #[derive(Debug)]
 pub struct BanTypes;
@@ -74,8 +75,8 @@ impl TryFrom<&str> for BannedType {
 }
 
 impl LintRule for BanTypes {
-  fn new() -> Box<Self> {
-    Box::new(BanTypes)
+  fn new() -> Arc<Self> {
+    Arc::new(BanTypes)
   }
 
   fn tags(&self) -> &'static [&'static str] {

--- a/src/rules/ban_unknown_rule_code.rs
+++ b/src/rules/ban_unknown_rule_code.rs
@@ -1,6 +1,7 @@
 // Copyright 2020-2021 the Deno authors. All rights reserved. MIT license.
 use super::{Context, LintRule};
 use crate::{Program, ProgramRef};
+use std::sync::Arc;
 
 /// This is a dummy struct just for having the docs.
 /// The actual implementation resides in [`Context`].
@@ -8,8 +9,8 @@ use crate::{Program, ProgramRef};
 pub struct BanUnknownRuleCode;
 
 impl LintRule for BanUnknownRuleCode {
-  fn new() -> Box<Self> {
-    Box::new(BanUnknownRuleCode)
+  fn new() -> Arc<Self> {
+    Arc::new(BanUnknownRuleCode)
   }
 
   fn tags(&self) -> &'static [&'static str] {

--- a/src/rules/ban_untagged_ignore.rs
+++ b/src/rules/ban_untagged_ignore.rs
@@ -2,6 +2,7 @@
 use super::{Context, LintRule};
 use crate::{Program, ProgramRef};
 use deno_ast::swc::common::Span;
+use std::sync::Arc;
 
 #[derive(Debug)]
 pub struct BanUntaggedIgnore;
@@ -9,8 +10,8 @@ pub struct BanUntaggedIgnore;
 const CODE: &str = "ban-untagged-ignore";
 
 impl LintRule for BanUntaggedIgnore {
-  fn new() -> Box<Self> {
-    Box::new(BanUntaggedIgnore)
+  fn new() -> Arc<Self> {
+    Arc::new(BanUntaggedIgnore)
   }
 
   fn tags(&self) -> &'static [&'static str] {

--- a/src/rules/ban_untagged_todo.rs
+++ b/src/rules/ban_untagged_todo.rs
@@ -5,6 +5,7 @@ use deno_ast::swc::common::comments::Comment;
 use deno_ast::swc::common::comments::CommentKind;
 use once_cell::sync::Lazy;
 use regex::Regex;
+use std::sync::Arc;
 
 #[derive(Debug)]
 pub struct BanUntaggedTodo;
@@ -14,8 +15,8 @@ const MESSAGE: &str = "TODO should be tagged with (@username) or (#issue)";
 const HINT: &str = "Add a user tag or issue reference to the TODO comment, e.g. TODO(@djones), TODO(djones), TODO(#123)";
 
 impl LintRule for BanUntaggedTodo {
-  fn new() -> Box<Self> {
-    Box::new(BanUntaggedTodo)
+  fn new() -> Arc<Self> {
+    Arc::new(BanUntaggedTodo)
   }
 
   fn code(&self) -> &'static str {

--- a/src/rules/ban_unused_ignore.rs
+++ b/src/rules/ban_unused_ignore.rs
@@ -1,6 +1,7 @@
 // Copyright 2020-2021 the Deno authors. All rights reserved. MIT license.
 use super::{Context, LintRule};
 use crate::{Program, ProgramRef};
+use std::sync::Arc;
 
 /// This is a dummy struct just for having the docs.
 /// The actual implementation resides in [`Context`].
@@ -8,8 +9,8 @@ use crate::{Program, ProgramRef};
 pub struct BanUnusedIgnore;
 
 impl LintRule for BanUnusedIgnore {
-  fn new() -> Box<Self> {
-    Box::new(BanUnusedIgnore)
+  fn new() -> Arc<Self> {
+    Arc::new(BanUnusedIgnore)
   }
 
   fn tags(&self) -> &'static [&'static str] {

--- a/src/rules/camelcase.rs
+++ b/src/rules/camelcase.rs
@@ -9,6 +9,7 @@ use deno_ast::view::Spanned;
 use once_cell::sync::Lazy;
 use regex::{Captures, Regex};
 use std::collections::{BTreeMap, BTreeSet};
+use std::sync::Arc;
 
 #[derive(Debug)]
 pub struct Camelcase;
@@ -16,8 +17,8 @@ pub struct Camelcase;
 const CODE: &str = "camelcase";
 
 impl LintRule for Camelcase {
-  fn new() -> Box<Self> {
-    Box::new(Camelcase)
+  fn new() -> Arc<Self> {
+    Arc::new(Camelcase)
   }
 
   fn tags(&self) -> &'static [&'static str] {

--- a/src/rules/constructor_super.rs
+++ b/src/rules/constructor_super.rs
@@ -5,6 +5,7 @@ use crate::{Program, ProgramRef};
 use deno_ast::view as ast_view;
 use deno_ast::view::{Span, Spanned};
 use if_chain::if_chain;
+use std::sync::Arc;
 
 #[derive(Debug)]
 pub struct ConstructorSuper;
@@ -14,8 +15,8 @@ const CODE: &str = "constructor-super";
 // This rule currently differs from the ESlint implementation
 // as there is currently no way of handling code paths in dlint
 impl LintRule for ConstructorSuper {
-  fn new() -> Box<Self> {
-    Box::new(ConstructorSuper)
+  fn new() -> Arc<Self> {
+    Arc::new(ConstructorSuper)
   }
 
   fn tags(&self) -> &'static [&'static str] {

--- a/src/rules/default_param_last.rs
+++ b/src/rules/default_param_last.rs
@@ -5,6 +5,7 @@ use crate::{Program, ProgramRef};
 use deno_ast::swc::common::Spanned;
 use deno_ast::view as ast_view;
 use derive_more::Display;
+use std::sync::Arc;
 
 #[derive(Debug)]
 pub struct DefaultParamLast;
@@ -26,8 +27,8 @@ enum DefaultParamLastHint {
 }
 
 impl LintRule for DefaultParamLast {
-  fn new() -> Box<Self> {
-    Box::new(DefaultParamLast)
+  fn new() -> Arc<Self> {
+    Arc::new(DefaultParamLast)
   }
 
   fn code(&self) -> &'static str {

--- a/src/rules/eqeqeq.rs
+++ b/src/rules/eqeqeq.rs
@@ -6,6 +6,7 @@ use deno_ast::swc::ast::BinaryOp;
 use deno_ast::swc::common::Spanned;
 use deno_ast::view as ast_view;
 use derive_more::Display;
+use std::sync::Arc;
 
 #[derive(Debug)]
 pub struct Eqeqeq;
@@ -29,8 +30,8 @@ enum EqeqeqHint {
 }
 
 impl LintRule for Eqeqeq {
-  fn new() -> Box<Self> {
-    Box::new(Eqeqeq)
+  fn new() -> Arc<Self> {
+    Arc::new(Eqeqeq)
   }
 
   fn code(&self) -> &'static str {

--- a/src/rules/explicit_function_return_type.rs
+++ b/src/rules/explicit_function_return_type.rs
@@ -5,6 +5,7 @@ use crate::{Program, ProgramRef};
 use deno_ast::view as ast_view;
 use deno_ast::view::Spanned;
 use derive_more::Display;
+use std::sync::Arc;
 
 #[derive(Debug)]
 pub struct ExplicitFunctionReturnType;
@@ -24,8 +25,8 @@ enum ExplicitFunctionReturnTypeHint {
 }
 
 impl LintRule for ExplicitFunctionReturnType {
-  fn new() -> Box<Self> {
-    Box::new(ExplicitFunctionReturnType)
+  fn new() -> Arc<Self> {
+    Arc::new(ExplicitFunctionReturnType)
   }
 
   fn code(&self) -> &'static str {

--- a/src/rules/explicit_module_boundary_types.rs
+++ b/src/rules/explicit_module_boundary_types.rs
@@ -6,6 +6,7 @@ use deno_ast::swc::visit::noop_visit_type;
 use deno_ast::swc::visit::Node;
 use deno_ast::swc::visit::Visit;
 use derive_more::Display;
+use std::sync::Arc;
 
 use deno_ast::swc::ast::{
   ArrowExpr, Class, ClassMember, Decl, DefaultDecl, Expr, Function, ModuleDecl,
@@ -36,8 +37,8 @@ enum ExplicitModuleBoundaryTypesHint {
 }
 
 impl LintRule for ExplicitModuleBoundaryTypes {
-  fn new() -> Box<Self> {
-    Box::new(ExplicitModuleBoundaryTypes)
+  fn new() -> Arc<Self> {
+    Arc::new(ExplicitModuleBoundaryTypes)
   }
 
   fn code(&self) -> &'static str {

--- a/src/rules/for_direction.rs
+++ b/src/rules/for_direction.rs
@@ -8,13 +8,14 @@ use deno_ast::swc::ast::UpdateOp;
 use deno_ast::swc::common::Spanned;
 use deno_ast::view as ast_view;
 use deno_ast::view::{AssignExpr, Expr, Pat, PatOrExpr, UnaryOp, UpdateExpr};
+use std::sync::Arc;
 
 #[derive(Debug)]
 pub struct ForDirection;
 
 impl LintRule for ForDirection {
-  fn new() -> Box<Self> {
-    Box::new(ForDirection)
+  fn new() -> Arc<Self> {
+    Arc::new(ForDirection)
   }
 
   fn tags(&self) -> &'static [&'static str] {

--- a/src/rules/getter_return.rs
+++ b/src/rules/getter_return.rs
@@ -14,6 +14,7 @@ use deno_ast::swc::visit::Visit;
 use deno_ast::swc::visit::VisitWith;
 use derive_more::Display;
 use std::collections::BTreeMap;
+use std::sync::Arc;
 
 #[derive(Debug)]
 pub struct GetterReturn;
@@ -35,8 +36,8 @@ enum GetterReturnHint {
 }
 
 impl LintRule for GetterReturn {
-  fn new() -> Box<Self> {
-    Box::new(GetterReturn)
+  fn new() -> Arc<Self> {
+    Arc::new(GetterReturn)
   }
 
   fn tags(&self) -> &'static [&'static str] {

--- a/src/rules/no_array_constructor.rs
+++ b/src/rules/no_array_constructor.rs
@@ -1,10 +1,11 @@
-// Copyright 2020-2021 the Deno authors. All rights reserved. MIT license.use super::{Context, LintRule};
+// Copyright 2020-2021 the Deno authors. All rights reserved. MIT license.
 use super::{Context, LintRule};
 use crate::handler::{Handler, Traverse};
 use crate::{Program, ProgramRef};
 use deno_ast::swc::common::Span;
 use deno_ast::swc::common::Spanned;
 use deno_ast::view::{CallExpr, Expr, ExprOrSpread, ExprOrSuper, NewExpr};
+use std::sync::Arc;
 
 #[derive(Debug)]
 pub struct NoArrayConstructor;
@@ -14,8 +15,8 @@ const MESSAGE: &str = "Array Constructor is not allowed";
 const HINT: &str = "Use array literal notation (e.g. []) or single argument specifying array size only (e.g. new Array(5)";
 
 impl LintRule for NoArrayConstructor {
-  fn new() -> Box<Self> {
-    Box::new(NoArrayConstructor)
+  fn new() -> Arc<Self> {
+    Arc::new(NoArrayConstructor)
   }
 
   fn tags(&self) -> &'static [&'static str] {

--- a/src/rules/no_async_promise_executor.rs
+++ b/src/rules/no_async_promise_executor.rs
@@ -4,6 +4,7 @@ use crate::handler::{Handler, Traverse};
 use crate::{Program, ProgramRef};
 use deno_ast::swc::common::Spanned;
 use deno_ast::view::{Expr, NewExpr, ParenExpr};
+use std::sync::Arc;
 
 #[derive(Debug)]
 pub struct NoAsyncPromiseExecutor;
@@ -14,8 +15,8 @@ const HINT: &str =
   "Remove `async` from executor function and adjust promise code as needed";
 
 impl LintRule for NoAsyncPromiseExecutor {
-  fn new() -> Box<Self> {
-    Box::new(NoAsyncPromiseExecutor)
+  fn new() -> Arc<Self> {
+    Arc::new(NoAsyncPromiseExecutor)
   }
 
   fn tags(&self) -> &'static [&'static str] {

--- a/src/rules/no_await_in_loop.rs
+++ b/src/rules/no_await_in_loop.rs
@@ -5,6 +5,7 @@ use crate::{Program, ProgramRef};
 use deno_ast::swc::common::Spanned;
 use deno_ast::view as ast_view;
 use deno_ast::view::NodeTrait;
+use std::sync::Arc;
 
 #[derive(Debug)]
 pub struct NoAwaitInLoop;
@@ -14,8 +15,8 @@ const MESSAGE: &str = "Unexpected `await` inside a loop.";
 const HINT: &str = "Remove `await` in loop body, store all promises generated and then `await Promise.all(storedPromises)` after the loop";
 
 impl LintRule for NoAwaitInLoop {
-  fn new() -> Box<Self> {
-    Box::new(NoAwaitInLoop)
+  fn new() -> Arc<Self> {
+    Arc::new(NoAwaitInLoop)
   }
 
   fn code(&self) -> &'static str {

--- a/src/rules/no_case_declarations.rs
+++ b/src/rules/no_case_declarations.rs
@@ -4,6 +4,7 @@ use crate::handler::{Handler, Traverse};
 use crate::{Program, ProgramRef};
 use deno_ast::swc::common::Spanned;
 use deno_ast::view::{Decl, Stmt, SwitchCase, VarDeclKind};
+use std::sync::Arc;
 
 #[derive(Debug)]
 pub struct NoCaseDeclarations;
@@ -13,8 +14,8 @@ const MESSAGE: &str = "Unexpected declaration in case";
 const HINT: &str = "Wrap switch case and default blocks in brackets";
 
 impl LintRule for NoCaseDeclarations {
-  fn new() -> Box<Self> {
-    Box::new(NoCaseDeclarations)
+  fn new() -> Arc<Self> {
+    Arc::new(NoCaseDeclarations)
   }
 
   fn tags(&self) -> &'static [&'static str] {

--- a/src/rules/no_class_assign.rs
+++ b/src/rules/no_class_assign.rs
@@ -7,6 +7,7 @@ use deno_ast::swc::visit::noop_visit_type;
 use deno_ast::swc::visit::Node;
 use deno_ast::swc::visit::VisitAll;
 use deno_ast::swc::visit::VisitAllWith;
+use std::sync::Arc;
 
 #[derive(Debug)]
 pub struct NoClassAssign;
@@ -16,8 +17,8 @@ const MESSAGE: &str = "Reassigning class declaration is not allowed";
 const HINT: &str = "Do you have the right variable here?";
 
 impl LintRule for NoClassAssign {
-  fn new() -> Box<Self> {
-    Box::new(NoClassAssign)
+  fn new() -> Arc<Self> {
+    Arc::new(NoClassAssign)
   }
 
   fn tags(&self) -> &'static [&'static str] {

--- a/src/rules/no_compare_neg_zero.rs
+++ b/src/rules/no_compare_neg_zero.rs
@@ -9,6 +9,7 @@ use deno_ast::swc::ast::UnaryOp::Minus;
 use deno_ast::swc::ast::{BinExpr, BinaryOp, Expr};
 use deno_ast::swc::visit::{noop_visit_type, Node, VisitAll, VisitAllWith};
 use derive_more::Display;
+use std::sync::Arc;
 
 #[derive(Debug)]
 pub struct NoCompareNegZero;
@@ -30,8 +31,8 @@ enum NoCompareNegZeroHint {
 }
 
 impl LintRule for NoCompareNegZero {
-  fn new() -> Box<Self> {
-    Box::new(NoCompareNegZero)
+  fn new() -> Arc<Self> {
+    Arc::new(NoCompareNegZero)
   }
 
   fn tags(&self) -> &'static [&'static str] {

--- a/src/rules/no_cond_assign.rs
+++ b/src/rules/no_cond_assign.rs
@@ -6,6 +6,7 @@ use deno_ast::swc::ast::Expr::{Assign, Bin, Paren};
 use deno_ast::swc::common::Span;
 use deno_ast::swc::visit::{noop_visit_type, Node, VisitAll, VisitAllWith};
 use derive_more::Display;
+use std::sync::Arc;
 
 #[derive(Debug)]
 pub struct NoCondAssign;
@@ -29,8 +30,8 @@ enum NoCondAssignHint {
 }
 
 impl LintRule for NoCondAssign {
-  fn new() -> Box<Self> {
-    Box::new(NoCondAssign)
+  fn new() -> Arc<Self> {
+    Arc::new(NoCondAssign)
   }
 
   fn tags(&self) -> &'static [&'static str] {

--- a/src/rules/no_const_assign.rs
+++ b/src/rules/no_const_assign.rs
@@ -12,6 +12,7 @@ use deno_ast::swc::common::Span;
 use deno_ast::swc::visit::Node;
 use deno_ast::swc::{utils::ident::IdentLike, visit::Visit};
 use derive_more::Display;
+use std::sync::Arc;
 
 #[derive(Debug)]
 pub struct NoConstAssign;
@@ -32,8 +33,8 @@ enum NoConstantAssignHint {
   Remove,
 }
 impl LintRule for NoConstAssign {
-  fn new() -> Box<Self> {
-    Box::new(NoConstAssign)
+  fn new() -> Arc<Self> {
+    Arc::new(NoConstAssign)
   }
 
   fn code(&self) -> &'static str {

--- a/src/rules/no_constant_condition.rs
+++ b/src/rules/no_constant_condition.rs
@@ -6,6 +6,7 @@ use deno_ast::swc::common::Span;
 use deno_ast::swc::common::Spanned;
 use deno_ast::swc::visit::{noop_visit_type, Node, VisitAll, VisitAllWith};
 use derive_more::Display;
+use std::sync::Arc;
 
 #[derive(Debug)]
 pub struct NoConstantCondition;
@@ -27,8 +28,8 @@ enum NoConstantConditionHint {
 }
 
 impl LintRule for NoConstantCondition {
-  fn new() -> Box<Self> {
-    Box::new(NoConstantCondition)
+  fn new() -> Arc<Self> {
+    Arc::new(NoConstantCondition)
   }
 
   fn tags(&self) -> &'static [&'static str] {

--- a/src/rules/no_control_regex.rs
+++ b/src/rules/no_control_regex.rs
@@ -10,6 +10,7 @@ use deno_ast::swc::visit::{VisitAll, VisitAllWith};
 use derive_more::Display;
 use std::iter::Peekable;
 use std::str::Chars;
+use std::sync::Arc;
 
 #[derive(Debug)]
 pub struct NoControlRegex;
@@ -34,8 +35,8 @@ enum NoControlRegexHint {
 }
 
 impl LintRule for NoControlRegex {
-  fn new() -> Box<Self> {
-    Box::new(NoControlRegex)
+  fn new() -> Arc<Self> {
+    Arc::new(NoControlRegex)
   }
 
   fn tags(&self) -> &'static [&'static str] {

--- a/src/rules/no_debugger.rs
+++ b/src/rules/no_debugger.rs
@@ -6,6 +6,7 @@ use deno_ast::swc::visit::noop_visit_type;
 use deno_ast::swc::visit::Node;
 use deno_ast::swc::visit::Visit;
 use derive_more::Display;
+use std::sync::Arc;
 
 #[derive(Debug)]
 pub struct NoDebugger;
@@ -25,8 +26,8 @@ enum NoDebuggerHint {
 }
 
 impl LintRule for NoDebugger {
-  fn new() -> Box<Self> {
-    Box::new(NoDebugger)
+  fn new() -> Arc<Self> {
+    Arc::new(NoDebugger)
   }
 
   fn tags(&self) -> &'static [&'static str] {

--- a/src/rules/no_delete_var.rs
+++ b/src/rules/no_delete_var.rs
@@ -8,6 +8,7 @@ use deno_ast::swc::visit::noop_visit_type;
 use deno_ast::swc::visit::Node;
 use deno_ast::swc::visit::Visit;
 use derive_more::Display;
+use std::sync::Arc;
 
 #[derive(Debug)]
 pub struct NoDeleteVar;
@@ -27,8 +28,8 @@ enum NoDeleteVarHint {
 }
 
 impl LintRule for NoDeleteVar {
-  fn new() -> Box<Self> {
-    Box::new(NoDeleteVar)
+  fn new() -> Arc<Self> {
+    Arc::new(NoDeleteVar)
   }
 
   fn tags(&self) -> &'static [&'static str] {

--- a/src/rules/no_deprecated_deno_api.rs
+++ b/src/rules/no_deprecated_deno_api.rs
@@ -8,6 +8,7 @@ use deno_ast::swc::utils::ident::IdentLike;
 use deno_ast::view as ast_view;
 use if_chain::if_chain;
 use std::convert::TryFrom;
+use std::sync::Arc;
 
 #[derive(Debug)]
 pub struct NoDeprecatedDenoApi;
@@ -15,8 +16,8 @@ pub struct NoDeprecatedDenoApi;
 const CODE: &str = "no-deprecated-deno-api";
 
 impl LintRule for NoDeprecatedDenoApi {
-  fn new() -> Box<Self> {
-    Box::new(NoDeprecatedDenoApi)
+  fn new() -> Arc<Self> {
+    Arc::new(NoDeprecatedDenoApi)
   }
 
   fn tags(&self) -> &'static [&'static str] {

--- a/src/rules/no_dupe_args.rs
+++ b/src/rules/no_dupe_args.rs
@@ -11,6 +11,7 @@ use deno_ast::swc::visit::Node;
 use deno_ast::swc::visit::{VisitAll, VisitAllWith};
 use derive_more::Display;
 use std::collections::{BTreeSet, HashSet};
+use std::sync::Arc;
 
 #[derive(Debug)]
 pub struct NoDupeArgs;
@@ -30,8 +31,8 @@ enum NoDupeArgsHint {
 }
 
 impl LintRule for NoDupeArgs {
-  fn new() -> Box<Self> {
-    Box::new(NoDupeArgs)
+  fn new() -> Arc<Self> {
+    Arc::new(NoDupeArgs)
   }
 
   fn tags(&self) -> &'static [&'static str] {

--- a/src/rules/no_dupe_class_members.rs
+++ b/src/rules/no_dupe_class_members.rs
@@ -10,6 +10,7 @@ use deno_ast::swc::visit::{noop_visit_type, Node, Visit, VisitWith};
 use derive_more::Display;
 use std::cmp::Ordering;
 use std::collections::BTreeMap;
+use std::sync::Arc;
 
 #[derive(Debug)]
 pub struct NoDupeClassMembers;
@@ -29,8 +30,8 @@ enum NoDupeClassMembersHint {
 }
 
 impl LintRule for NoDupeClassMembers {
-  fn new() -> Box<Self> {
-    Box::new(NoDupeClassMembers)
+  fn new() -> Arc<Self> {
+    Arc::new(NoDupeClassMembers)
   }
 
   fn tags(&self) -> &'static [&'static str] {

--- a/src/rules/no_dupe_else_if.rs
+++ b/src/rules/no_dupe_else_if.rs
@@ -7,6 +7,7 @@ use deno_ast::swc::utils::drop_span;
 use deno_ast::swc::visit::{noop_visit_type, Node, VisitAll, VisitAllWith};
 use derive_more::Display;
 use std::collections::HashSet;
+use std::sync::Arc;
 
 #[derive(Debug)]
 pub struct NoDupeElseIf;
@@ -30,8 +31,8 @@ enum NoDupeElseIfHint {
 }
 
 impl LintRule for NoDupeElseIf {
-  fn new() -> Box<Self> {
-    Box::new(NoDupeElseIf)
+  fn new() -> Arc<Self> {
+    Arc::new(NoDupeElseIf)
   }
 
   fn tags(&self) -> &'static [&'static str] {

--- a/src/rules/no_dupe_keys.rs
+++ b/src/rules/no_dupe_keys.rs
@@ -11,6 +11,7 @@ use deno_ast::swc::visit::{noop_visit_type, Node, VisitAll, VisitAllWith};
 use derive_more::Display;
 use std::collections::hash_map::Entry;
 use std::collections::HashMap;
+use std::sync::Arc;
 
 #[derive(Debug)]
 pub struct NoDupeKeys;
@@ -30,8 +31,8 @@ enum NoDupeKeysHint {
 }
 
 impl LintRule for NoDupeKeys {
-  fn new() -> Box<Self> {
-    Box::new(NoDupeKeys)
+  fn new() -> Arc<Self> {
+    Arc::new(NoDupeKeys)
   }
 
   fn tags(&self) -> &'static [&'static str] {

--- a/src/rules/no_duplicate_case.rs
+++ b/src/rules/no_duplicate_case.rs
@@ -8,6 +8,7 @@ use deno_ast::swc::visit::Node;
 use deno_ast::swc::visit::{VisitAll, VisitAllWith};
 use derive_more::Display;
 use std::collections::HashSet;
+use std::sync::Arc;
 
 #[derive(Debug)]
 pub struct NoDuplicateCase;
@@ -27,8 +28,8 @@ enum NoDuplicateCaseHint {
 }
 
 impl LintRule for NoDuplicateCase {
-  fn new() -> Box<Self> {
-    Box::new(NoDuplicateCase)
+  fn new() -> Arc<Self> {
+    Arc::new(NoDuplicateCase)
   }
 
   fn tags(&self) -> &'static [&'static str] {

--- a/src/rules/no_empty.rs
+++ b/src/rules/no_empty.rs
@@ -5,6 +5,7 @@ use deno_ast::swc::ast::{
   ArrowExpr, BlockStmt, BlockStmtOrExpr, Constructor, Function, SwitchStmt,
 };
 use deno_ast::swc::visit::{noop_visit_type, Node, Visit, VisitWith};
+use std::sync::Arc;
 
 #[derive(Debug)]
 pub struct NoEmpty;
@@ -12,8 +13,8 @@ pub struct NoEmpty;
 const CODE: &str = "no-empty";
 
 impl LintRule for NoEmpty {
-  fn new() -> Box<Self> {
-    Box::new(NoEmpty)
+  fn new() -> Arc<Self> {
+    Arc::new(NoEmpty)
   }
 
   fn tags(&self) -> &'static [&'static str] {

--- a/src/rules/no_empty_character_class.rs
+++ b/src/rules/no_empty_character_class.rs
@@ -6,6 +6,7 @@ use deno_ast::swc::visit::noop_visit_type;
 use deno_ast::swc::visit::Node;
 use deno_ast::swc::visit::Visit;
 use once_cell::sync::Lazy;
+use std::sync::Arc;
 
 #[derive(Debug)]
 pub struct NoEmptyCharacterClass;
@@ -16,8 +17,8 @@ const HINT: &str =
   "Remove or rework the empty character class (`[]`) in the RegExp";
 
 impl LintRule for NoEmptyCharacterClass {
-  fn new() -> Box<Self> {
-    Box::new(NoEmptyCharacterClass)
+  fn new() -> Arc<Self> {
+    Arc::new(NoEmptyCharacterClass)
   }
 
   fn tags(&self) -> &'static [&'static str] {

--- a/src/rules/no_empty_enum.rs
+++ b/src/rules/no_empty_enum.rs
@@ -4,6 +4,7 @@ use crate::handler::{Handler, Traverse};
 use crate::{Program, ProgramRef};
 use deno_ast::swc::common::Spanned;
 use deno_ast::view as ast_view;
+use std::sync::Arc;
 
 #[derive(Debug)]
 pub struct NoEmptyEnum;
@@ -12,8 +13,8 @@ const CODE: &str = "no-empty-enum";
 const MESSAGE: &str = "An empty enum is equivalent to `{}`. Remove this enum or add members to this enum.";
 
 impl LintRule for NoEmptyEnum {
-  fn new() -> Box<Self> {
-    Box::new(NoEmptyEnum)
+  fn new() -> Arc<Self> {
+    Arc::new(NoEmptyEnum)
   }
 
   fn tags(&self) -> &'static [&'static str] {

--- a/src/rules/no_empty_interface.rs
+++ b/src/rules/no_empty_interface.rs
@@ -5,6 +5,7 @@ use deno_ast::swc::ast::TsInterfaceDecl;
 use deno_ast::swc::visit::Node;
 use deno_ast::swc::visit::Visit;
 use derive_more::Display;
+use std::sync::Arc;
 
 #[derive(Debug)]
 pub struct NoEmptyInterface;
@@ -32,8 +33,8 @@ enum NoEmptyInterfaceHint {
 }
 
 impl LintRule for NoEmptyInterface {
-  fn new() -> Box<Self> {
-    Box::new(NoEmptyInterface)
+  fn new() -> Arc<Self> {
+    Arc::new(NoEmptyInterface)
   }
 
   fn tags(&self) -> &'static [&'static str] {

--- a/src/rules/no_empty_pattern.rs
+++ b/src/rules/no_empty_pattern.rs
@@ -5,6 +5,7 @@ use deno_ast::swc::ast::{ArrayPat, ObjectPat, ObjectPatProp};
 use deno_ast::swc::visit::noop_visit_type;
 use deno_ast::swc::visit::Node;
 use deno_ast::swc::visit::Visit;
+use std::sync::Arc;
 
 #[derive(Debug)]
 pub struct NoEmptyPattern;
@@ -15,8 +16,8 @@ const HINT: &str =
   "Add variable to pattern or apply correct default value syntax with `=`";
 
 impl LintRule for NoEmptyPattern {
-  fn new() -> Box<Self> {
-    Box::new(NoEmptyPattern)
+  fn new() -> Arc<Self> {
+    Arc::new(NoEmptyPattern)
   }
 
   fn tags(&self) -> &'static [&'static str] {

--- a/src/rules/no_eval.rs
+++ b/src/rules/no_eval.rs
@@ -11,6 +11,7 @@ use deno_ast::swc::common::Span;
 use deno_ast::swc::visit::noop_visit_type;
 use deno_ast::swc::visit::Node;
 use deno_ast::swc::visit::Visit;
+use std::sync::Arc;
 
 #[derive(Debug)]
 pub struct NoEval;
@@ -20,8 +21,8 @@ const MESSAGE: &str = "`eval` call is not allowed";
 const HINT: &str = "Remove the use of `eval`";
 
 impl LintRule for NoEval {
-  fn new() -> Box<Self> {
-    Box::new(NoEval)
+  fn new() -> Arc<Self> {
+    Arc::new(NoEval)
   }
 
   fn code(&self) -> &'static str {

--- a/src/rules/no_ex_assign.rs
+++ b/src/rules/no_ex_assign.rs
@@ -3,6 +3,7 @@ use super::{Context, LintRule, DUMMY_NODE};
 use crate::ProgramRef;
 use crate::{scopes::BindingKind, swc_util::find_lhs_ids};
 use derive_more::Display;
+use std::sync::Arc;
 
 use deno_ast::swc::ast::AssignExpr;
 use deno_ast::swc::visit::{noop_visit_type, Node, VisitAll, VisitAllWith};
@@ -25,8 +26,8 @@ enum NoExAssignHint {
 }
 
 impl LintRule for NoExAssign {
-  fn new() -> Box<Self> {
-    Box::new(NoExAssign)
+  fn new() -> Arc<Self> {
+    Arc::new(NoExAssign)
   }
 
   fn tags(&self) -> &'static [&'static str] {

--- a/src/rules/no_explicit_any.rs
+++ b/src/rules/no_explicit_any.rs
@@ -4,6 +4,7 @@ use crate::ProgramRef;
 use deno_ast::swc::ast::TsKeywordType;
 use deno_ast::swc::visit::Node;
 use deno_ast::swc::visit::Visit;
+use std::sync::Arc;
 
 #[derive(Debug)]
 pub struct NoExplicitAny;
@@ -13,8 +14,8 @@ const MESSAGE: &str = "`any` type is not allowed";
 const HINT: &str = "Use a specific type other than `any`";
 
 impl LintRule for NoExplicitAny {
-  fn new() -> Box<Self> {
-    Box::new(NoExplicitAny)
+  fn new() -> Arc<Self> {
+    Arc::new(NoExplicitAny)
   }
 
   fn tags(&self) -> &'static [&'static str] {

--- a/src/rules/no_extra_boolean_cast.rs
+++ b/src/rules/no_extra_boolean_cast.rs
@@ -10,6 +10,7 @@ use deno_ast::swc::visit::noop_visit_type;
 use deno_ast::swc::visit::Node;
 use deno_ast::swc::visit::{VisitAll, VisitAllWith};
 use derive_more::Display;
+use std::sync::Arc;
 
 #[derive(Debug)]
 pub struct NoExtraBooleanCast;
@@ -33,8 +34,8 @@ enum NoExtraBooleanCastHint {
 }
 
 impl LintRule for NoExtraBooleanCast {
-  fn new() -> Box<Self> {
-    Box::new(NoExtraBooleanCast)
+  fn new() -> Arc<Self> {
+    Arc::new(NoExtraBooleanCast)
   }
 
   fn tags(&self) -> &'static [&'static str] {

--- a/src/rules/no_extra_non_null_assertion.rs
+++ b/src/rules/no_extra_non_null_assertion.rs
@@ -9,6 +9,7 @@ use deno_ast::swc::common::Span;
 use deno_ast::swc::visit::Node;
 use deno_ast::swc::visit::{VisitAll, VisitAllWith};
 use derive_more::Display;
+use std::sync::Arc;
 
 #[derive(Debug)]
 pub struct NoExtraNonNullAssertion;
@@ -28,8 +29,8 @@ enum NoExtraNonNullAssertionHint {
 }
 
 impl LintRule for NoExtraNonNullAssertion {
-  fn new() -> Box<Self> {
-    Box::new(NoExtraNonNullAssertion)
+  fn new() -> Arc<Self> {
+    Arc::new(NoExtraNonNullAssertion)
   }
 
   fn tags(&self) -> &'static [&'static str] {

--- a/src/rules/no_extra_semi.rs
+++ b/src/rules/no_extra_semi.rs
@@ -7,6 +7,7 @@ use deno_ast::swc::ast::{
 };
 use deno_ast::swc::visit::{noop_visit_type, Node, Visit, VisitWith};
 use derive_more::Display;
+use std::sync::Arc;
 
 #[derive(Debug)]
 pub struct NoExtraSemi;
@@ -26,8 +27,8 @@ enum NoExtraSemiHint {
 }
 
 impl LintRule for NoExtraSemi {
-  fn new() -> Box<Self> {
-    Box::new(NoExtraSemi)
+  fn new() -> Arc<Self> {
+    Arc::new(NoExtraSemi)
   }
 
   fn tags(&self) -> &'static [&'static str] {

--- a/src/rules/no_fallthrough.rs
+++ b/src/rules/no_fallthrough.rs
@@ -7,6 +7,7 @@ use deno_ast::swc::{
   visit::{noop_visit_type, Node, Visit, VisitWith},
 };
 use derive_more::Display;
+use std::sync::Arc;
 
 #[derive(Debug)]
 pub struct NoFallthrough;
@@ -28,8 +29,8 @@ enum NoFallthroughHint {
 }
 
 impl LintRule for NoFallthrough {
-  fn new() -> Box<Self> {
-    Box::new(NoFallthrough)
+  fn new() -> Arc<Self> {
+    Arc::new(NoFallthrough)
   }
 
   fn tags(&self) -> &'static [&'static str] {

--- a/src/rules/no_func_assign.rs
+++ b/src/rules/no_func_assign.rs
@@ -7,6 +7,7 @@ use deno_ast::swc::visit::noop_visit_type;
 use deno_ast::swc::visit::Node;
 use deno_ast::swc::visit::{VisitAll, VisitAllWith};
 use derive_more::Display;
+use std::sync::Arc;
 
 #[derive(Debug)]
 pub struct NoFuncAssign;
@@ -28,8 +29,8 @@ enum NoFuncAssignHint {
 }
 
 impl LintRule for NoFuncAssign {
-  fn new() -> Box<Self> {
-    Box::new(NoFuncAssign)
+  fn new() -> Arc<Self> {
+    Arc::new(NoFuncAssign)
   }
 
   fn tags(&self) -> &'static [&'static str] {

--- a/src/rules/no_global_assign.rs
+++ b/src/rules/no_global_assign.rs
@@ -11,6 +11,7 @@ use deno_ast::swc::{
   visit::{noop_visit_type, Visit, VisitWith},
 };
 use derive_more::Display;
+use std::sync::Arc;
 
 #[derive(Debug)]
 pub struct NoGlobalAssign;
@@ -30,8 +31,8 @@ enum NoGlobalAssignHint {
 }
 
 impl LintRule for NoGlobalAssign {
-  fn new() -> Box<Self> {
-    Box::new(NoGlobalAssign)
+  fn new() -> Arc<Self> {
+    Arc::new(NoGlobalAssign)
   }
 
   fn tags(&self) -> &'static [&'static str] {

--- a/src/rules/no_import_assign.rs
+++ b/src/rules/no_import_assign.rs
@@ -11,6 +11,7 @@ use deno_ast::swc::{
   visit::Node,
   visit::{noop_visit_type, Visit, VisitWith},
 };
+use std::sync::Arc;
 
 #[derive(Debug)]
 pub struct NoImportAssign;
@@ -20,8 +21,8 @@ const MESSAGE: &str = "Assignment to import is not allowed";
 const HINT: &str = "Assign to another variable, this assignment is invalid";
 
 impl LintRule for NoImportAssign {
-  fn new() -> Box<Self> {
-    Box::new(NoImportAssign)
+  fn new() -> Arc<Self> {
+    Arc::new(NoImportAssign)
   }
 
   fn tags(&self) -> &'static [&'static str] {

--- a/src/rules/no_inferrable_types.rs
+++ b/src/rules/no_inferrable_types.rs
@@ -10,6 +10,7 @@ use deno_ast::swc::common::Span;
 use deno_ast::swc::visit::Node;
 use deno_ast::swc::visit::{VisitAll, VisitAllWith};
 use derive_more::Display;
+use std::sync::Arc;
 
 #[derive(Debug)]
 pub struct NoInferrableTypes;
@@ -29,8 +30,8 @@ enum NoInferrableTypesHint {
 }
 
 impl LintRule for NoInferrableTypes {
-  fn new() -> Box<Self> {
-    Box::new(NoInferrableTypes)
+  fn new() -> Arc<Self> {
+    Arc::new(NoInferrableTypes)
   }
 
   fn tags(&self) -> &'static [&'static str] {

--- a/src/rules/no_inner_declarations.rs
+++ b/src/rules/no_inner_declarations.rs
@@ -12,6 +12,7 @@ use deno_ast::swc::visit::{
 };
 use derive_more::Display;
 use std::collections::HashSet;
+use std::sync::Arc;
 
 #[derive(Debug)]
 pub struct NoInnerDeclarations;
@@ -31,8 +32,8 @@ enum NoInnerDeclarationsHint {
 }
 
 impl LintRule for NoInnerDeclarations {
-  fn new() -> Box<Self> {
-    Box::new(NoInnerDeclarations)
+  fn new() -> Arc<Self> {
+    Arc::new(NoInnerDeclarations)
   }
 
   fn tags(&self) -> &'static [&'static str] {

--- a/src/rules/no_invalid_regexp.rs
+++ b/src/rules/no_invalid_regexp.rs
@@ -8,6 +8,7 @@ use deno_ast::swc::common::Span;
 use deno_ast::swc::visit::noop_visit_type;
 use deno_ast::swc::visit::Node;
 use deno_ast::swc::visit::Visit;
+use std::sync::Arc;
 
 #[derive(Debug)]
 pub struct NoInvalidRegexp;
@@ -17,8 +18,8 @@ const MESSAGE: &str = "Invalid RegExp literal";
 const HINT: &str = "Rework regular expression to be a valid";
 
 impl LintRule for NoInvalidRegexp {
-  fn new() -> Box<Self> {
-    Box::new(NoInvalidRegexp)
+  fn new() -> Arc<Self> {
+    Arc::new(NoInvalidRegexp)
   }
 
   fn tags(&self) -> &'static [&'static str] {

--- a/src/rules/no_invalid_triple_slash_reference.rs
+++ b/src/rules/no_invalid_triple_slash_reference.rs
@@ -5,6 +5,7 @@ use deno_ast::swc::common::comments::{Comment, CommentKind};
 use deno_ast::swc::common::Span;
 use once_cell::sync::Lazy;
 use regex::Regex;
+use std::sync::Arc;
 
 #[derive(Debug)]
 pub struct NoInvalidTripleSlashReference;
@@ -12,8 +13,8 @@ pub struct NoInvalidTripleSlashReference;
 const CODE: &str = "no-invalid-triple-slash-reference";
 
 impl LintRule for NoInvalidTripleSlashReference {
-  fn new() -> Box<Self> {
-    Box::new(NoInvalidTripleSlashReference)
+  fn new() -> Arc<Self> {
+    Arc::new(NoInvalidTripleSlashReference)
   }
 
   fn tags(&self) -> &'static [&'static str] {

--- a/src/rules/no_irregular_whitespace.rs
+++ b/src/rules/no_irregular_whitespace.rs
@@ -6,6 +6,7 @@ use deno_ast::view::RootNode;
 use derive_more::Display;
 use once_cell::sync::Lazy;
 use regex::{Matches, Regex};
+use std::sync::Arc;
 
 #[derive(Debug)]
 pub struct NoIrregularWhitespace;
@@ -39,8 +40,8 @@ fn test_for_whitespace(value: &str) -> Vec<Matches> {
 }
 
 impl LintRule for NoIrregularWhitespace {
-  fn new() -> Box<Self> {
-    Box::new(NoIrregularWhitespace)
+  fn new() -> Arc<Self> {
+    Arc::new(NoIrregularWhitespace)
   }
 
   fn tags(&self) -> &'static [&'static str] {

--- a/src/rules/no_misused_new.rs
+++ b/src/rules/no_misused_new.rs
@@ -9,6 +9,7 @@ use deno_ast::swc::ast::{
 use deno_ast::swc::visit::Node;
 use deno_ast::swc::visit::{VisitAll, VisitAllWith};
 use derive_more::Display;
+use std::sync::Arc;
 
 #[derive(Debug)]
 pub struct NoMisusedNew;
@@ -36,8 +37,8 @@ enum NoMisusedNewHint {
 }
 
 impl LintRule for NoMisusedNew {
-  fn new() -> Box<Self> {
-    Box::new(NoMisusedNew)
+  fn new() -> Arc<Self> {
+    Arc::new(NoMisusedNew)
   }
 
   fn lint_program<'view>(

--- a/src/rules/no_namespace.rs
+++ b/src/rules/no_namespace.rs
@@ -5,6 +5,7 @@ use crate::{Program, ProgramRef};
 use deno_ast::swc::common::Spanned;
 use deno_ast::view as ast_view;
 use deno_ast::view::NodeTrait;
+use std::sync::Arc;
 
 #[derive(Debug)]
 pub struct NoNamespace;
@@ -16,8 +17,8 @@ const HINT: &str = "Use ES2015 module syntax (`import`/`export`) to organize
 the code instead";
 
 impl LintRule for NoNamespace {
-  fn new() -> Box<Self> {
-    Box::new(NoNamespace)
+  fn new() -> Arc<Self> {
+    Arc::new(NoNamespace)
   }
 
   fn tags(&self) -> &'static [&'static str] {

--- a/src/rules/no_new_symbol.rs
+++ b/src/rules/no_new_symbol.rs
@@ -7,6 +7,7 @@ use deno_ast::swc::visit::noop_visit_type;
 use deno_ast::swc::visit::Node;
 use deno_ast::swc::visit::{VisitAll, VisitAllWith};
 use if_chain::if_chain;
+use std::sync::Arc;
 
 #[derive(Debug)]
 pub struct NoNewSymbol;
@@ -15,8 +16,8 @@ const CODE: &str = "no-new-symbol";
 const MESSAGE: &str = "`Symbol` cannot be called as a constructor.";
 
 impl LintRule for NoNewSymbol {
-  fn new() -> Box<Self> {
-    Box::new(NoNewSymbol)
+  fn new() -> Arc<Self> {
+    Arc::new(NoNewSymbol)
   }
 
   fn tags(&self) -> &'static [&'static str] {

--- a/src/rules/no_non_null_asserted_optional_chain.rs
+++ b/src/rules/no_non_null_asserted_optional_chain.rs
@@ -5,6 +5,7 @@ use deno_ast::swc::ast::{Expr, ExprOrSuper};
 use deno_ast::swc::visit::Node;
 use deno_ast::swc::visit::Visit;
 use derive_more::Display;
+use std::sync::Arc;
 
 use deno_ast::swc::common::Span;
 
@@ -22,8 +23,8 @@ enum NoNonNullAssertedOptionalChainMessage {
 }
 
 impl LintRule for NoNonNullAssertedOptionalChain {
-  fn new() -> Box<Self> {
-    Box::new(NoNonNullAssertedOptionalChain)
+  fn new() -> Arc<Self> {
+    Arc::new(NoNonNullAssertedOptionalChain)
   }
 
   fn code(&self) -> &'static str {

--- a/src/rules/no_non_null_assertion.rs
+++ b/src/rules/no_non_null_assertion.rs
@@ -4,6 +4,7 @@ use crate::ProgramRef;
 use deno_ast::swc::visit::Node;
 use deno_ast::swc::visit::Visit;
 use derive_more::Display;
+use std::sync::Arc;
 
 #[derive(Debug)]
 pub struct NoNonNullAssertion;
@@ -17,8 +18,8 @@ enum NoNonNullAssertionMessage {
 }
 
 impl LintRule for NoNonNullAssertion {
-  fn new() -> Box<Self> {
-    Box::new(NoNonNullAssertion)
+  fn new() -> Arc<Self> {
+    Arc::new(NoNonNullAssertion)
   }
 
   fn code(&self) -> &'static str {

--- a/src/rules/no_obj_calls.rs
+++ b/src/rules/no_obj_calls.rs
@@ -5,6 +5,7 @@ use deno_ast::swc::ast::{CallExpr, Expr, ExprOrSuper, Ident, NewExpr};
 use deno_ast::swc::common::Span;
 use deno_ast::swc::utils::ident::IdentLike;
 use deno_ast::swc::visit::{noop_visit_type, Node, Visit};
+use std::sync::Arc;
 
 #[derive(Debug)]
 pub struct NoObjCalls;
@@ -16,8 +17,8 @@ fn get_message(callee_name: &str) -> String {
 }
 
 impl LintRule for NoObjCalls {
-  fn new() -> Box<Self> {
-    Box::new(NoObjCalls)
+  fn new() -> Arc<Self> {
+    Arc::new(NoObjCalls)
   }
 
   fn tags(&self) -> &'static [&'static str] {

--- a/src/rules/no_octal.rs
+++ b/src/rules/no_octal.rs
@@ -6,6 +6,7 @@ use deno_ast::swc::visit::Node;
 use deno_ast::swc::visit::Visit;
 use once_cell::sync::Lazy;
 use regex::Regex;
+use std::sync::Arc;
 
 #[derive(Debug)]
 pub struct NoOctal;
@@ -15,8 +16,8 @@ const MESSAGE: &str = "Numeric literals beginning with `0` are not allowed";
 const HINT: &str = "To express octal numbers, use `0o` as a prefix instead";
 
 impl LintRule for NoOctal {
-  fn new() -> Box<Self> {
-    Box::new(NoOctal)
+  fn new() -> Arc<Self> {
+    Arc::new(NoOctal)
   }
 
   fn tags(&self) -> &'static [&'static str] {

--- a/src/rules/no_prototype_builtins.rs
+++ b/src/rules/no_prototype_builtins.rs
@@ -1,6 +1,7 @@
 // Copyright 2020-2021 the Deno authors. All rights reserved. MIT license.
 use super::{Context, LintRule, DUMMY_NODE};
 use crate::ProgramRef;
+use std::sync::Arc;
 
 use deno_ast::swc::ast::CallExpr;
 use deno_ast::swc::ast::Expr;
@@ -25,8 +26,8 @@ fn get_message(prop: &str) -> String {
 }
 
 impl LintRule for NoPrototypeBuiltins {
-  fn new() -> Box<Self> {
-    Box::new(NoPrototypeBuiltins)
+  fn new() -> Arc<Self> {
+    Arc::new(NoPrototypeBuiltins)
   }
 
   fn tags(&self) -> &'static [&'static str] {

--- a/src/rules/no_redeclare.rs
+++ b/src/rules/no_redeclare.rs
@@ -6,6 +6,7 @@ use deno_ast::swc::{
   ast::*, utils::find_ids, utils::ident::IdentLike, utils::Id, visit::Node,
   visit::Visit, visit::VisitWith,
 };
+use std::sync::Arc;
 
 use std::collections::HashSet;
 
@@ -16,8 +17,8 @@ const CODE: &str = "no-redeclare";
 const MESSAGE: &str = "Redeclaration is not allowed";
 
 impl LintRule for NoRedeclare {
-  fn new() -> Box<Self> {
-    Box::new(NoRedeclare)
+  fn new() -> Arc<Self> {
+    Arc::new(NoRedeclare)
   }
 
   fn tags(&self) -> &'static [&'static str] {

--- a/src/rules/no_regex_spaces.rs
+++ b/src/rules/no_regex_spaces.rs
@@ -8,6 +8,7 @@ use deno_ast::swc::visit::noop_visit_type;
 use deno_ast::swc::visit::Node;
 use deno_ast::swc::visit::{VisitAll, VisitAllWith};
 use once_cell::sync::Lazy;
+use std::sync::Arc;
 
 #[derive(Debug)]
 pub struct NoRegexSpaces;
@@ -17,8 +18,8 @@ const MESSAGE: &str =
   "more than one consecutive spaces in RegExp is not allowed";
 
 impl LintRule for NoRegexSpaces {
-  fn new() -> Box<Self> {
-    Box::new(NoRegexSpaces)
+  fn new() -> Arc<Self> {
+    Arc::new(NoRegexSpaces)
   }
 
   fn tags(&self) -> &'static [&'static str] {

--- a/src/rules/no_self_assign.rs
+++ b/src/rules/no_self_assign.rs
@@ -2,6 +2,7 @@
 use super::{Context, LintRule, DUMMY_NODE};
 use crate::swc_util::StringRepr;
 use crate::ProgramRef;
+use std::sync::Arc;
 
 use deno_ast::swc::ast::AssignExpr;
 use deno_ast::swc::ast::AssignOp;
@@ -41,8 +42,8 @@ enum NoSelfAssignHint {
 }
 
 impl LintRule for NoSelfAssign {
-  fn new() -> Box<Self> {
-    Box::new(NoSelfAssign)
+  fn new() -> Arc<Self> {
+    Arc::new(NoSelfAssign)
   }
 
   fn tags(&self) -> &'static [&'static str] {

--- a/src/rules/no_setter_return.rs
+++ b/src/rules/no_setter_return.rs
@@ -4,6 +4,7 @@ use crate::handler::{Handler, Traverse};
 use crate::{Program, ProgramRef};
 use deno_ast::view as ast_view;
 use deno_ast::view::{NodeTrait, Spanned};
+use std::sync::Arc;
 
 #[derive(Debug)]
 pub struct NoSetterReturn;
@@ -12,8 +13,8 @@ const CODE: &str = "no-setter-return";
 const MESSAGE: &str = "Setter cannot return a value";
 
 impl LintRule for NoSetterReturn {
-  fn new() -> Box<Self> {
-    Box::new(NoSetterReturn)
+  fn new() -> Arc<Self> {
+    Arc::new(NoSetterReturn)
   }
 
   fn tags(&self) -> &'static [&'static str] {

--- a/src/rules/no_shadow_restricted_names.rs
+++ b/src/rules/no_shadow_restricted_names.rs
@@ -7,6 +7,7 @@ use deno_ast::swc::ast::{
 };
 use deno_ast::swc::visit::{noop_visit_type, Node, VisitAll, VisitAllWith};
 use derive_more::Display;
+use std::sync::Arc;
 
 #[derive(Debug)]
 pub struct NoShadowRestrictedNames;
@@ -20,8 +21,8 @@ enum NoShadowRestrictedNamesMessage {
 }
 
 impl LintRule for NoShadowRestrictedNames {
-  fn new() -> Box<Self> {
-    Box::new(NoShadowRestrictedNames)
+  fn new() -> Arc<Self> {
+    Arc::new(NoShadowRestrictedNames)
   }
 
   fn lint_program<'view>(

--- a/src/rules/no_sparse_arrays.rs
+++ b/src/rules/no_sparse_arrays.rs
@@ -5,6 +5,7 @@ use deno_ast::swc::visit::noop_visit_type;
 use deno_ast::swc::visit::Node;
 use deno_ast::swc::visit::Visit;
 use derive_more::Display;
+use std::sync::Arc;
 
 #[derive(Debug)]
 pub struct NoSparseArrays;
@@ -18,8 +19,8 @@ enum NoSparseArraysMessage {
 }
 
 impl LintRule for NoSparseArrays {
-  fn new() -> Box<Self> {
-    Box::new(NoSparseArrays)
+  fn new() -> Arc<Self> {
+    Arc::new(NoSparseArrays)
   }
 
   fn code(&self) -> &'static str {

--- a/src/rules/no_this_alias.rs
+++ b/src/rules/no_this_alias.rs
@@ -6,6 +6,7 @@ use deno_ast::swc::visit::noop_visit_type;
 use deno_ast::swc::visit::Node;
 use deno_ast::swc::visit::{VisitAll, VisitAllWith};
 use if_chain::if_chain;
+use std::sync::Arc;
 
 #[derive(Debug)]
 pub struct NoThisAlias;
@@ -14,8 +15,8 @@ const CODE: &str = "no-this-alias";
 const MESSAGE: &str = "assign `this` to declare a value is not allowed";
 
 impl LintRule for NoThisAlias {
-  fn new() -> Box<Self> {
-    Box::new(NoThisAlias)
+  fn new() -> Arc<Self> {
+    Arc::new(NoThisAlias)
   }
 
   fn tags(&self) -> &'static [&'static str] {

--- a/src/rules/no_this_before_super.rs
+++ b/src/rules/no_this_before_super.rs
@@ -4,6 +4,7 @@ use crate::handler::{Handler, Traverse};
 use crate::{Program, ProgramRef};
 use deno_ast::view as ast_view;
 use deno_ast::view::{NodeTrait, Span, Spanned};
+use std::sync::Arc;
 
 #[derive(Debug)]
 pub struct NoThisBeforeSuper;
@@ -13,8 +14,8 @@ const MESSAGE: &str = "In the constructor of derived classes, `this` / `super` a
 const HINT: &str = "Call `super()` before using `this` or `super` keyword.";
 
 impl LintRule for NoThisBeforeSuper {
-  fn new() -> Box<Self> {
-    Box::new(NoThisBeforeSuper)
+  fn new() -> Arc<Self> {
+    Arc::new(NoThisBeforeSuper)
   }
 
   fn tags(&self) -> &'static [&'static str] {

--- a/src/rules/no_throw_literal.rs
+++ b/src/rules/no_throw_literal.rs
@@ -6,6 +6,7 @@ use deno_ast::swc::visit::noop_visit_type;
 use deno_ast::swc::visit::Node;
 use deno_ast::swc::visit::Visit;
 use derive_more::Display;
+use std::sync::Arc;
 
 #[derive(Debug)]
 pub struct NoThrowLiteral;
@@ -22,8 +23,8 @@ enum NoThrowLiteralMessage {
 }
 
 impl LintRule for NoThrowLiteral {
-  fn new() -> Box<Self> {
-    Box::new(NoThrowLiteral)
+  fn new() -> Arc<Self> {
+    Arc::new(NoThrowLiteral)
   }
 
   fn code(&self) -> &'static str {

--- a/src/rules/no_undef.rs
+++ b/src/rules/no_undef.rs
@@ -9,13 +9,14 @@ use deno_ast::swc::{
   visit::Node,
   visit::{noop_visit_type, Visit, VisitWith},
 };
+use std::sync::Arc;
 
 #[derive(Debug)]
 pub struct NoUndef;
 
 impl LintRule for NoUndef {
-  fn new() -> Box<Self> {
-    Box::new(NoUndef)
+  fn new() -> Arc<Self> {
+    Arc::new(NoUndef)
   }
 
   fn code(&self) -> &'static str {

--- a/src/rules/no_unreachable.rs
+++ b/src/rules/no_unreachable.rs
@@ -6,6 +6,7 @@ use deno_ast::swc::common::Spanned;
 use deno_ast::swc::visit::Node;
 use deno_ast::swc::visit::Visit;
 use deno_ast::swc::visit::VisitWith;
+use std::sync::Arc;
 
 #[derive(Debug)]
 pub struct NoUnreachable;
@@ -14,8 +15,8 @@ const CODE: &str = "no-unreachable";
 const MESSAGE: &str = "This statement is unreachable";
 
 impl LintRule for NoUnreachable {
-  fn new() -> Box<Self> {
-    Box::new(NoUnreachable)
+  fn new() -> Arc<Self> {
+    Arc::new(NoUnreachable)
   }
 
   fn tags(&self) -> &'static [&'static str] {

--- a/src/rules/no_unsafe_finally.rs
+++ b/src/rules/no_unsafe_finally.rs
@@ -6,6 +6,7 @@ use deno_ast::swc::common::{Span, Spanned};
 use deno_ast::view as ast_view;
 use deno_ast::view::NodeTrait;
 use derive_more::Display;
+use std::sync::Arc;
 
 #[derive(Debug)]
 pub struct NoUnsafeFinally;
@@ -38,8 +39,8 @@ impl From<StmtKind<'_>> for NoUnsafeFinallyMessage {
 }
 
 impl LintRule for NoUnsafeFinally {
-  fn new() -> Box<Self> {
-    Box::new(NoUnsafeFinally)
+  fn new() -> Arc<Self> {
+    Arc::new(NoUnsafeFinally)
   }
 
   fn tags(&self) -> &'static [&'static str] {

--- a/src/rules/no_unsafe_negation.rs
+++ b/src/rules/no_unsafe_negation.rs
@@ -6,6 +6,7 @@ use deno_ast::swc::common::Spanned;
 use deno_ast::view as ast_view;
 use derive_more::Display;
 use if_chain::if_chain;
+use std::sync::Arc;
 
 #[derive(Debug)]
 pub struct NoUnsafeNegation;
@@ -21,8 +22,8 @@ enum NoUnsafeNegationMessage {
 const HINT: &str = "Add parentheses to clarify which range the negation operator should be applied to";
 
 impl LintRule for NoUnsafeNegation {
-  fn new() -> Box<Self> {
-    Box::new(NoUnsafeNegation)
+  fn new() -> Arc<Self> {
+    Arc::new(NoUnsafeNegation)
   }
 
   fn tags(&self) -> &'static [&'static str] {

--- a/src/rules/no_unused_labels.rs
+++ b/src/rules/no_unused_labels.rs
@@ -6,6 +6,7 @@ use deno_ast::swc::common::Spanned;
 use deno_ast::view as ast_view;
 use derive_more::Display;
 use if_chain::if_chain;
+use std::sync::Arc;
 
 #[derive(Debug)]
 pub struct NoUnusedLabels;
@@ -19,8 +20,8 @@ enum NoUnusedLabelsMessage {
 }
 
 impl LintRule for NoUnusedLabels {
-  fn new() -> Box<Self> {
-    Box::new(NoUnusedLabels)
+  fn new() -> Arc<Self> {
+    Arc::new(NoUnusedLabels)
   }
 
   fn tags(&self) -> &'static [&'static str] {

--- a/src/rules/no_unused_vars.rs
+++ b/src/rules/no_unused_vars.rs
@@ -19,6 +19,7 @@ use derive_more::Display;
 use if_chain::if_chain;
 use std::collections::HashSet;
 use std::iter;
+use std::sync::Arc;
 
 #[derive(Debug)]
 pub struct NoUnusedVars;
@@ -47,8 +48,8 @@ enum NoUnusedVarsHint {
 }
 
 impl LintRule for NoUnusedVars {
-  fn new() -> Box<Self> {
-    Box::new(NoUnusedVars)
+  fn new() -> Arc<Self> {
+    Arc::new(NoUnusedVars)
   }
 
   fn tags(&self) -> &'static [&'static str] {

--- a/src/rules/no_var.rs
+++ b/src/rules/no_var.rs
@@ -6,6 +6,7 @@ use deno_ast::swc::ast::VarDeclKind;
 use deno_ast::swc::visit::noop_visit_type;
 use deno_ast::swc::visit::Node;
 use deno_ast::swc::visit::Visit;
+use std::sync::Arc;
 
 #[derive(Debug)]
 pub struct NoVar;
@@ -14,8 +15,8 @@ const MESSAGE: &str = "`var` keyword is not allowed.";
 const CODE: &str = "no-var";
 
 impl LintRule for NoVar {
-  fn new() -> Box<Self> {
-    Box::new(NoVar)
+  fn new() -> Arc<Self> {
+    Arc::new(NoVar)
   }
 
   fn tags(&self) -> &'static [&'static str] {

--- a/src/rules/no_window_prefix.rs
+++ b/src/rules/no_window_prefix.rs
@@ -9,6 +9,7 @@ use deno_ast::view as ast_view;
 use if_chain::if_chain;
 use once_cell::sync::Lazy;
 use std::collections::HashSet;
+use std::sync::Arc;
 
 #[derive(Debug)]
 pub struct NoWindowPrefix;
@@ -19,8 +20,8 @@ const HINT: &str =
   "Instead, call this API via `self`, `globalThis`, or no extra prefix";
 
 impl LintRule for NoWindowPrefix {
-  fn new() -> Box<Self> {
-    Box::new(NoWindowPrefix)
+  fn new() -> Arc<Self> {
+    Arc::new(NoWindowPrefix)
   }
 
   fn tags(&self) -> &'static [&'static str] {

--- a/src/rules/no_with.rs
+++ b/src/rules/no_with.rs
@@ -4,6 +4,7 @@ use crate::handler::{Handler, Traverse};
 use crate::{Program, ProgramRef};
 use deno_ast::swc::common::Spanned;
 use deno_ast::view as ast_view;
+use std::sync::Arc;
 
 #[derive(Debug)]
 pub struct NoWith;
@@ -12,8 +13,8 @@ const CODE: &str = "no-with";
 const MESSAGE: &str = "`with` statement is not allowed";
 
 impl LintRule for NoWith {
-  fn new() -> Box<Self> {
-    Box::new(NoWith)
+  fn new() -> Arc<Self> {
+    Arc::new(NoWith)
   }
 
   fn tags(&self) -> &'static [&'static str] {

--- a/src/rules/prefer_as_const.rs
+++ b/src/rules/prefer_as_const.rs
@@ -9,6 +9,7 @@ use deno_ast::swc::common::{Span, Spanned};
 use deno_ast::swc::visit::Node;
 use deno_ast::swc::visit::{VisitAll, VisitAllWith};
 use derive_more::Display;
+use std::sync::Arc;
 
 const CODE: &str = "prefer-as-const";
 
@@ -30,8 +31,8 @@ enum PreferAsConstHint {
 pub struct PreferAsConst;
 
 impl LintRule for PreferAsConst {
-  fn new() -> Box<Self> {
-    Box::new(PreferAsConst)
+  fn new() -> Arc<Self> {
+    Arc::new(PreferAsConst)
   }
 
   fn tags(&self) -> &'static [&'static str] {

--- a/src/rules/prefer_ascii.rs
+++ b/src/rules/prefer_ascii.rs
@@ -2,6 +2,7 @@
 use super::{Context, LintRule};
 use crate::{Program, ProgramRef};
 use deno_ast::swc::common::{BytePos, Span};
+use std::sync::Arc;
 
 #[derive(Debug)]
 pub struct PreferAscii;
@@ -17,8 +18,8 @@ fn hint(c: char) -> String {
 }
 
 impl LintRule for PreferAscii {
-  fn new() -> Box<Self> {
-    Box::new(PreferAscii)
+  fn new() -> Arc<Self> {
+    Arc::new(PreferAscii)
   }
 
   fn code(&self) -> &'static str {

--- a/src/rules/prefer_const.rs
+++ b/src/rules/prefer_const.rs
@@ -19,6 +19,7 @@ use std::collections::{BTreeMap, HashMap};
 use std::iter;
 use std::mem;
 use std::rc::Rc;
+use std::sync::Arc;
 
 #[derive(Debug)]
 pub struct PreferConst;
@@ -38,8 +39,8 @@ enum PreferConstHint {
 }
 
 impl LintRule for PreferConst {
-  fn new() -> Box<Self> {
-    Box::new(PreferConst)
+  fn new() -> Arc<Self> {
+    Arc::new(PreferConst)
   }
 
   fn tags(&self) -> &'static [&'static str] {

--- a/src/rules/prefer_namespace_keyword.rs
+++ b/src/rules/prefer_namespace_keyword.rs
@@ -6,6 +6,7 @@ use deno_ast::swc::visit::Node;
 use deno_ast::swc::visit::Visit;
 use once_cell::sync::Lazy;
 use regex::Regex;
+use std::sync::Arc;
 
 #[derive(Debug)]
 pub struct PreferNamespaceKeyword;
@@ -14,8 +15,8 @@ const CODE: &str = "prefer-namespace-keyword";
 const MESSAGE: &str = "`module` keyword in module decleration is not allowed";
 
 impl LintRule for PreferNamespaceKeyword {
-  fn new() -> Box<Self> {
-    Box::new(PreferNamespaceKeyword)
+  fn new() -> Arc<Self> {
+    Arc::new(PreferNamespaceKeyword)
   }
 
   fn tags(&self) -> &'static [&'static str] {

--- a/src/rules/prefer_primordials.rs
+++ b/src/rules/prefer_primordials.rs
@@ -8,6 +8,7 @@ use deno_ast::swc::utils::ident::IdentLike;
 use deno_ast::view as ast_view;
 use deno_ast::view::NodeTrait;
 use if_chain::if_chain;
+use std::sync::Arc;
 
 #[derive(Debug)]
 pub struct PreferPrimordials;
@@ -17,8 +18,8 @@ const MESSAGE: &str = "Don't use the global intrinsic";
 const HINT: &str = "Instead use the equivalent from the `primordials` object";
 
 impl LintRule for PreferPrimordials {
-  fn new() -> Box<Self> {
-    Box::new(PreferPrimordials)
+  fn new() -> Arc<Self> {
+    Arc::new(PreferPrimordials)
   }
 
   fn tags(&self) -> &'static [&'static str] {

--- a/src/rules/require_await.rs
+++ b/src/rules/require_await.rs
@@ -9,6 +9,7 @@ use deno_ast::swc::ast::{
 use deno_ast::swc::common::Spanned;
 use deno_ast::swc::visit::{noop_visit_type, Node, Visit, VisitWith};
 use derive_more::Display;
+use std::sync::Arc;
 
 #[derive(Debug)]
 pub struct RequireAwait;
@@ -38,8 +39,8 @@ enum RequireAwaitHint {
 }
 
 impl LintRule for RequireAwait {
-  fn new() -> Box<Self> {
-    Box::new(RequireAwait)
+  fn new() -> Arc<Self> {
+    Arc::new(RequireAwait)
   }
 
   fn tags(&self) -> &'static [&'static str] {

--- a/src/rules/require_yield.rs
+++ b/src/rules/require_yield.rs
@@ -11,6 +11,7 @@ use deno_ast::swc::ast::YieldExpr;
 use deno_ast::swc::visit::noop_visit_type;
 use deno_ast::swc::visit::Node;
 use deno_ast::swc::visit::Visit;
+use std::sync::Arc;
 
 #[derive(Debug)]
 pub struct RequireYield;
@@ -19,8 +20,8 @@ const CODE: &str = "require-yield";
 const MESSAGE: &str = "Generator function has no `yield`";
 
 impl LintRule for RequireYield {
-  fn new() -> Box<Self> {
-    Box::new(RequireYield)
+  fn new() -> Arc<Self> {
+    Arc::new(RequireYield)
   }
 
   fn tags(&self) -> &'static [&'static str] {

--- a/src/rules/single_var_declarator.rs
+++ b/src/rules/single_var_declarator.rs
@@ -6,6 +6,7 @@ use deno_ast::swc::visit::noop_visit_type;
 use deno_ast::swc::visit::Node;
 use deno_ast::swc::visit::Visit;
 use derive_more::Display;
+use std::sync::Arc;
 
 #[derive(Debug)]
 pub struct SingleVarDeclarator;
@@ -19,8 +20,8 @@ enum SingleVarDeclaratorMessage {
 }
 
 impl LintRule for SingleVarDeclarator {
-  fn new() -> Box<Self> {
-    Box::new(SingleVarDeclarator)
+  fn new() -> Arc<Self> {
+    Arc::new(SingleVarDeclarator)
   }
 
   fn code(&self) -> &'static str {

--- a/src/rules/triple_slash_reference.rs
+++ b/src/rules/triple_slash_reference.rs
@@ -7,6 +7,7 @@ use deno_ast::swc::common::Span;
 use derive_more::Display;
 use once_cell::sync::Lazy;
 use regex::Regex;
+use std::sync::Arc;
 
 #[derive(Debug)]
 pub struct TripleSlashReference;
@@ -26,8 +27,8 @@ impl TripleSlashReference {
 }
 
 impl LintRule for TripleSlashReference {
-  fn new() -> Box<Self> {
-    Box::new(TripleSlashReference)
+  fn new() -> Arc<Self> {
+    Arc::new(TripleSlashReference)
   }
 
   fn code(&self) -> &'static str {

--- a/src/rules/use_isnan.rs
+++ b/src/rules/use_isnan.rs
@@ -5,6 +5,7 @@ use deno_ast::swc::visit::noop_visit_type;
 use deno_ast::swc::visit::Node;
 use deno_ast::swc::visit::Visit;
 use derive_more::Display;
+use std::sync::Arc;
 
 #[derive(Debug)]
 pub struct UseIsNaN;
@@ -28,8 +29,8 @@ enum UseIsNaNMessage {
 }
 
 impl LintRule for UseIsNaN {
-  fn new() -> Box<Self> {
-    Box::new(UseIsNaN)
+  fn new() -> Arc<Self> {
+    Arc::new(UseIsNaN)
   }
 
   fn tags(&self) -> &'static [&'static str] {

--- a/src/rules/valid_typeof.rs
+++ b/src/rules/valid_typeof.rs
@@ -9,6 +9,7 @@ use deno_ast::swc::ast::Lit::Str;
 use deno_ast::swc::ast::UnaryOp::TypeOf;
 use deno_ast::swc::common::Spanned;
 use deno_ast::swc::visit::{noop_visit_type, Node, Visit};
+use std::sync::Arc;
 
 #[derive(Debug)]
 pub struct ValidTypeof;
@@ -17,8 +18,8 @@ const CODE: &str = "valid-typeof";
 const MESSAGE: &str = "Invalid typeof comparison value";
 
 impl LintRule for ValidTypeof {
-  fn new() -> Box<Self> {
-    Box::new(ValidTypeof)
+  fn new() -> Arc<Self> {
+    Arc::new(ValidTypeof)
   }
 
   fn tags(&self) -> &'static [&'static str] {

--- a/src/test_util.rs
+++ b/src/test_util.rs
@@ -289,7 +289,7 @@ fn get_ts_config_with_tsx() -> Syntax {
 }
 
 fn lint(
-  rule: Box<dyn LintRule>,
+  rule: Arc<dyn LintRule>,
   source: &str,
   filename: &str,
 ) -> Vec<LintDiagnostic> {
@@ -299,7 +299,7 @@ fn lint(
     } else {
       ast_parser::get_default_ts_config()
     })
-    .rules(Arc::new(vec![rule]))
+    .rules(vec![rule])
     .build();
 
   match linter.lint(filename.to_string(), source.to_string()) {

--- a/tools/scaffold.ts
+++ b/tools/scaffold.ts
@@ -110,8 +110,8 @@ const MESSAGE: &str = "";
 const HINT: &str = "";
 
 impl LintRule for ${pascalCasedLintName} {
-  fn new() -> Box<Self> {
-    Box::new(${pascalCasedLintName})
+  fn new() -> Arc<Self> {
+    Arc::new(${pascalCasedLintName})
   }
 
   fn code(&self) -> &'static str {

--- a/tools/scaffold.ts
+++ b/tools/scaffold.ts
@@ -101,6 +101,7 @@ use crate::handler::{Handler, Traverse};
 use crate::{Program, ProgramRef};
 use deno_ast::swc::common::Spanned;
 use deno_ast::view as ast_view;
+use std::sync::Arc;
 
 #[derive(Debug)]
 pub struct ${pascalCasedLintName};

--- a/tools/tests/scaffold_test.ts
+++ b/tools/tests/scaffold_test.ts
@@ -102,8 +102,8 @@ const MESSAGE: &str = "";
 const HINT: &str = "";
 
 impl LintRule for FooBarBaz {
-  fn new() -> Box<Self> {
-    Box::new(FooBarBaz)
+  fn new() -> Arc<Self> {
+    Arc::new(FooBarBaz)
   }
 
   fn code(&self) -> &'static str {
@@ -193,7 +193,7 @@ pub mod default_param_last;
 
 pub trait LintRule {}
 
-pub fn get_all_rules() -> Vec<Box<dyn LintRule>> {
+pub fn get_all_rules() -> Vec<Arc<dyn LintRule>> {
   vec![]
 }
 
@@ -227,7 +227,7 @@ pub mod default_param_last;
 
 pub trait LintRule {}
 
-pub fn get_all_rules() -> Vec<Box<dyn LintRule>> {
+pub fn get_all_rules() -> Vec<Arc<dyn LintRule>> {
   vec![]
 }
 

--- a/tools/tests/scaffold_test.ts
+++ b/tools/tests/scaffold_test.ts
@@ -93,6 +93,7 @@ use crate::handler::{Handler, Traverse};
 use crate::{Program, ProgramRef};
 use deno_ast::swc::common::Spanned;
 use deno_ast::view as ast_view;
+use std::sync::Arc;
 
 #[derive(Debug)]
 pub struct FooBarBaz;
@@ -179,6 +180,7 @@ use crate::context::Context;
 use crate::Program;
 use crate::ProgramRef;
 use std::collections::HashSet;
+use std::sync::Arc;
 
 pub mod adjacent_overload_signatures;
 pub mod ban_ts_comment;
@@ -212,6 +214,7 @@ use crate::context::Context;
 use crate::Program;
 use crate::ProgramRef;
 use std::collections::HashSet;
+use std::sync::Arc;
 
 pub mod foo_bar_baz;
 pub mod adjacent_overload_signatures;


### PR DESCRIPTION
Follow up to https://github.com/denoland/deno_lint/pull/845

As described in https://github.com/denoland/deno_lint/issues/847#issuecomment-922381168 having a list of rules being `Arc<Vec<_>>` makes it hard to use and some operations become very cumbersome to achieve. So instead of storing trait objects of `LintRule` in `Box`es we store them in `Arc`s.

CC @magurotuna 