### PR TITLE
feat: Add LintRule::priority()

### DIFF
--- a/src/linter.rs
+++ b/src/linter.rs
@@ -14,6 +14,7 @@ use deno_ast::swc::common::SyntaxContext;
 use deno_ast::swc::parser::Syntax;
 use deno_ast::view::ProgramRef;
 use deno_ast::ParsedSource;
+use std::cmp::Ordering;
 use std::sync::Arc;
 use std::time::Instant;
 
@@ -192,11 +193,24 @@ impl Linter {
         top_level_ctxt,
       );
 
+      // First sort lint rules by priority and alphabetically.
+      let mut sorted_rules = self.rules.clone();
+      sorted_rules.sort_by(|rule1, rule2| {
+        let priority_cmp = rule1.priority().cmp(&rule2.priority());
+
+        if priority_cmp == Ordering::Equal {
+          return rule1.code().cmp(&rule2.code());
+        }
+
+        priority_cmp
+      });
+
       // Run builtin rules
-      for rule in self.rules.iter() {
+      for rule in sorted_rules.iter() {
         rule.lint_program_with_ast_view(&mut context, pg);
       }
 
+      // TODO(bartlomieju): plugins rules should be sorted by priority as well.
       // Run plugin rules
       for plugin in self.plugins.iter() {
         // Ignore any error

--- a/src/linter.rs
+++ b/src/linter.rs
@@ -199,7 +199,7 @@ impl Linter {
         let priority_cmp = rule1.priority().cmp(&rule2.priority());
 
         if priority_cmp == Ordering::Equal {
-          return rule1.code().cmp(&rule2.code());
+          return rule1.code().cmp(rule2.code());
         }
 
         priority_cmp

--- a/src/linter.rs
+++ b/src/linter.rs
@@ -192,11 +192,10 @@ impl Linter {
         top_level_ctxt,
       );
 
-      let mut sorted_rules = self.rules.clone();
-      crate::rules::sort_rules_by_priority(&mut sorted_rules);
+      crate::rules::sort_rules_by_priority(&mut self.rules);
 
       // Run builtin rules
-      for rule in sorted_rules.iter() {
+      for rule in self.rules.iter() {
         rule.lint_program_with_ast_view(&mut context, pg);
       }
 

--- a/src/linter.rs
+++ b/src/linter.rs
@@ -14,7 +14,6 @@ use deno_ast::swc::common::SyntaxContext;
 use deno_ast::swc::parser::Syntax;
 use deno_ast::view::ProgramRef;
 use deno_ast::ParsedSource;
-use std::cmp::Ordering;
 use std::sync::Arc;
 use std::time::Instant;
 
@@ -193,17 +192,8 @@ impl Linter {
         top_level_ctxt,
       );
 
-      // First sort lint rules by priority and alphabetically.
       let mut sorted_rules = self.rules.clone();
-      sorted_rules.sort_by(|rule1, rule2| {
-        let priority_cmp = rule1.priority().cmp(&rule2.priority());
-
-        if priority_cmp == Ordering::Equal {
-          return rule1.code().cmp(rule2.code());
-        }
-
-        priority_cmp
-      });
+      crate::rules::sort_rules_by_priority(&mut sorted_rules);
 
       // Run builtin rules
       for rule in sorted_rules.iter() {

--- a/src/rules.rs
+++ b/src/rules.rs
@@ -139,6 +139,14 @@ pub trait LintRule: std::fmt::Debug + Send + Sync {
   /// examples.
   #[cfg(feature = "docs")]
   fn docs(&self) -> &'static str;
+
+  /// The lower the return value is, the earlier this rule will be run.
+  ///
+  /// By default it is 0. Some rules might want to defer being run to the end
+  /// and they might override this value.
+  fn priority(&self) -> u32 {
+    0
+  }
 }
 
 pub fn get_all_rules() -> Vec<Arc<dyn LintRule>> {

--- a/src/rules/ban_unknown_rule_code.rs
+++ b/src/rules/ban_unknown_rule_code.rs
@@ -37,4 +37,9 @@ impl LintRule for BanUnknownRuleCode {
   fn docs(&self) -> &'static str {
     include_str!("../../docs/rules/ban_unknown_rule_code.md")
   }
+
+  // This rule should be run second to last.
+  fn priority(&self) -> u32 {
+    u32::MAX - 1
+  }
 }

--- a/src/rules/ban_unused_ignore.rs
+++ b/src/rules/ban_unused_ignore.rs
@@ -37,4 +37,9 @@ impl LintRule for BanUnusedIgnore {
   fn docs(&self) -> &'static str {
     include_str!("../../docs/rules/ban_unused_ignore.md")
   }
+
+  // This rule should be run last.
+  fn priority(&self) -> u32 {
+    u32::MAX
+  }
 }


### PR DESCRIPTION
Closes https://github.com/denoland/deno_lint/issues/847

This commit adds new method to "LintRule" trait called "priority".
The lower the priority the earlier the rule will be run. This value
defaults to 0 and most rules need not change it.