### PR TITLE
refactor: use deno_ast's scope analysis

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -245,8 +245,6 @@ dependencies = [
 [[package]]
 name = "deno_ast"
 version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "427e7091c1fd8a13b002824f43773b6ef2d5c8ded445ee20013bea7f6ca8bc5b"
 dependencies = [
  "dprint-swc-ecma-ast-view",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ default = []
 docs = []
 
 [dependencies]
-deno_ast = { version = "0.2.0", features = ["transforms", "utils", "visit", "view"] }
+deno_ast = { version = "0.2.0", features = ["transforms", "utils", "visit", "view"], path = "../deno_ast" }
 log = "0.4.14"
 serde = { version = "1.0.125", features = ["derive"] }
 serde_json = "1.0.64"

--- a/src/ast_parser.rs
+++ b/src/ast_parser.rs
@@ -1,9 +1,5 @@
 // Copyright 2020-2021 the Deno authors. All rights reserved. MIT license.
-use deno_ast::swc::common::Globals;
-use deno_ast::swc::common::Mark;
 use deno_ast::swc::parser::Syntax;
-use deno_ast::swc::transforms::resolver::ts_resolver;
-use deno_ast::swc::visit::FoldWith;
 use deno_ast::MediaType;
 use deno_ast::ParsedSource;
 use std::error::Error;
@@ -39,59 +35,18 @@ impl SwcDiagnostic {
   }
 }
 
-/// Low-level utility structure with common AST parsing functions.
-///
-/// Allows to build more complicated parser by providing a callback
-/// to `parse_module`.
-pub(crate) struct AstParser {
-  pub(crate) globals: Globals,
-  /// The marker passed to the resolver (from swc).
-  ///
-  /// This mark is applied to top level bindings and unresolved references.
-  pub(crate) top_level_mark: Mark,
-}
-
-impl AstParser {
-  pub(crate) fn new() -> Self {
-    let globals = Globals::new();
-    let top_level_mark = deno_ast::swc::common::GLOBALS
-      .set(&globals, || Mark::fresh(Mark::root()));
-
-    AstParser {
-      globals,
-      top_level_mark,
-    }
-  }
-
-  pub(crate) fn parse_program(
-    &self,
-    file_name: &str,
-    syntax: Syntax,
-    source_code: String,
-  ) -> Result<ParsedSource, SwcDiagnostic> {
-    deno_ast::parse_program_with_post_process(
-      deno_ast::ParseParams {
-        specifier: file_name.to_string(),
-        media_type: MediaType::Unknown,
-        source: deno_ast::SourceTextInfo::from_string(source_code),
-        capture_tokens: true,
-        maybe_syntax: Some(syntax),
-      },
-      |program| {
-        // This is used to apply proper "syntax context" to all AST elements. When SWC performs
-        // transforms/folding it might change some of those context and "ts_resolver" ensures
-        // that all elements end up in proper lexical scope.
-        deno_ast::swc::common::GLOBALS.set(&self.globals, || {
-          program.fold_with(&mut ts_resolver(self.top_level_mark))
-        })
-      },
-    )
-    .map_err(|diagnostic| SwcDiagnostic::from_diagnostic(&diagnostic))
-  }
-}
-
-impl Default for AstParser {
-  fn default() -> Self {
-    Self::new()
-  }
+pub(crate) fn parse_program(
+  file_name: &str,
+  syntax: Syntax,
+  source_code: String,
+) -> Result<ParsedSource, SwcDiagnostic> {
+  deno_ast::parse_program(deno_ast::ParseParams {
+    specifier: file_name.to_string(),
+    media_type: MediaType::Unknown,
+    source: deno_ast::SourceTextInfo::from_string(source_code),
+    capture_tokens: true,
+    maybe_syntax: Some(syntax),
+    scope_analysis: true,
+  })
+  .map_err(|diagnostic| SwcDiagnostic::from_diagnostic(&diagnostic))
 }

--- a/src/test_util.rs
+++ b/src/test_util.rs
@@ -383,14 +383,12 @@ pub fn assert_lint_ok<T: LintRule + 'static>(
 const TEST_FILE_NAME: &str = "lint_test.ts";
 
 pub fn parse(source_code: &str) -> ParsedSource {
-  let ast_parser = ast_parser::AstParser::new();
-  ast_parser
-    .parse_program(
-      TEST_FILE_NAME,
-      deno_ast::get_syntax(MediaType::TypeScript),
-      source_code.to_string(),
-    )
-    .unwrap()
+  ast_parser::parse_program(
+    TEST_FILE_NAME,
+    deno_ast::get_syntax(MediaType::TypeScript),
+    source_code.to_string(),
+  )
+  .unwrap()
 }
 
 pub fn parse_and_then(source_code: &str, test: impl Fn(ast_view::Program)) {


### PR DESCRIPTION
Waiting on a deno_ast release before merging (will happen later).

Uses https://github.com/denoland/deno_ast/pull/20