### PR TITLE
feature: adding Lint rule in favor of arr.at(-1) (#779)

### DIFF
--- a/docs/rules/ban_array_length_minus_one.md
+++ b/docs/rules/ban_array_length_minus_one.md
@@ -1,0 +1,89 @@
+Disallows assigning variables to `this`.
+
+In most cases, storing a reference to `this` in a variable could be avoided by
+using arrow functions properly, since they establish `this` based on the scope
+where the arrow function is defined.
+
+Let's take a look at a concrete example:
+
+```typescript
+const obj = {
+  count: 0,
+  doSomethingLater() {
+    setTimeout(function () { // this function executes on the global scope; `this` evalutes to `globalThis`
+      this.count++;
+      console.log(this.count);
+    }, 300);
+  },
+};
+
+obj.doSomethingLater();
+// `NaN` is printed, because the property `count` is not in the global scope.
+```
+
+In the above example, `this` in the function passed to `setTimeout` evaluates to
+`globalThis`, which results in the expected value `1` not being printed.
+
+If you wanted to work around it without arrow functions, you would store a
+reference to `this` in another variable:
+
+```typescript
+const obj = {
+  count: 0,
+  doSomethingLater() {
+    const self = this; // store a reference to `this` in `self`
+    setTimeout(function () {
+      // use `self` instead of `this`
+      self.count++;
+      console.log(self.count);
+    }, 300);
+  },
+};
+
+obj.doSomethingLater();
+// `1` is printed as expected
+```
+
+But in this case arrow functions come in handy. With arrow functions, the code
+becomes way clearer and easier to understand:
+
+```typescript
+const obj = {
+  count: 0,
+  doSomethingLater() {
+    setTimeout(() => { // pass an arrow function
+      // `this` evaluates to `obj` here
+      this.count++;
+      console.log(this.count);
+    }, 300);
+  },
+};
+
+obj.doSomethingLater();
+// `1` is printed as expected
+```
+
+This example is taken from
+[MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions).
+
+### Invalid:
+
+```typescript
+const self = this;
+
+function foo() {
+  const self = this;
+}
+
+const bar = () => {
+  const self = this;
+};
+```
+
+### Valid:
+
+```typescript
+const self = "this";
+
+const [foo] = this;
+```

--- a/src/rules.rs
+++ b/src/rules.rs
@@ -96,6 +96,7 @@ pub mod single_var_declarator;
 pub mod triple_slash_reference;
 pub mod use_isnan;
 pub mod valid_typeof;
+pub mod ban_array_length_minus_one;
 
 const DUMMY_NODE: () = ();
 
@@ -233,6 +234,7 @@ pub(crate) fn sort_rules_by_priority(rules: &mut Vec<Arc<dyn LintRule>>) {
 fn get_all_rules_raw() -> Vec<Arc<dyn LintRule>> {
   vec![
     adjacent_overload_signatures::AdjacentOverloadSignatures::new(),
+    ban_array_length_minus_one::BanArrayLengthMinusOne::new(),
     ban_ts_comment::BanTsComment::new(),
     ban_types::BanTypes::new(),
     ban_unknown_rule_code::BanUnknownRuleCode::new(),

--- a/src/rules/ban_array_length_minus_one.rs
+++ b/src/rules/ban_array_length_minus_one.rs
@@ -1,0 +1,98 @@
+// Copyright 2020-2021 the Deno authors. All rights reserved. MIT license.
+use super::{Context, LintRule};
+use crate::handler::{Handler, Traverse};
+use crate::{Program, ProgramRef};
+use regex::Regex;
+use std::sync::Arc;
+use deno_ast::swc::common::Spanned;
+use deno_ast::view as ast_view;
+use deno_ast::view::NodeTrait;
+
+#[derive(Debug)]
+pub struct BanArrayLengthMinusOne;
+
+const CODE: &str = "ban-array-length-minus-one";
+const MESSAGE: &str = "arr[arr.length - 1] is deprecated.";
+const HINT: &str = "Please consider using arr.at(-1) instead of arr[arr.length - 1]";
+
+impl LintRule for BanArrayLengthMinusOne {
+  fn new() -> Arc<Self> {
+    Arc::new(BanArrayLengthMinusOne)
+  }
+
+  fn lint_program(&self, _context: &mut Context, _program: ProgramRef<'_>) {
+    unreachable!();
+  }
+
+  fn lint_program_with_ast_view(
+    &self,
+    context: &mut Context,
+    program: Program<'_>,
+  ) {
+      BanArrayLengthMinusOneHandler.traverse(program, context);
+  }
+
+  fn code(&self) -> &'static str {
+    CODE
+  }
+
+  fn tags(&self) -> &'static [&'static str] {
+    &["recommended"]
+  }
+
+  #[cfg(feature = "docs")]
+  fn docs(&self) -> &'static str {
+    include_str!("../../docs/rules/ban_array_length_minus_one.md")
+  }
+}
+
+struct BanArrayLengthMinusOneHandler;
+
+impl Handler for BanArrayLengthMinusOneHandler {
+  fn member_expr(
+    &mut self,
+    member_expr: &ast_view::MemberExpr,
+    ctx: &mut Context,
+  ) {
+    let obj = member_expr.obj;
+    let prop = member_expr.prop;
+    let mut regex_string:String = obj.text().to_owned();
+    let property_string = ".length *- *1$";
+    regex_string.push_str(property_string);
+    let re = Regex::new(regex_string.as_str()).unwrap();
+
+    if re.is_match(prop.text()) {
+      ctx.add_diagnostic_with_hint(member_expr.prop.span(), CODE, MESSAGE, HINT);
+    }
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn ban_array_length_minus_one_valid() {
+    assert_lint_ok! {
+      BanArrayLengthMinusOne,
+            r#"
+const _x = fruits[fruits.length-2];
+      "#
+    }
+  }
+
+  #[test]
+  fn ban_array_length_minus_one_invalid() {
+    assert_lint_err! {
+      BanArrayLengthMinusOne,
+      MESSAGE,
+      HINT,
+            r#"
+const _x = fruits[fruits.length-1];
+      "#: [{ line: 2, col: 18 }],
+            r#"
+const _x = fruits[fruits.length - 1];
+      "#: [{ line: 2, col: 18 }]
+    }
+  }
+}


### PR DESCRIPTION
I have created a pull request for the lining rule mentioned. Right now, the following things are considered.
1. a basic regex is validating if the pattern is matching or not. It can get complicated based on the scope. It will be of great help if the reviewer can help me with other use cases.
2. Some basic UTs are added. More UTs are needed to be added based on the scope of the rule.
3. A copied documentation file is added. The contents are needed to be finalized.
4. Message, code, and hint need to be finalized.
5. We need to decide if the rule is "recommended" or not at this moment.

Please consider it a basic POC. Please let me know the pointers I need to incorporate to make the rule robust. There are also some unused import. I will work on those during revision.


Testing Details:

Input:
```
const fruits = ['Apple', 'Banana']
const _x = fruits[fruits.length-1];
```

Output:
```
error[ban-array-length-minus-one]: arr[arr.length - 1] is deprecated.
 --> /Users/subhakundu/JS_Examples/array_size.ts:2:19
  |
2 | const _x = fruits[fruits.length-1];
  |                   ^^^^^^^^^^^^^^^
  |
  = help: Please consider using arr.at(-1) instead of arr[arr.length - 1]
Found 1 problem
```