### PR TITLE
Change recommendation on what type to use instead of `{}`

### DIFF
--- a/src/rules/ban_types.rs
+++ b/src/rules/ban_types.rs
@@ -51,7 +51,7 @@ impl BannedType {
       }
       LowerObject => "Use `Record<string, unknown>` instead",
       EmptyObjectLiteral => {
-        r#"If you want a type that means "empty object", use `Record<string, never>` instead"#
+        r#"If you want a type that means "empty object", use `Record<never, never>` instead"#
       }
     }
   }


### PR DESCRIPTION
Solves #941  .

`Record<never, never` is the "best" representation of an empt object type, as it will not allow to access any propeties on it and it can safely be `&`-extended (which is both not true for `Record<string, never>`).

As pointed out by @bartlomieju , we should probably follow ts-eslint's change to allow `object` again (see https://github.com/typescript-eslint/typescript-eslint/releases/tag/v5.0.0), but I think that should be done in a separate issue and should not apply to `{}`, which already has separate linting code.