### PR TITLE
fix: break in loop/case/func dont affect parent scope

### DIFF
--- a/src/control_flow/analyze_test.rs
+++ b/src/control_flow/analyze_test.rs
@@ -843,6 +843,32 @@ throw err;
   assert_flow!(flow, 70, false, Some(End::forced_throw())); // throw stmt
 }
 
+// https://github.com/denoland/deno_lint/issues/823
+#[test]
+fn issue_823() {
+  let src = r#"
+switch (foo) {
+  case 1:
+    switch (bar) {
+      case 1:
+        break;
+    }
+    return 0;
+  default: {
+    return 0;
+  }
+}"#;
+  let flow = analyze_flow(src);
+  assert_flow!(flow, 1, false, Some(End::forced_return())); // switch foo stmt
+  assert_flow!(flow, 18, false, Some(End::forced_return())); // `switch foo case 1`
+  assert_flow!(flow, 30, false, Some(End::Continue)); // `switch bar stmt`
+  assert_flow!(flow, 51, false, Some(End::Break)); // `switch bar case1`
+  assert_flow!(flow, 67, false, Some(End::Break)); // `break stmt`
+  assert_flow!(flow, 84, false, Some(End::forced_return())); // `return stmt`
+  assert_flow!(flow, 96, false, Some(End::forced_return())); // `default`
+  assert_flow!(flow, 111, false, Some(End::forced_return())); // `return stmt`
+}
+
 // https://github.com/denoland/deno_lint/issues/644
 #[test]
 fn issue_644() {

--- a/src/control_flow/mod.rs
+++ b/src/control_flow/mod.rs
@@ -262,10 +262,19 @@ impl Analyzer<'_> {
 
     // Preserve information about visited ast nodes.
     self.scope.may_throw |= may_throw;
-    if self.scope.found_break.is_none() {
-      self.scope.found_break = found_break;
-    }
+
     self.scope.found_continue |= found_continue;
+
+    match kind {
+      BlockKind::Case => {}
+      BlockKind::Function => {}
+      BlockKind::Loop => {}
+      _ => {
+        if self.scope.found_break.is_none() {
+          self.scope.found_break = found_break;
+        }
+      }
+    };
 
     if let Some(end) = end {
       match kind {


### PR DESCRIPTION
Close #823 
```js
switch (foo) {
  case 1: {
    // found break and this break may cause case 1 break
    if (bar) break;
    {..}
  }
  case 2: {
    // found break but this break dont cause case 2 break
    switch (bar) {
      case 1:
        break;
      default:
        return;
    }
  }
}
```
