### PR TITLE
feature: add no-boolean-literal-args lint rule

### DIFF
--- a/docs/rules/no_boolean_literal_args.md
+++ b/docs/rules/no_boolean_literal_args.md
@@ -1,0 +1,22 @@
+Disallows the use of `true` and `false` as arguments.
+
+### Invalid:
+
+```typescript
+function foo(a: boolean) {
+  console.log(a);
+}
+
+foo(false);
+```
+
+### Valid:
+
+```typescript
+function foo(a: boolean) {
+  console.log(a);
+}
+
+const bar = false;
+foo(bar);
+```

--- a/src/rules.rs
+++ b/src/rules.rs
@@ -24,6 +24,7 @@ pub mod getter_return;
 pub mod no_array_constructor;
 pub mod no_async_promise_executor;
 pub mod no_await_in_loop;
+pub mod no_boolean_literal_args;
 pub mod no_case_declarations;
 pub mod no_class_assign;
 pub mod no_compare_neg_zero;
@@ -250,6 +251,7 @@ fn get_all_rules_raw() -> Vec<Arc<dyn LintRule>> {
     no_array_constructor::NoArrayConstructor::new(),
     no_async_promise_executor::NoAsyncPromiseExecutor::new(),
     no_await_in_loop::NoAwaitInLoop::new(),
+    no_boolean_literal_args::NoBooleanLiteralArgs::new(),
     no_case_declarations::NoCaseDeclarations::new(),
     no_class_assign::NoClassAssign::new(),
     no_compare_neg_zero::NoCompareNegZero::new(),

--- a/src/rules/no_boolean_literal_args.rs
+++ b/src/rules/no_boolean_literal_args.rs
@@ -1,0 +1,146 @@
+// Copyright 2020-2021 the Deno authors. All rights reserved. MIT license.
+use super::{Context, LintRule};
+use crate::handler::{Handler, Traverse};
+use crate::{Program, ProgramRef};
+use deno_ast::swc::common::Spanned;
+use deno_ast::view::{Expr, ExprOrSpread, Lit};
+use derive_more::Display;
+use std::sync::Arc;
+
+#[derive(Debug)]
+pub struct NoBooleanLiteralArgs;
+
+const CODE: &str = "no-boolean-literal-args";
+
+#[derive(Display)]
+enum NoBooleanLiteralArgsMessage {
+  #[display(fmt = "Not allowed to use true or false as an argument")]
+  Unexpected,
+}
+
+#[derive(Display)]
+enum NoBooleanLiteralArgsHint {
+  #[display(fmt = "Create a boolean to pass to the function instead")]
+  CreateBoolean,
+}
+
+impl LintRule for NoBooleanLiteralArgs {
+  fn new() -> Arc<Self> {
+    Arc::new(NoBooleanLiteralArgs)
+  }
+
+  fn tags(&self) -> &'static [&'static str] {
+    &[]
+  }
+
+  fn code(&self) -> &'static str {
+    "no-boolean-literal-args"
+  }
+
+  fn lint_program(&self, _context: &mut Context, _program: ProgramRef) {
+    unreachable!();
+  }
+
+  fn lint_program_with_ast_view(
+    &self,
+    context: &mut Context,
+    program: Program,
+  ) {
+    let mut handler = NoBooleanLiteralArgsHandler::default();
+    handler.traverse(program, context);
+  }
+
+  #[cfg(feature = "docs")]
+  fn docs(&self) -> &'static str {
+    include_str!("../../docs/rules/no_boolean_literal_args.md")
+  }
+}
+
+#[derive(Default)]
+struct NoBooleanLiteralArgsHandler;
+
+impl NoBooleanLiteralArgsHandler {
+  fn check_args<'a>(&'a mut self, args: &[&ExprOrSpread], ctx: &mut Context) {
+    for arg in args {
+      if let Expr::Lit(Lit::Bool(_)) = &arg.expr {
+        ctx.add_diagnostic_with_hint(
+          arg.expr.span(),
+          CODE,
+          NoBooleanLiteralArgsMessage::Unexpected,
+          NoBooleanLiteralArgsHint::CreateBoolean,
+        );
+      }
+    }
+  }
+}
+
+impl Handler for NoBooleanLiteralArgsHandler {
+  fn call_expr(&mut self, expr: &deno_ast::view::CallExpr, ctx: &mut Context) {
+    self.check_args(&expr.args, ctx);
+  }
+
+  fn new_expr(&mut self, expr: &deno_ast::view::NewExpr, ctx: &mut Context) {
+    if let Some(args) = &expr.args {
+      self.check_args(args, ctx);
+    }
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn no_boolean_literal_args_valid() {
+    assert_lint_ok! {
+      NoBooleanLiteralArgs,
+      "let x = func(CONST_BOOL_1, 5, 3)",
+      "let x = func(trueBool, 0)",
+      "let x = func(y, 1, z)",
+      "func(falseBool, CONST_BOOL_1)",
+      "func(CONST_BOOL_1, func2(CONST_BOOL_2))",
+    };
+  }
+
+  #[test]
+  fn no_boolean_literal_args_invalid() {
+    assert_lint_err! {
+      NoBooleanLiteralArgs,
+      "func(true, a, b)": [
+        {
+          col: 5,
+          message: NoBooleanLiteralArgsMessage::Unexpected,
+          hint: NoBooleanLiteralArgsHint::CreateBoolean,
+        }
+      ],
+      "func(a, b, true)": [
+        {
+          col: 11,
+          message: NoBooleanLiteralArgsMessage::Unexpected,
+          hint: NoBooleanLiteralArgsHint::CreateBoolean,
+        }
+      ],
+      "let x = func(true)": [
+        {
+          col: 13,
+          message: NoBooleanLiteralArgsMessage::Unexpected,
+          hint: NoBooleanLiteralArgsHint::CreateBoolean,
+        }
+      ],
+      "let x = func(func2(false))": [
+        {
+          col: 19,
+          message: NoBooleanLiteralArgsMessage::Unexpected,
+          hint: NoBooleanLiteralArgsHint::CreateBoolean,
+        }
+      ],
+      "let x = new MyObject(false)": [
+        {
+          col: 21,
+          message: NoBooleanLiteralArgsMessage::Unexpected,
+          hint: NoBooleanLiteralArgsHint::CreateBoolean,
+        }
+      ]
+    };
+  }
+}


### PR DESCRIPTION
This PR contains the lint rule asked for in issue #975. It will not allow you to use boolean literals (`true` and `false`) when you make a function call.

It is an opt-in (as requested) lint rule.

Previously, this would be allowed :

```typescript
foo(a: boolean) {
  console.log(a);
}

foo(true);
```

But with this lint rule, you have to do the following or else you will get a warning :

```typescript
foo(a: boolean) {
  console.log(a);
}

let bar = true;

foo(bar);
```