### PR TITLE
fix: allow regexp with `d` flag

### DIFF
--- a/src/js_regex/mod.rs
+++ b/src/js_regex/mod.rs
@@ -12,7 +12,7 @@ mod tests {
 
   #[test]
   fn valid_flags() {
-    let validator = EcmaRegexValidator::new(EcmaVersion::Es2018);
+    let validator = EcmaRegexValidator::new(EcmaVersion::Es2022);
     assert_eq!(validator.validate_flags("gimuys"), Ok(()));
     assert_eq!(validator.validate_flags("gimuy"), Ok(()));
     assert_eq!(validator.validate_flags("gim"), Ok(()));
@@ -22,6 +22,7 @@ mod tests {
     assert_eq!(validator.validate_flags("s"), Ok(()));
     assert_eq!(validator.validate_flags("u"), Ok(()));
     assert_eq!(validator.validate_flags("y"), Ok(()));
+    assert_eq!(validator.validate_flags("d"), Ok(()));
 
     assert_eq!(validator.validate_flags("gy"), Ok(()));
     assert_eq!(validator.validate_flags("iy"), Ok(()));

--- a/src/js_regex/validator.rs
+++ b/src/js_regex/validator.rs
@@ -102,6 +102,7 @@ pub enum EcmaVersion {
   Es2019,
   Es2020,
   Es2021,
+  Es2022,
 }
 
 #[derive(Debug)]
@@ -174,6 +175,7 @@ impl EcmaRegexValidator {
         || (flag == 'u' && self.ecma_version >= EcmaVersion::Es2015)
         || (flag == 'y' && self.ecma_version >= EcmaVersion::Es2015)
         || (flag == 's' && self.ecma_version >= EcmaVersion::Es2018)
+        || (flag == 'd' && self.ecma_version >= EcmaVersion::Es2022)
       {
         // do nothing
       } else {

--- a/src/rules/no_empty_character_class.rs
+++ b/src/rules/no_empty_character_class.rs
@@ -65,7 +65,7 @@ impl Handler for NoEmptyCharacterClassVisitor {
        * 4. `[gimuy]*`: optional regexp flags
        * 5. `$`: fix the match at the end of the string
        */
-      regex::Regex::new(r"(?u)^/([^\\\[]|\\.|\[([^\\\]]|\\.)+\])*/[gimuys]*$")
+      regex::Regex::new(r"(?u)^/([^\\\[]|\\.|\[([^\\\]]|\\.)+\])*/[gimuysd]*$")
         .unwrap()
     });
 

--- a/src/rules/no_empty_character_class.rs
+++ b/src/rules/no_empty_character_class.rs
@@ -95,6 +95,7 @@ mod tests {
     const foo = /[\-\[\]\/\{\}\(\)\*\+\?\.\\^\$\|]/g;
     const foo = /\[/g;
     const foo = /\]/i;
+    const foo = /\]/d;
     "#,
     };
   }

--- a/src/rules/no_invalid_regexp.rs
+++ b/src/rules/no_invalid_regexp.rs
@@ -64,7 +64,7 @@ impl<'c, 'view> NoInvalidRegexpVisitor<'c, 'view> {
   fn new(context: &'c mut Context<'view>) -> Self {
     Self {
       context,
-      validator: EcmaRegexValidator::new(EcmaVersion::Es2018),
+      validator: EcmaRegexValidator::new(EcmaVersion::Es2022),
     }
   }
 


### PR DESCRIPTION
Both `no_empty_character_class` and `no_invalid_regexp` should allow regexp with `d` flag.

Closes #985 