### PR TITLE
fix(ban-types): ban types should not flag non-global types

### DIFF
--- a/src/rules/ban_types.rs
+++ b/src/rules/ban_types.rs
@@ -116,6 +116,8 @@ impl Handler for BanTypesHandler {
   ) {
     if_chain! {
       if let TsEntityName::Ident(ident) = &ts_type_ref.type_name;
+      if ident.span().ctxt == ctx.top_level_ctxt();
+      if ctx.scope().is_global(&ident.to_id());
       if let Ok(banned_type) = BannedType::try_from(ident.sym().as_ref());
       then {
         ctx.add_diagnostic_with_hint(
@@ -173,6 +175,8 @@ mod tests {
       "let g = Object.create(null);",
       "let h = String(false);",
       "let e: foo.String;",
+      "export interface Symbol {} let f: Symbol;",
+      "function test() { interface Symbol {} let f: Symbol; }",
     };
   }
 

--- a/src/scopes.rs
+++ b/src/scopes.rs
@@ -3,8 +3,8 @@ use deno_ast::swc::ast::{
   ArrowExpr, BlockStmt, BlockStmtOrExpr, CatchClause, ClassDecl, ClassExpr,
   DoWhileStmt, Expr, FnDecl, FnExpr, ForInStmt, ForOfStmt, ForStmt, Function,
   Ident, ImportDefaultSpecifier, ImportNamedSpecifier, ImportStarAsSpecifier,
-  Param, Pat, SwitchStmt, TsTypeAliasDecl, VarDecl, VarDeclKind, WhileStmt,
-  WithStmt,
+  Param, Pat, SwitchStmt, TsInterfaceDecl, TsTypeAliasDecl, VarDecl,
+  VarDeclKind, WhileStmt, WithStmt,
 };
 use deno_ast::swc::atoms::JsWord;
 use deno_ast::swc::utils::find_ids;
@@ -101,7 +101,7 @@ pub enum BindingKind {
   ///   - import { foo } from "foo.ts";
   ValueImport,
 
-  TypeAlias,
+  Type,
 }
 
 impl BindingKind {
@@ -340,9 +340,11 @@ impl Visit for Analyzer<'_> {
   }
 
   fn visit_ts_type_alias_decl(&mut self, n: &TsTypeAliasDecl) {
-    self.declare(BindingKind::TypeAlias, &n.id);
-    n.type_params.visit_with(self);
-    n.type_ann.visit_with(self);
+    self.declare(BindingKind::Type, &n.id);
+  }
+
+  fn visit_ts_interface_decl(&mut self, n: &TsInterfaceDecl) {
+    self.declare(BindingKind::Type, &n.id);
   }
 }
 


### PR DESCRIPTION
Basically if you do:

```ts
import { Symbol } from "./something";

const t: Symbol;
```

...it should not be a lint diagnostic.