### PR TITLE
fix(prefer-primordials): Force `SafeArrayIterator` to be used for spread syntax in deno core

### DIFF
--- a/src/rules/prefer_primordials.rs
+++ b/src/rules/prefer_primordials.rs
@@ -139,7 +139,7 @@ impl Handler for PreferPrimordialsHandler {
   fn expr_or_spread(
     &mut self,
     expr_or_spread: &ast_view::ExprOrSpread,
-    ctx: &mut Context
+    ctx: &mut Context,
   ) {
     if_chain! {
       if expr_or_spread.inner.spread.is_some();


### PR DESCRIPTION
Related https://github.com/denoland/deno_lint/issues/968