### PR TITLE
feat: add `no-top-level-await` rule

### DIFF
--- a/docs/rules/no_top_level_await.md
+++ b/docs/rules/no_top_level_await.md
@@ -1,0 +1,23 @@
+Disallows the use of top level await expressions.
+
+Top level await cannot be used when distributing CommonJS/UMD via dnt.
+
+### Invalid:
+
+```typescript
+await foo();
+
+for await (item of items) {}
+```
+
+### Valid:
+
+```typescript
+async function foo() {
+  await task();
+}
+
+async function foo() {
+  for await (item of items) {}
+}
+```

--- a/docs/rules/no_top_level_await.md
+++ b/docs/rules/no_top_level_await.md
@@ -6,7 +6,6 @@ Top level await cannot be used when distributing CommonJS/UMD via dnt.
 
 ```typescript
 await foo();
-
 for await (item of items) {}
 ```
 
@@ -16,7 +15,6 @@ for await (item of items) {}
 async function foo() {
   await task();
 }
-
 async function foo() {
   for await (item of items) {}
 }

--- a/src/rules.rs
+++ b/src/rules.rs
@@ -76,6 +76,7 @@ pub mod no_sparse_arrays;
 pub mod no_this_alias;
 pub mod no_this_before_super;
 pub mod no_throw_literal;
+pub mod no_top_level_await;
 pub mod no_undef;
 pub mod no_unreachable;
 pub mod no_unsafe_finally;
@@ -300,6 +301,7 @@ fn get_all_rules_raw() -> Vec<Arc<dyn LintRule>> {
     no_this_alias::NoThisAlias::new(),
     no_this_before_super::NoThisBeforeSuper::new(),
     no_throw_literal::NoThrowLiteral::new(),
+    no_top_level_await::NoTopLevelAwait::new(),
     no_undef::NoUndef::new(),
     no_unreachable::NoUnreachable::new(),
     no_unsafe_finally::NoUnsafeFinally::new(),

--- a/src/rules/no_top_level_await.rs
+++ b/src/rules/no_top_level_await.rs
@@ -100,7 +100,6 @@ mod tests {
         private async bar(){ await task(); }
       }"#,
       r#"const foo = { bar : async () => { await task()} }"#,
-      r#"const foo = { bar : async () => { await task()} }"#,
     };
   }
 

--- a/src/rules/no_top_level_await.rs
+++ b/src/rules/no_top_level_await.rs
@@ -1,0 +1,119 @@
+// Copyright 2020-2022 the Deno authors. All rights reserved. MIT license.
+use super::{Context, LintRule};
+use crate::handler::{Handler, Traverse};
+use crate::{Program, ProgramRef};
+use deno_ast::swc::common::Spanned;
+use deno_ast::view::NodeTrait;
+use deno_ast::view::{self as ast_view};
+use std::sync::Arc;
+
+#[derive(Debug)]
+pub struct NoTopLevelAwait;
+
+const CODE: &str = "no-top-level-await";
+const MESSAGE: &str = "Top level await is not allowed";
+
+impl LintRule for NoTopLevelAwait {
+  fn new() -> Arc<Self> {
+    Arc::new(NoTopLevelAwait)
+  }
+
+  fn code(&self) -> &'static str {
+    CODE
+  }
+
+  fn lint_program(&self, _context: &mut Context, _program: ProgramRef<'_>) {
+    unreachable!();
+  }
+
+  fn lint_program_with_ast_view(
+    &self,
+    context: &mut Context,
+    program: Program<'_>,
+  ) {
+    NoTopLevelAwaitHandler.traverse(program, context);
+  }
+
+  #[cfg(feature = "docs")]
+  fn docs(&self) -> &'static str {
+    include_str!("../../docs/rules/no_top_level_await.md")
+  }
+}
+
+struct NoTopLevelAwaitHandler;
+
+impl Handler for NoTopLevelAwaitHandler {
+  fn await_expr(
+    &mut self,
+    await_expr: &ast_view::AwaitExpr,
+    ctx: &mut Context,
+  ) {
+    if !is_node_inside_function(await_expr) {
+      ctx.add_diagnostic(await_expr.span(), CODE, MESSAGE);
+    }
+  }
+
+  fn for_of_stmt(
+    &mut self,
+    for_of_stmt: &ast_view::ForOfStmt,
+    ctx: &mut Context,
+  ) {
+    if !is_node_inside_function(for_of_stmt) {
+      ctx.add_diagnostic(for_of_stmt.span(), CODE, MESSAGE);
+    }
+  }
+}
+
+fn is_node_inside_function<'a>(node: &impl NodeTrait<'a>) -> bool {
+  use deno_ast::view::Node;
+  match node.parent() {
+    Some(Node::FnDecl(_))
+    | Some(Node::FnExpr(_))
+    | Some(Node::ArrowExpr(_))
+    | Some(Node::ClassMethod(_))
+    | Some(Node::PrivateMethod(_)) => true,
+    None => false,
+    Some(n) => is_node_inside_function(&n),
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn no_top_level_await_valid() {
+    assert_lint_ok! {
+      NoTopLevelAwait,
+      r#"async function foo() { await bar(); }"#,
+      r#"const foo = async function () { await bar()};"#,
+      r#"const foo = () => { await bar()};"#,
+      r#"async function foo() { for await (item of items){}}"#,
+      r#"async function foo() { await bar(); }"#,
+      r#"class Foo {
+        async foo() { await task(); }
+        private async bar(){ await task(); }
+      }"#,
+      r#"const foo = { bar : async () => { await task()} }"#,
+    };
+  }
+
+  #[test]
+  fn no_top_level_await_invalid() {
+    assert_lint_err! {
+      NoTopLevelAwait,
+      r#"await foo()"#: [
+        {
+          col: 0,
+          message: MESSAGE,
+        },
+      ],
+      r#"for await (item of items) {}"#: [
+        {
+          col: 0,
+          message: MESSAGE,
+        },
+      ],
+    };
+  }
+}

--- a/www/public/docs.json
+++ b/www/public/docs.json
@@ -464,6 +464,11 @@
     "tags": []
   },
   {
+    "code": "no-top-level-await",
+    "docs": "Disallows the use of top level await expressions.\n\nTop level await cannot be used when distributing CommonJS/UMD via dnt.\n\n### Invalid:\n\n```typescript\nawait foo();\n\nfor await (item of items) {}\n```\n\n### Valid:\n\n```typescript\nasync function foo() {\n  await task();\n}\n\nasync function foo() {\n  for await (item of items) {}\n}\n```\n",
+    "tags": []
+  },
+  {
     "code": "no-undef",
     "docs": "",
     "tags": []

--- a/www/public/docs.json
+++ b/www/public/docs.json
@@ -465,7 +465,7 @@
   },
   {
     "code": "no-top-level-await",
-    "docs": "Disallows the use of top level await expressions.\n\nTop level await cannot be used when distributing CommonJS/UMD via dnt.\n\n### Invalid:\n\n```typescript\nawait foo();\n\nfor await (item of items) {}\n```\n\n### Valid:\n\n```typescript\nasync function foo() {\n  await task();\n}\n\nasync function foo() {\n  for await (item of items) {}\n}\n```\n",
+    "docs": "Disallows the use of top level await expressions.\n\nTop level await cannot be used when distributing CommonJS/UMD via dnt.\n\n### Invalid:\n\n```typescript\nawait foo();\nfor await (item of items) {}\n```\n\n### Valid:\n\n```typescript\nasync function foo() {\n  await task();\n}\nasync function foo() {\n  for await (item of items) {}\n}\n```\n",
     "tags": []
   },
   {


### PR DESCRIPTION
This lint rule is useful for `dnt` users because top-level-await doesn't work in CommonJS.

Maybe we should enable this rule in `deno_std`.