### PR TITLE
fix(prefer-primordials): Force `SafeArrayIterator` to be used in `for-of` statement in deno core

### DIFF
--- a/src/rules/prefer_primordials.rs
+++ b/src/rules/prefer_primordials.rs
@@ -156,7 +156,12 @@ impl Handler for PreferPrimordialsHandler {
     ctx: &mut Context,
   ) {
     if !for_of_stmt.right.is::<ast_view::NewExpr>() {
-      ctx.add_diagnostic_with_hint(for_of_stmt.right.span(), CODE, MESSAGE, HINT);
+      ctx.add_diagnostic_with_hint(
+        for_of_stmt.right.span(),
+        CODE,
+        MESSAGE,
+        HINT,
+      );
     }
   }
 


### PR DESCRIPTION
Closes https://github.com/denoland/deno_lint/issues/968