### PR TITLE
Include  `eval` in prefer-primordials lint

### DIFF
--- a/src/rules/prefer_primordials.rs
+++ b/src/rules/prefer_primordials.rs
@@ -555,7 +555,7 @@ const noop = Function.prototype;
       r#"eval("console.log('This test should fail!');");"#: [
         {
           col: 0,
-          message: MASSAGE,
+          message: MESSAGE,
           hint: HINT,
         },
       ],

--- a/src/rules/prefer_primordials.rs
+++ b/src/rules/prefer_primordials.rs
@@ -323,6 +323,10 @@ const { SafeArrayIterator } = primordials;
 for (const val of new SafeArrayIterator(arr)) {}
 for (const val of new SafeArrayIterator([1, 2, 3])) {}
       "#,
+      r#"
+const { indirectEval } = primordials;
+indirectEval("console.log('This test should pass.');");
+      "#,
     };
   }
 
@@ -545,6 +549,13 @@ const noop = Function.prototype;
         {
           col: 18,
           message: MESSAGE,
+          hint: HINT,
+        },
+      ],
+      r#"eval("console.log('This test should fail!');");"#: [
+        {
+          col: 0,
+          message: MASSAGE,
           hint: HINT,
         },
       ],

--- a/src/rules/prefer_primordials.rs
+++ b/src/rules/prefer_primordials.rs
@@ -92,7 +92,7 @@ const TARGETS: &[&str] = &[
   "WeakMap",
   "WeakSet",
   "Promise",
-  "eval"
+  "eval",
 ];
 
 struct PreferPrimordialsHandler;

--- a/src/rules/prefer_primordials.rs
+++ b/src/rules/prefer_primordials.rs
@@ -92,6 +92,7 @@ const TARGETS: &[&str] = &[
   "WeakMap",
   "WeakSet",
   "Promise",
+  "eval"
 ];
 
 struct PreferPrimordialsHandler;


### PR DESCRIPTION
Warns authors of Deno's internal runtime JavaScript to avoid using the global `eval` function.
Fixes #1062.
