### PR TITLE
fix: Fix markdown css import url and the starting command in README

### DIFF
--- a/www/README.md
+++ b/www/README.md
@@ -5,7 +5,7 @@
 Start the project (from the root of the repo):
 
 ```
-deno run -A --unstable --watch main.ts
+deno run -A --unstable --watch www/main.ts
 ```
 
 After adding, removing, or moving a page in the `pages` directory, run:

--- a/www/pages/ignoring-rules.tsx
+++ b/www/pages/ignoring-rules.tsx
@@ -15,7 +15,7 @@ function IgnoringRulesPage() {
         <Head>
           <link
             rel="stylesheet"
-            href="https://cdn.jsdelivr.net/gh/lucacasonato/manual@www/www/static/markdown.css"
+            href="https://cdn.jsdelivr.net/gh/lucacasonato/manual@df7ae27/www/static/markdown.css"
             crossOrigin="anonymous"
           />
         </Head>


### PR DESCRIPTION
- The project start command was wrong, since we need to start from root, the `www/` is needed. Maybe we should add a `deno.json`
- The ignoring-rules page didn't have proper markdown formatting, since the css import url was wrong. As a hotfix, I changed to the one used in the index page, which works