### PR TITLE
feat: Add styleing for darkmode

### DIFF
--- a/www/deps.ts
+++ b/www/deps.ts
@@ -6,7 +6,7 @@ export { default as marked } from "https://esm.sh/marked@3.0.4";
 
 // prism
 export { default as Prism } from "https://esm.sh/prismjs@1.25.0?pin=v57";
-import "https://esm.sh/prismjs@1.25.0/components/prism-javascript.js?no-check&pin=v57"
+import "https://esm.sh/prismjs@1.25.0/components/prism-javascript.js?no-check&pin=v57";
 import "https://esm.sh/prismjs@1.25.0/components/prism-typescript.js?no-check&pin=v57";
 
 // twind

--- a/www/pages/index.tsx
+++ b/www/pages/index.tsx
@@ -53,7 +53,8 @@ function IndexPage(props: PageProps) {
             <input
               type="text"
               name="q"
-              class={tw`w-full border h-10 border-gray-200 dark:border-gray-500 rounded rounded-r-none px-3 relative dark:bg-gray-800 `}
+              class={tw
+                `w-full border h-10 border-gray-200 dark:border-gray-500 rounded rounded-r-none px-3 relative dark:bg-gray-800 `}
               placeholder="Search"
               value={search}
             />
@@ -94,11 +95,13 @@ function Rule(props: { rule: RuleData }) {
 
   return (
     <section
-      class={tw`my-8 border-gray-200 dark:border-[#313235] border-2 rounded-lg overflow-hidden`}
+      class={tw
+        `my-8 border-gray-200 dark:border-[#313235] border-2 rounded-lg overflow-hidden`}
       id={rule.code}
     >
       <div
-        class={tw`p-3 border-b border-gray-200 flex justify-between flex-wrap gap-2 items-center bg-white dark:bg-[#0d1117] dark:border-[#313235]`}
+        class={tw
+          `p-3 border-b border-gray-200 flex justify-between flex-wrap gap-2 items-center bg-white dark:bg-[#0d1117] dark:border-[#313235]`}
       >
         <h1 class={tw`text-xl font-bold`}>
           <a href={`#${rule.code}`} class={tw`hover:underline`}>
@@ -107,7 +110,8 @@ function Rule(props: { rule: RuleData }) {
         </h1>
         {rule.tags.includes("recommended") && (
           <span
-            class={tw`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium leading-4 bg-blue-100 text-blue-800`}
+            class={tw
+              `inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium leading-4 bg-blue-100 text-blue-800`}
           >
             Recommended
           </span>

--- a/www/pages/index.tsx
+++ b/www/pages/index.tsx
@@ -79,7 +79,7 @@ function IndexPage(props: PageProps) {
             }}
           >
           </script>
-          <div class={tw`mt-6 text-gray-600`}>
+          <div class={tw`mt-6 text-gray-600 dark:text-gray-400`}>
             Showing {searchResults.length} out of {rules.length} rules
           </div>
           <div>

--- a/www/pages/index.tsx
+++ b/www/pages/index.tsx
@@ -37,53 +37,55 @@ function IndexPage(props: PageProps) {
     .filter((rule: RuleData) => rule.code.includes(search));
 
   return (
-    <div class={tw`mx-auto max-w-screen-md px-6 sm:px-6 md:px-8`}>
-      <Head>
-        <link
-          rel="stylesheet"
-          href="https://cdn.jsdelivr.net/gh/lucacasonato/manual@df7ae27/www/static/markdown.css"
-          crossOrigin="anonymous"
-        />
-      </Head>
-      <Header />
-      <main class={tw`my-8`}>
-        <label for="search" class={tw`sr-only`}>Search</label>
-        <form id="search_form">
-          <input
-            type="text"
-            name="q"
-            class={tw
-              `w-full border h-10 border-gray-200 rounded rounded-r-none px-3 relative`}
-            placeholder="Search"
-            value={search}
+    <div class={tw`dark:bg-[#0d1117] dark:text-white py-6`}>
+      <div class={tw`mx-auto max-w-screen-md px-6 sm:px-6 md:px-8`}>
+        <Head>
+          <link
+            rel="stylesheet"
+            href="https://cdn.jsdelivr.net/gh/lucacasonato/manual@df7ae27/www/static/markdown.css"
+            crossOrigin="anonymous"
           />
-          <div class={tw`mt-2`}>
+        </Head>
+        <Header />
+        <main class={tw`my-8`}>
+          <label for="search" class={tw`sr-only`}>Search</label>
+          <form id="search_form">
             <input
-              type="checkbox"
-              id="all_rules"
-              name="all"
-              checked={allRules}
+              type="text"
+              name="q"
+              class={tw
+                `w-full border h-10 border-gray-200 dark:border-gray-500 rounded rounded-r-none px-3 relative dark:bg-gray-800 `}
+              placeholder="Search"
+              value={search}
             />
-            <label htmlFor="all_rules" class={tw`ml-2`}>
-              Show all rules
-            </label>
+            <div class={tw`mt-2`}>
+              <input
+                type="checkbox"
+                id="all_rules"
+                name="all"
+                checked={allRules}
+              />
+              <label htmlFor="all_rules" class={tw`ml-2`}>
+                Show all rules
+              </label>
+            </div>
+          </form>
+          <script
+            dangerouslySetInnerHTML={{
+              __html:
+                "document.getElementById('all_rules').oninput = () => document.getElementById('search_form').submit();",
+            }}
+          >
+          </script>
+          <div class={tw`mt-6 text-gray-600`}>
+            Showing {searchResults.length} out of {rules.length} rules
           </div>
-        </form>
-        <script
-          dangerouslySetInnerHTML={{
-            __html:
-              "document.getElementById('all_rules').oninput = () => document.getElementById('search_form').submit();",
-          }}
-        >
-        </script>
-        <div class={tw`mt-6 text-gray-600`}>
-          Showing {searchResults.length} out of {rules.length} rules
-        </div>
-        <div>
-          {searchResults
-            .map((rule: RuleData) => <Rule key={rule.code} rule={rule} />)}
-        </div>
-      </main>
+          <div>
+            {searchResults
+              .map((rule: RuleData) => <Rule key={rule.code} rule={rule} />)}
+          </div>
+        </main>
+      </div>
     </div>
   );
 }
@@ -93,12 +95,12 @@ function Rule(props: { rule: RuleData }) {
 
   return (
     <section
-      class={tw`my-8 border-gray-200 border-2 rounded-lg overflow-hidden`}
+      class={tw`my-8 border-gray-200 dark:border-[#313235] border-2 rounded-lg overflow-hidden`}
       id={rule.code}
     >
       <div
         class={tw
-          `p-3 border-b border-gray-200 flex justify-between flex-wrap gap-2 items-center bg-white`}
+          `p-3 border-b border-gray-200 flex justify-between flex-wrap gap-2 items-center bg-white dark:bg-[#0d1117] dark:border-[#313235]`}
       >
         <h1 class={tw`text-xl font-bold`}>
           <a href={`#${rule.code}`} class={tw`hover:underline`}>
@@ -115,7 +117,7 @@ function Rule(props: { rule: RuleData }) {
         )}
       </div>
       <div
-        class={tw`relative bg-gray-50 dark:bg-[#0d1117] dark:text-white p-3`}
+        class={tw`relative bg-gray-50 dark:bg-[#192029] dark:text-white p-3`}
       >
         {rule.docs.length > 0
           ? (

--- a/www/pages/index.tsx
+++ b/www/pages/index.tsx
@@ -53,8 +53,7 @@ function IndexPage(props: PageProps) {
             <input
               type="text"
               name="q"
-              class={tw
-                `w-full border h-10 border-gray-200 dark:border-gray-500 rounded rounded-r-none px-3 relative dark:bg-gray-800 `}
+              class={tw`w-full border h-10 border-gray-200 dark:border-gray-500 rounded rounded-r-none px-3 relative dark:bg-gray-800 `}
               placeholder="Search"
               value={search}
             />
@@ -99,8 +98,7 @@ function Rule(props: { rule: RuleData }) {
       id={rule.code}
     >
       <div
-        class={tw
-          `p-3 border-b border-gray-200 flex justify-between flex-wrap gap-2 items-center bg-white dark:bg-[#0d1117] dark:border-[#313235]`}
+        class={tw`p-3 border-b border-gray-200 flex justify-between flex-wrap gap-2 items-center bg-white dark:bg-[#0d1117] dark:border-[#313235]`}
       >
         <h1 class={tw`text-xl font-bold`}>
           <a href={`#${rule.code}`} class={tw`hover:underline`}>
@@ -109,8 +107,7 @@ function Rule(props: { rule: RuleData }) {
         </h1>
         {rule.tags.includes("recommended") && (
           <span
-            class={tw
-              `inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium leading-4 bg-blue-100 text-blue-800`}
+            class={tw`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium leading-4 bg-blue-100 text-blue-800`}
           >
             Recommended
           </span>

--- a/www/pages/index.tsx
+++ b/www/pages/index.tsx
@@ -56,8 +56,7 @@ function IndexPage(props: PageProps) {
             <input
               type="text"
               name="q"
-              class={tw
-                `w-full border h-10 border-gray-200 dark:border-gray-500 rounded rounded-r-none px-3 relative dark:bg-gray-800 `}
+              class={tw`w-full border h-10 border-gray-200 dark:border-gray-500 rounded rounded-r-none px-3 relative dark:bg-gray-800 `}
               placeholder="Search"
               value={search}
             />
@@ -98,13 +97,11 @@ function Rule(props: { rule: RuleData }) {
 
   return (
     <section
-      class={tw
-        `my-8 border-gray-200 dark:border-[#313235] border-2 rounded-lg overflow-hidden`}
+      class={tw`my-8 border-gray-200 dark:border-[#313235] border-2 rounded-lg overflow-hidden`}
       id={rule.code}
     >
       <div
-        class={tw
-          `p-3 border-b border-gray-200 flex justify-between flex-wrap gap-2 items-center bg-white dark:bg-[#0d1117] dark:border-[#313235]`}
+        class={tw`p-3 border-b border-gray-200 flex justify-between flex-wrap gap-2 items-center bg-white dark:bg-[#0d1117] dark:border-[#313235]`}
       >
         <h1 class={tw`text-xl font-bold`}>
           <a href={`#${rule.code}`} class={tw`hover:underline`}>


### PR DESCRIPTION
Add darkmode support for the index page (the ignore rules page was handled already).

The diff on github looks worst than what actually changed.

<details>
<summary>Previous</summary>

![image](https://user-images.githubusercontent.com/32012862/184727476-91d758a6-068f-4d49-afe3-a49f882b5c85.png)

</details>

Now:

![image](https://user-images.githubusercontent.com/32012862/184727045-a4182779-6b5f-4d90-8667-8088b220bf87.png)



