### PR TITLE
Revert "fix: Fix markdown css import url and the starting command in README"

### DIFF
--- a/www/README.md
+++ b/www/README.md
@@ -5,7 +5,7 @@
 Start the project (from the root of the repo):
 
 ```
-deno run -A --unstable --watch www/main.ts
+deno run -A --unstable --watch main.ts
 ```
 
 After adding, removing, or moving a page in the `pages` directory, run:

--- a/www/pages/ignoring-rules.tsx
+++ b/www/pages/ignoring-rules.tsx
@@ -15,7 +15,7 @@ function IgnoringRulesPage() {
         <Head>
           <link
             rel="stylesheet"
-            href="https://cdn.jsdelivr.net/gh/lucacasonato/manual@df7ae27/www/static/markdown.css"
+            href="https://cdn.jsdelivr.net/gh/lucacasonato/manual@www/www/static/markdown.css"
             crossOrigin="anonymous"
           />
         </Head>


### PR DESCRIPTION
Although the cause is not fully understood, Revert because it now returns "500 Internal Server Error"