### PR TITLE
feat: add compact format

### DIFF
--- a/examples/dlint/diagnostics.rs
+++ b/examples/dlint/diagnostics.rs
@@ -11,43 +11,46 @@ pub fn display_diagnostics(
   filename: &str,
   format: Option<&str>,
 ) {
-  for diagnostic in diagnostics {
-    match format {
-      Some("compact") => print_compact(filename, diagnostic),
-      _ => print_pretty(source_file, filename, diagnostic),
-    }
+  match format {
+    Some("compact") => print_compact(diagnostics, filename),
+    Some("pretty") => print_pretty(diagnostics, source_file, filename),
+    _ => unreachable!("Invalid output format specified"),
   }
 }
 
-fn print_compact(filename: &str, diagnostic: &LintDiagnostic) {
-  eprintln!(
-    "{}: line {}, col {}, Error - {} ({})",
-    filename,
-    diagnostic.range.start.line_index + 1,
-    diagnostic.range.start.column_index + 1,
-    diagnostic.message,
-    diagnostic.code
-  )
+fn print_compact(diagnostics: &[LintDiagnostic], filename: &str) {
+  for diagnostic in diagnostics {
+    eprintln!(
+      "{}: line {}, col {}, Error - {} ({})",
+      filename,
+      diagnostic.range.start.line_index + 1,
+      diagnostic.range.start.column_index + 1,
+      diagnostic.message,
+      diagnostic.code
+    )
+  }
 }
 
 fn print_pretty(
+  diagnostics: &[LintDiagnostic],
   source_file: &SourceTextInfo,
   filename: &str,
-  diagnostic: &LintDiagnostic,
 ) {
-  let reporter = miette::GraphicalReportHandler::new();
-  let miette_source_code = MietteSourceCode {
-    source: source_file,
-    filename,
-  };
+  for diagnostic in diagnostics {
+    let reporter = miette::GraphicalReportHandler::new();
+    let miette_source_code = MietteSourceCode {
+      source: source_file,
+      filename,
+    };
 
-  let mut s = String::new();
-  let miette_diag = MietteDiagnostic {
-    source_code: &miette_source_code,
-    lint_diagnostic: diagnostic,
-  };
-  reporter.render_report(&mut s, &miette_diag).unwrap();
-  eprintln!("{}", s);
+    let mut s = String::new();
+    let miette_diag = MietteDiagnostic {
+      source_code: &miette_source_code,
+      lint_diagnostic: diagnostic,
+    };
+    reporter.render_report(&mut s, &miette_diag).unwrap();
+    eprintln!("{}", s);
+  }
 }
 
 #[derive(Debug)]

--- a/examples/dlint/diagnostics.rs
+++ b/examples/dlint/diagnostics.rs
@@ -9,6 +9,31 @@ pub fn display_diagnostics(
   diagnostics: &[LintDiagnostic],
   source_file: &SourceTextInfo,
   filename: &str,
+  format: Option<&str>,
+) {
+  for diagnostic in diagnostics {
+    match format {
+      Some("compact") => print_compact(filename, diagnostic),
+      _ => print_pretty(source_file, filename, diagnostic),
+    }
+  }
+}
+
+fn print_compact(filename: &str, diagnostic: &LintDiagnostic) {
+  eprintln!(
+    "{}: line {}, col {}, Error - {} ({})",
+    filename,
+    diagnostic.range.start.line_index + 1,
+    diagnostic.range.start.column_index + 1,
+    diagnostic.message,
+    diagnostic.code
+  )
+}
+
+fn print_pretty(
+  source_file: &SourceTextInfo,
+  filename: &str,
+  diagnostic: &LintDiagnostic,
 ) {
   let reporter = miette::GraphicalReportHandler::new();
   let miette_source_code = MietteSourceCode {
@@ -16,15 +41,13 @@ pub fn display_diagnostics(
     filename,
   };
 
-  for diagnostic in diagnostics {
-    let mut s = String::new();
-    let miette_diag = MietteDiagnostic {
-      source_code: &miette_source_code,
-      lint_diagnostic: diagnostic,
-    };
-    reporter.render_report(&mut s, &miette_diag).unwrap();
-    eprintln!("{}", s);
-  }
+  let mut s = String::new();
+  let miette_diag = MietteDiagnostic {
+    source_code: &miette_source_code,
+    lint_diagnostic: diagnostic,
+  };
+  reporter.render_report(&mut s, &miette_diag).unwrap();
+  eprintln!("{}", s);
 }
 
 #[derive(Debug)]

--- a/examples/dlint/main.rs
+++ b/examples/dlint/main.rs
@@ -54,7 +54,13 @@ fn create_cli_app<'a>() -> Command<'a> {
           Arg::new("FORMAT")
             .long("format")
             .help("Configure output format")
-            .takes_value(true),
+            .takes_value(true)
+            .default_value("pretty")
+            .validator(|val: &str| match val {
+              "compact" => Ok(()),
+              "pretty" => Ok(()),
+              _ => Err("Output format must be compact or pretty")
+            }),
         )
     )
 }


### PR DESCRIPTION
closes https://github.com/denoland/deno_lint/issues/1077

Added a --format compact option that outputs like the following

<img width="691" alt="image" src="https://user-images.githubusercontent.com/184235/189506463-8cb42a99-d2e3-4c59-962c-42aead06135e.png">
