### PR TITLE
fix: no_self_assign - getter and private class member with same name

### DIFF
--- a/src/rules/no_self_assign.rs
+++ b/src/rules/no_self_assign.rs
@@ -367,6 +367,8 @@ mod tests {
       "this.x = this.y",
       "this.x = options.x",
       "this.name = this.constructor.name",
+
+      // https://github.com/denoland/deno_lint/issues/1081
       r#"
         class Foo {
           constructor() {


### PR DESCRIPTION
# Fixes #1081 
fix no_self_assign rule, when getter and private class member with same name.
`NoSelfAssignVisitor#are_same_property()` returns false, if the MemberExpr.prop is a pair of `MemberProp::Ident` and `MemberProp::PrivateName`.