### PR TITLE
fix: no-self-assign rule grammar

### DIFF
--- a/src/rules/no_self_assign.rs
+++ b/src/rules/no_self_assign.rs
@@ -36,7 +36,7 @@ enum NoSelfAssignMessage {
 #[derive(Display)]
 enum NoSelfAssignHint {
   #[display(
-    fmt = "Self assignments have no effect. Perhaps you make a mistake?"
+    fmt = "Self assignments have no effect. Perhaps you made a mistake?"
   )]
   Mistake,
 }


### PR DESCRIPTION
Fixes #1080 

Changed `make` to `made` in message for no-self-assign rule.