### PR TITLE
fix: empty object type recommendation

### DIFF
--- a/src/rules/ban_types.rs
+++ b/src/rules/ban_types.rs
@@ -50,7 +50,7 @@ impl BannedType {
       }
       LowerObject => "Use `Record<string, unknown>` instead",
       EmptyObjectLiteral => {
-        r#"If you want a type that means "empty object", use `Record<never, never>` instead"#
+        r#"If you want a type that means "empty object", use `Record<string | number | symbol, never>` instead"#
       }
     }
   }


### PR DESCRIPTION
The linter currently suggests `Record<never, never>` as a way to represent an empty object in TS. However, typing the keys as `never` actually prevents TS from validating anything:

```ts
type CurrentlyRecommendedEmptyObject = Record<never, never>

// No type errors because TS doesn't check keys typed as "never"
const empty: CurrentlyRecommendedEmptyObject = { whoops: "" }
```

This PR amends the recommended type to `Record<string | number | symbol, never>`, which correctly ensures that the object is empty:

```ts
type ImprovedEmptyObjectRecommendation = Record<string | number | symbol, never>

// TypeError: Type 'string' is not assignable to type 'never'.
const empty: ImprovedEmptyObject = { whoops: " " }
```

`Record<any, never>` is terser and does the same thing, but creates another lint error by default so I went with the more explicit option.