### PR TITLE
chore: add devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,15 @@
+# [Choice] Debian OS version: bullseye, buster
+ARG VARIANT=bullseye
+FROM --platform=linux/amd64 mcr.microsoft.com/devcontainers/base:0-${VARIANT}
+
+ENV DENO_INSTALL=/deno
+RUN mkdir -p /deno \
+    && curl -fsSL https://deno.land/x/install/install.sh | sh \
+    && chown -R vscode /deno
+
+ENV PATH=${DENO_INSTALL}/bin:${PATH} \
+    DENO_DIR=${DENO_INSTALL}/.cache/deno
+
+# [Optional] Uncomment this section to install additional OS packages.
+# RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+#    && apt-get -y install --no-install-recommends <your-package-list-here>

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,7 +1,7 @@
-# [Choice] Debian OS version: bullseye, buster
 ARG VARIANT=bullseye
 FROM --platform=linux/amd64 mcr.microsoft.com/devcontainers/base:0-${VARIANT}
 
+# install deno
 ENV DENO_INSTALL=/deno
 RUN mkdir -p /deno \
     && curl -fsSL https://deno.land/x/install/install.sh | sh \
@@ -9,7 +9,3 @@ RUN mkdir -p /deno \
 
 ENV PATH=${DENO_INSTALL}/bin:${PATH} \
     DENO_DIR=${DENO_INSTALL}/.cache/deno
-
-# [Optional] Uncomment this section to install additional OS packages.
-# RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
-#    && apt-get -y install --no-install-recommends <your-package-list-here>

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,29 @@
+{
+	"name": "Deno",
+ 	"build": {
+		"dockerfile": "Dockerfile"
+	},
+
+	"customizations": {
+		"vscode": {
+			"settings": { 
+				// Enables the project as a Deno project
+				"deno.enable": true,
+				// Enables Deno linting for the project
+				"deno.lint": true,
+				// Sets Deno as the default formatter for the project
+				"editor.defaultFormatter": "denoland.vscode-deno"
+			},
+			
+			"extensions": [
+				"denoland.vscode-deno"
+			]
+		}
+	},
+
+	"remoteUser": "vscode",
+	"features": {
+		// Add rust support
+		"ghcr.io/devcontainers/features/rust:1": {}
+	}
+}

--- a/tools/format.ts
+++ b/tools/format.ts
@@ -37,6 +37,7 @@ const p3 = await Deno.run({
     "www/pages",
     "docs/rules",
     "README.md",
+    ".devcontainer",
   ],
   stdin: "null",
 }).status();


### PR DESCRIPTION
adds a devcontainer with Deno (for www) and Rust (for the repo itself) support.

(If a contributor agrees) I do also think that the perf tools should be added as well (as mentioned in README), but for now it's a bare container.