### PR TITLE
Drop `LintRule::lint_program`

### DIFF
--- a/src/rules.rs
+++ b/src/rules.rs
@@ -107,30 +107,13 @@ pub trait LintRule: std::fmt::Debug + Send + Sync {
   where
     Self: Sized;
 
-  /// Executes lint on the given `Program`.
-  /// TODO(@magurotuna): remove this after all rules get to use ast_view
-  fn lint_program<'view>(
-    &self,
-    _context: &mut Context<'view>,
-    _program: ProgramRef<'view>,
-  ) {
-    unreachable!();
-  }
-
   /// Executes lint using `dprint-swc-ecma-ast-view`.
   /// Falls back to the `lint_program` method if not implemented.
   fn lint_program_with_ast_view<'view>(
     &self,
     context: &mut Context<'view>,
     program: Program<'view>,
-  ) {
-    use Program::*;
-    let program_ref = match program {
-      Module(m) => ProgramRef::Module(m.inner),
-      Script(s) => ProgramRef::Script(s.inner),
-    };
-    self.lint_program(context, program_ref);
-  }
+  );
 
   /// Returns the unique code that identifies the rule
   fn code(&self) -> &'static str;
@@ -151,6 +134,14 @@ pub trait LintRule: std::fmt::Debug + Send + Sync {
   /// and they might override this value.
   fn priority(&self) -> u32 {
     0
+  }
+}
+
+/// TODO(@magurotuna): remove this after all rules get to use ast_view
+pub fn program_ref(program: Program) -> ProgramRef {
+  match program {
+    Program::Module(m) => ProgramRef::Module(m.inner),
+    Program::Script(s) => ProgramRef::Script(s.inner),
   }
 }
 

--- a/src/rules.rs
+++ b/src/rules.rs
@@ -111,9 +111,11 @@ pub trait LintRule: std::fmt::Debug + Send + Sync {
   /// TODO(@magurotuna): remove this after all rules get to use ast_view
   fn lint_program<'view>(
     &self,
-    context: &mut Context<'view>,
-    program: ProgramRef<'view>,
-  );
+    _context: &mut Context<'view>,
+    _program: ProgramRef<'view>,
+  ) {
+    unreachable!();
+  }
 
   /// Executes lint using `dprint-swc-ecma-ast-view`.
   /// Falls back to the `lint_program` method if not implemented.

--- a/src/rules/adjacent_overload_signatures.rs
+++ b/src/rules/adjacent_overload_signatures.rs
@@ -2,7 +2,7 @@
 use super::{Context, LintRule};
 use crate::handler::{Handler, Traverse};
 use crate::swc_util::StringRepr;
-use crate::{Program, ProgramRef};
+use crate::Program;
 use deno_ast::{view as ast_view, SourceRanged};
 use derive_more::Display;
 use std::collections::HashSet;
@@ -36,10 +36,6 @@ impl LintRule for AdjacentOverloadSignatures {
 
   fn code(&self) -> &'static str {
     CODE
-  }
-
-  fn lint_program(&self, _context: &mut Context, _program: ProgramRef<'_>) {
-    unreachable!();
   }
 
   fn lint_program_with_ast_view<'view>(

--- a/src/rules/ban_ts_comment.rs
+++ b/src/rules/ban_ts_comment.rs
@@ -1,6 +1,6 @@
 // Copyright 2020-2021 the Deno authors. All rights reserved. MIT license.
 use super::{Context, LintRule};
-use crate::{Program, ProgramRef};
+use crate::Program;
 use deno_ast::swc::common::comments::Comment;
 use deno_ast::swc::common::comments::CommentKind;
 use deno_ast::SourceRange;
@@ -78,10 +78,6 @@ impl LintRule for BanTsComment {
 
   fn code(&self) -> &'static str {
     CODE
-  }
-
-  fn lint_program(&self, _context: &mut Context, _program: ProgramRef<'_>) {
-    unreachable!();
   }
 
   fn lint_program_with_ast_view(

--- a/src/rules/ban_types.rs
+++ b/src/rules/ban_types.rs
@@ -1,7 +1,7 @@
 // Copyright 2020-2021 the Deno authors. All rights reserved. MIT license.
 use super::{Context, LintRule};
 use crate::handler::{Handler, Traverse};
-use crate::{Program, ProgramRef};
+use crate::Program;
 use deno_ast::view::{TsEntityName, TsKeywordTypeKind};
 use deno_ast::{view as ast_view, SourceRanged};
 use if_chain::if_chain;
@@ -88,10 +88,6 @@ impl LintRule for BanTypes {
 
   fn code(&self) -> &'static str {
     CODE
-  }
-
-  fn lint_program(&self, _context: &mut Context, _program: ProgramRef) {
-    unreachable!();
   }
 
   fn lint_program_with_ast_view(

--- a/src/rules/ban_unknown_rule_code.rs
+++ b/src/rules/ban_unknown_rule_code.rs
@@ -1,6 +1,6 @@
 // Copyright 2020-2021 the Deno authors. All rights reserved. MIT license.
 use super::{Context, LintRule};
-use crate::{Program, ProgramRef};
+use crate::Program;
 use std::sync::Arc;
 
 /// This is a dummy struct just for having the docs.
@@ -21,10 +21,6 @@ impl LintRule for BanUnknownRuleCode {
 
   fn code(&self) -> &'static str {
     CODE
-  }
-
-  fn lint_program(&self, _context: &mut Context, _program: ProgramRef<'_>) {
-    unreachable!();
   }
 
   fn lint_program_with_ast_view(

--- a/src/rules/ban_untagged_ignore.rs
+++ b/src/rules/ban_untagged_ignore.rs
@@ -1,6 +1,6 @@
 // Copyright 2020-2021 the Deno authors. All rights reserved. MIT license.
 use super::{Context, LintRule};
-use crate::{Program, ProgramRef};
+use crate::Program;
 use deno_ast::SourceRange;
 use std::sync::Arc;
 
@@ -20,10 +20,6 @@ impl LintRule for BanUntaggedIgnore {
 
   fn code(&self) -> &'static str {
     CODE
-  }
-
-  fn lint_program(&self, _context: &mut Context, _program: ProgramRef<'_>) {
-    unreachable!();
   }
 
   fn lint_program_with_ast_view(

--- a/src/rules/ban_untagged_todo.rs
+++ b/src/rules/ban_untagged_todo.rs
@@ -1,6 +1,6 @@
 // Copyright 2020-2021 the Deno authors. All rights reserved. MIT license.
 use super::{Context, LintRule};
-use crate::{Program, ProgramRef};
+use crate::Program;
 use deno_ast::swc::common::comments::Comment;
 use deno_ast::swc::common::comments::CommentKind;
 use deno_ast::SourceRangedForSpanned;
@@ -22,10 +22,6 @@ impl LintRule for BanUntaggedTodo {
 
   fn code(&self) -> &'static str {
     CODE
-  }
-
-  fn lint_program(&self, _context: &mut Context, _program: ProgramRef<'_>) {
-    unreachable!();
   }
 
   fn lint_program_with_ast_view(

--- a/src/rules/ban_unused_ignore.rs
+++ b/src/rules/ban_unused_ignore.rs
@@ -1,6 +1,6 @@
 // Copyright 2020-2021 the Deno authors. All rights reserved. MIT license.
 use super::{Context, LintRule};
-use crate::{Program, ProgramRef};
+use crate::Program;
 use std::sync::Arc;
 
 /// This is a dummy struct just for having the docs.
@@ -19,10 +19,6 @@ impl LintRule for BanUnusedIgnore {
 
   fn code(&self) -> &'static str {
     "ban-unused-ignore"
-  }
-
-  fn lint_program(&self, _context: &mut Context, _program: ProgramRef<'_>) {
-    unreachable!();
   }
 
   fn lint_program_with_ast_view(

--- a/src/rules/camelcase.rs
+++ b/src/rules/camelcase.rs
@@ -2,7 +2,7 @@
 use super::{Context, LintRule};
 use crate::handler::{Handler, Traverse};
 use crate::swc_util::StringRepr;
-use crate::ProgramRef;
+
 use deno_ast::{view as ast_view, SourceRange, SourceRanged};
 use once_cell::sync::Lazy;
 use regex::{Captures, Regex};
@@ -25,14 +25,6 @@ impl LintRule for Camelcase {
 
   fn code(&self) -> &'static str {
     CODE
-  }
-
-  fn lint_program<'view>(
-    &self,
-    _context: &mut Context<'view>,
-    _program: ProgramRef<'view>,
-  ) {
-    unreachable!();
   }
 
   fn lint_program_with_ast_view(

--- a/src/rules/constructor_super.rs
+++ b/src/rules/constructor_super.rs
@@ -1,7 +1,7 @@
 // Copyright 2020-2021 the Deno authors. All rights reserved. MIT license.
 use super::{Context, LintRule};
 use crate::handler::{Handler, Traverse};
-use crate::{Program, ProgramRef};
+use crate::Program;
 use deno_ast::{view as ast_view, SourceRange, SourceRanged};
 use if_chain::if_chain;
 use std::sync::Arc;
@@ -24,10 +24,6 @@ impl LintRule for ConstructorSuper {
 
   fn code(&self) -> &'static str {
     CODE
-  }
-
-  fn lint_program(&self, _context: &mut Context, _program: ProgramRef) {
-    unreachable!();
   }
 
   fn lint_program_with_ast_view(

--- a/src/rules/default_param_last.rs
+++ b/src/rules/default_param_last.rs
@@ -1,7 +1,7 @@
 // Copyright 2020-2021 the Deno authors. All rights reserved. MIT license.
 use super::{Context, LintRule};
 use crate::handler::{Handler, Traverse};
-use crate::{Program, ProgramRef};
+use crate::Program;
 use deno_ast::{view as ast_view, SourceRanged};
 use derive_more::Display;
 use std::sync::Arc;
@@ -32,14 +32,6 @@ impl LintRule for DefaultParamLast {
 
   fn code(&self) -> &'static str {
     CODE
-  }
-
-  fn lint_program<'view>(
-    &self,
-    _context: &mut Context<'view>,
-    _program: ProgramRef<'view>,
-  ) {
-    unreachable!();
   }
 
   fn lint_program_with_ast_view(

--- a/src/rules/eqeqeq.rs
+++ b/src/rules/eqeqeq.rs
@@ -1,7 +1,7 @@
 // Copyright 2020-2021 the Deno authors. All rights reserved. MIT license.
 use super::{Context, LintRule};
 use crate::handler::{Handler, Traverse};
-use crate::{Program, ProgramRef};
+use crate::Program;
 use deno_ast::swc::ast::BinaryOp;
 use deno_ast::{view as ast_view, SourceRanged};
 use derive_more::Display;
@@ -35,14 +35,6 @@ impl LintRule for Eqeqeq {
 
   fn code(&self) -> &'static str {
     CODE
-  }
-
-  fn lint_program<'view>(
-    &self,
-    _context: &mut Context<'view>,
-    _program: ProgramRef<'view>,
-  ) {
-    unreachable!();
   }
 
   fn lint_program_with_ast_view(

--- a/src/rules/explicit_function_return_type.rs
+++ b/src/rules/explicit_function_return_type.rs
@@ -1,7 +1,7 @@
 // Copyright 2020-2021 the Deno authors. All rights reserved. MIT license.
 use super::{Context, LintRule};
 use crate::handler::{Handler, Traverse};
-use crate::{Program, ProgramRef};
+use crate::Program;
 use deno_ast::{view as ast_view, MediaType, SourceRanged};
 use derive_more::Display;
 use std::sync::Arc;
@@ -30,10 +30,6 @@ impl LintRule for ExplicitFunctionReturnType {
 
   fn code(&self) -> &'static str {
     CODE
-  }
-
-  fn lint_program(&self, _context: &mut Context, _program: ProgramRef) {
-    unreachable!();
   }
 
   fn lint_program_with_ast_view(

--- a/src/rules/explicit_module_boundary_types.rs
+++ b/src/rules/explicit_module_boundary_types.rs
@@ -1,7 +1,7 @@
 // Copyright 2020-2021 the Deno authors. All rights reserved. MIT license.
 use super::{Context, LintRule};
 use crate::handler::{Handler, Traverse};
-use crate::ProgramRef;
+
 use deno_ast::{view as ast_view, MediaType, SourceRange, SourceRanged};
 use derive_more::Display;
 use std::sync::Arc;
@@ -36,14 +36,6 @@ impl LintRule for ExplicitModuleBoundaryTypes {
 
   fn code(&self) -> &'static str {
     CODE
-  }
-
-  fn lint_program<'view>(
-    &self,
-    _context: &mut Context<'view>,
-    _program: ProgramRef<'view>,
-  ) {
-    unreachable!();
   }
 
   fn lint_program_with_ast_view(

--- a/src/rules/for_direction.rs
+++ b/src/rules/for_direction.rs
@@ -1,7 +1,7 @@
 // Copyright 2020-2021 the Deno authors. All rights reserved. MIT license.
 use super::{Context, LintRule};
 use crate::handler::{Handler, Traverse};
-use crate::{Program, ProgramRef};
+use crate::Program;
 use deno_ast::swc::ast::AssignOp;
 use deno_ast::swc::ast::BinaryOp;
 use deno_ast::swc::ast::UpdateOp;
@@ -23,14 +23,6 @@ impl LintRule for ForDirection {
 
   fn code(&self) -> &'static str {
     "for-direction"
-  }
-
-  fn lint_program<'view>(
-    &self,
-    _context: &mut Context<'view>,
-    _program: ProgramRef<'view>,
-  ) {
-    unreachable!();
   }
 
   fn lint_program_with_ast_view(

--- a/src/rules/getter_return.rs
+++ b/src/rules/getter_return.rs
@@ -1,6 +1,8 @@
 // Copyright 2020-2021 the Deno authors. All rights reserved. MIT license.
+use super::program_ref;
 use super::{Context, LintRule};
 use crate::swc_util::StringRepr;
+use crate::Program;
 use crate::ProgramRef;
 use deno_ast::swc::ast::{
   ArrowExpr, BlockStmtOrExpr, CallExpr, Callee, ClassMethod, Expr, FnDecl,
@@ -49,11 +51,12 @@ impl LintRule for GetterReturn {
     CODE
   }
 
-  fn lint_program<'view>(
+  fn lint_program_with_ast_view<'view>(
     &self,
     context: &mut Context<'view>,
-    program: ProgramRef<'view>,
+    program: Program<'view>,
   ) {
+    let program = program_ref(program);
     let mut visitor = GetterReturnVisitor::new(context);
     match program {
       ProgramRef::Module(m) => visitor.visit_module(m),

--- a/src/rules/guard_for_in.rs
+++ b/src/rules/guard_for_in.rs
@@ -1,7 +1,7 @@
 // Copyright 2020-2022 the Deno authors. All rights reserved. MIT license.
 use super::{Context, LintRule};
 use crate::handler::{Handler, Traverse};
-use crate::{Program, ProgramRef};
+use crate::Program;
 use deno_ast::SourceRanged;
 use std::sync::Arc;
 
@@ -19,10 +19,6 @@ impl LintRule for GuardForIn {
 
   fn code(&self) -> &'static str {
     CODE
-  }
-
-  fn lint_program(&self, _context: &mut Context, _program: ProgramRef<'_>) {
-    unreachable!();
   }
 
   fn lint_program_with_ast_view(

--- a/src/rules/no_array_constructor.rs
+++ b/src/rules/no_array_constructor.rs
@@ -1,7 +1,7 @@
 // Copyright 2020-2021 the Deno authors. All rights reserved. MIT license.
 use super::{Context, LintRule};
 use crate::handler::{Handler, Traverse};
-use crate::{Program, ProgramRef};
+use crate::Program;
 use deno_ast::view::{CallExpr, Callee, Expr, ExprOrSpread, NewExpr};
 use deno_ast::{SourceRange, SourceRanged};
 use std::sync::Arc;
@@ -24,14 +24,6 @@ impl LintRule for NoArrayConstructor {
 
   fn code(&self) -> &'static str {
     CODE
-  }
-
-  fn lint_program<'view>(
-    &self,
-    _context: &mut Context<'view>,
-    _program: ProgramRef<'view>,
-  ) {
-    unreachable!();
   }
 
   fn lint_program_with_ast_view(

--- a/src/rules/no_async_promise_executor.rs
+++ b/src/rules/no_async_promise_executor.rs
@@ -1,7 +1,7 @@
 // Copyright 2020-2021 the Deno authors. All rights reserved. MIT license.
 use super::{Context, LintRule};
 use crate::handler::{Handler, Traverse};
-use crate::{Program, ProgramRef};
+use crate::Program;
 use deno_ast::view::{Expr, NewExpr, ParenExpr};
 use deno_ast::SourceRanged;
 use std::sync::Arc;
@@ -25,14 +25,6 @@ impl LintRule for NoAsyncPromiseExecutor {
 
   fn code(&self) -> &'static str {
     CODE
-  }
-
-  fn lint_program<'view>(
-    &self,
-    _context: &mut Context<'view>,
-    _program: ProgramRef<'view>,
-  ) {
-    unreachable!();
   }
 
   fn lint_program_with_ast_view(

--- a/src/rules/no_await_in_loop.rs
+++ b/src/rules/no_await_in_loop.rs
@@ -1,7 +1,7 @@
 // Copyright 2020-2021 the Deno authors. All rights reserved. MIT license.
 use super::{Context, LintRule};
 use crate::handler::{Handler, Traverse};
-use crate::{Program, ProgramRef};
+use crate::Program;
 use deno_ast::view::NodeTrait;
 use deno_ast::{view as ast_view, SourceRanged};
 use std::sync::Arc;
@@ -20,10 +20,6 @@ impl LintRule for NoAwaitInLoop {
 
   fn code(&self) -> &'static str {
     CODE
-  }
-
-  fn lint_program(&self, _context: &mut Context, _program: ProgramRef<'_>) {
-    unreachable!();
   }
 
   fn lint_program_with_ast_view(

--- a/src/rules/no_case_declarations.rs
+++ b/src/rules/no_case_declarations.rs
@@ -1,7 +1,7 @@
 // Copyright 2020-2021 the Deno authors. All rights reserved. MIT license.
 use super::{Context, LintRule};
 use crate::handler::{Handler, Traverse};
-use crate::{Program, ProgramRef};
+use crate::Program;
 use deno_ast::view::{Decl, Stmt, SwitchCase, VarDeclKind};
 use deno_ast::SourceRanged;
 use std::sync::Arc;
@@ -24,14 +24,6 @@ impl LintRule for NoCaseDeclarations {
 
   fn code(&self) -> &'static str {
     CODE
-  }
-
-  fn lint_program<'view>(
-    &self,
-    _context: &mut Context<'view>,
-    _program: ProgramRef<'view>,
-  ) {
-    unreachable!();
   }
 
   fn lint_program_with_ast_view(

--- a/src/rules/no_class_assign.rs
+++ b/src/rules/no_class_assign.rs
@@ -1,6 +1,8 @@
 // Copyright 2020-2021 the Deno authors. All rights reserved. MIT license.
+use super::program_ref;
 use super::{Context, LintRule};
 use crate::swc_util::find_lhs_ids;
+use crate::Program;
 use crate::ProgramRef;
 use deno_ast::swc::ast::AssignExpr;
 use deno_ast::swc::visit::noop_visit_type;
@@ -30,11 +32,12 @@ impl LintRule for NoClassAssign {
     CODE
   }
 
-  fn lint_program<'view>(
+  fn lint_program_with_ast_view<'view>(
     &self,
     context: &mut Context<'view>,
-    program: ProgramRef<'view>,
+    program: Program<'view>,
   ) {
+    let program = program_ref(program);
     let mut visitor = NoClassAssignVisitor::new(context);
     match program {
       ProgramRef::Module(m) => m.visit_all_with(&mut visitor),

--- a/src/rules/no_compare_neg_zero.rs
+++ b/src/rules/no_compare_neg_zero.rs
@@ -1,7 +1,7 @@
 // Copyright 2020-2021 the Deno authors. All rights reserved. MIT license.
 use super::{Context, LintRule};
 use crate::handler::{Handler, Traverse};
-use crate::{Program, ProgramRef};
+use crate::Program;
 use deno_ast::swc::ast::BinaryOp::*;
 use deno_ast::swc::ast::Expr::Lit;
 use deno_ast::swc::ast::Lit::Num;
@@ -42,10 +42,6 @@ impl LintRule for NoCompareNegZero {
 
   fn code(&self) -> &'static str {
     CODE
-  }
-
-  fn lint_program(&self, _context: &mut Context, _program: ProgramRef<'_>) {
-    unreachable!();
   }
 
   fn lint_program_with_ast_view<'view>(

--- a/src/rules/no_cond_assign.rs
+++ b/src/rules/no_cond_assign.rs
@@ -1,7 +1,7 @@
 // Copyright 2020-2021 the Deno authors. All rights reserved. MIT license.
 use super::{Context, LintRule};
 use crate::handler::{Handler, Traverse};
-use crate::{Program, ProgramRef};
+use crate::Program;
 use deno_ast::view::{CondExpr, DoWhileStmt, Expr, ForStmt, IfStmt, WhileStmt};
 use deno_ast::{SourceRange, SourceRanged};
 use derive_more::Display;
@@ -39,10 +39,6 @@ impl LintRule for NoCondAssign {
 
   fn code(&self) -> &'static str {
     CODE
-  }
-
-  fn lint_program(&self, _context: &mut Context, _program: ProgramRef<'_>) {
-    unreachable!();
   }
 
   fn lint_program_with_ast_view<'view>(

--- a/src/rules/no_const_assign.rs
+++ b/src/rules/no_const_assign.rs
@@ -1,7 +1,7 @@
 // Copyright 2020-2021 the Deno authors. All rights reserved. MIT license.
 use super::{Context, LintRule};
 use crate::handler::{Handler, Traverse};
-use crate::{Program, ProgramRef};
+use crate::Program;
 use deno_ast::view::{
   ArrayPat, AssignExpr, Expr, Ident, ObjectPat, ObjectPatProp, Pat, PatOrExpr,
   UpdateExpr,
@@ -35,10 +35,6 @@ impl LintRule for NoConstAssign {
 
   fn code(&self) -> &'static str {
     CODE
-  }
-
-  fn lint_program(&self, _context: &mut Context, _program: ProgramRef<'_>) {
-    unreachable!();
   }
 
   fn lint_program_with_ast_view<'view>(

--- a/src/rules/no_constant_condition.rs
+++ b/src/rules/no_constant_condition.rs
@@ -1,5 +1,7 @@
 // Copyright 2020-2021 the Deno authors. All rights reserved. MIT license.
+use super::program_ref;
 use super::{Context, LintRule};
+use crate::Program;
 use crate::ProgramRef;
 use deno_ast::swc::ast::{BinaryOp, CondExpr, Expr, IfStmt, Lit, UnaryOp};
 use deno_ast::swc::visit::{noop_visit_type, VisitAll, VisitAllWith};
@@ -40,11 +42,12 @@ impl LintRule for NoConstantCondition {
     CODE
   }
 
-  fn lint_program<'view>(
+  fn lint_program_with_ast_view<'view>(
     &self,
     context: &mut Context<'view>,
-    program: ProgramRef<'view>,
+    program: Program<'view>,
   ) {
+    let program = program_ref(program);
     let mut visitor = NoConstantConditionVisitor::new(context);
     match program {
       ProgramRef::Module(m) => m.visit_all_with(&mut visitor),

--- a/src/rules/no_control_regex.rs
+++ b/src/rules/no_control_regex.rs
@@ -2,7 +2,7 @@
 use super::{Context, LintRule};
 use crate::handler::{Handler, Traverse};
 use crate::swc_util::extract_regex;
-use crate::{Program, ProgramRef};
+use crate::Program;
 use deno_ast::view::{CallExpr, Callee, Expr, NewExpr, Regex};
 use deno_ast::{SourceRange, SourceRanged};
 use derive_more::Display;
@@ -43,10 +43,6 @@ impl LintRule for NoControlRegex {
 
   fn code(&self) -> &'static str {
     CODE
-  }
-
-  fn lint_program(&self, _context: &mut Context, _program: ProgramRef) {
-    unreachable!();
   }
 
   fn lint_program_with_ast_view(

--- a/src/rules/no_debugger.rs
+++ b/src/rules/no_debugger.rs
@@ -1,7 +1,7 @@
 // Copyright 2020-2021 the Deno authors. All rights reserved. MIT license.
 use super::{Context, LintRule};
 use crate::handler::{Handler, Traverse};
-use crate::{Program, ProgramRef};
+use crate::Program;
 use deno_ast::view::DebuggerStmt;
 use deno_ast::SourceRanged;
 use derive_more::Display;
@@ -35,10 +35,6 @@ impl LintRule for NoDebugger {
 
   fn code(&self) -> &'static str {
     CODE
-  }
-
-  fn lint_program(&self, _context: &mut Context, _program: ProgramRef) {
-    unreachable!();
   }
 
   fn lint_program_with_ast_view(

--- a/src/rules/no_delete_var.rs
+++ b/src/rules/no_delete_var.rs
@@ -1,7 +1,7 @@
 // Copyright 2020-2021 the Deno authors. All rights reserved. MIT license.
 use super::{Context, LintRule};
 use crate::handler::{Handler, Traverse};
-use crate::{Program, ProgramRef};
+use crate::Program;
 use deno_ast::view::{Expr, UnaryExpr, UnaryOp};
 use deno_ast::SourceRanged;
 use derive_more::Display;
@@ -35,14 +35,6 @@ impl LintRule for NoDeleteVar {
 
   fn code(&self) -> &'static str {
     CODE
-  }
-
-  fn lint_program<'view>(
-    &self,
-    _context: &mut Context<'view>,
-    _program: ProgramRef<'view>,
-  ) {
-    unreachable!();
   }
 
   fn lint_program_with_ast_view(

--- a/src/rules/no_deprecated_deno_api.rs
+++ b/src/rules/no_deprecated_deno_api.rs
@@ -4,7 +4,7 @@ use super::LintRule;
 use crate::handler::Handler;
 use crate::handler::Traverse;
 use crate::Program;
-use crate::ProgramRef;
+
 use deno_ast::view as ast_view;
 use deno_ast::SourceRanged;
 use if_chain::if_chain;
@@ -27,10 +27,6 @@ impl LintRule for NoDeprecatedDenoApi {
 
   fn code(&self) -> &'static str {
     CODE
-  }
-
-  fn lint_program(&self, _context: &mut Context, _program: ProgramRef<'_>) {
-    unreachable!();
   }
 
   fn lint_program_with_ast_view(

--- a/src/rules/no_dupe_args.rs
+++ b/src/rules/no_dupe_args.rs
@@ -1,7 +1,7 @@
 // Copyright 2020-2021 the Deno authors. All rights reserved. MIT license.
 use super::{Context, LintRule};
 use crate::handler::{Handler, Traverse};
-use crate::{Program, ProgramRef};
+use crate::Program;
 use deno_ast::view::{ArrowExpr, Function, Param, Pat};
 use deno_ast::{SourceRange, SourceRanged};
 use derive_more::Display;
@@ -36,10 +36,6 @@ impl LintRule for NoDupeArgs {
 
   fn code(&self) -> &'static str {
     "no-dupe-args"
-  }
-
-  fn lint_program(&self, _context: &mut Context, _program: ProgramRef) {
-    unreachable!();
   }
 
   fn lint_program_with_ast_view(

--- a/src/rules/no_dupe_class_members.rs
+++ b/src/rules/no_dupe_class_members.rs
@@ -1,5 +1,7 @@
 // Copyright 2020-2021 the Deno authors. All rights reserved. MIT license.
+use super::program_ref;
 use super::{Context, LintRule};
+use crate::Program;
 use crate::ProgramRef;
 use deno_ast::swc::ast::{
   BigInt, Bool, Class, ClassMethod, ComputedPropName, Expr, Ident, Lit,
@@ -43,11 +45,12 @@ impl LintRule for NoDupeClassMembers {
     CODE
   }
 
-  fn lint_program<'view>(
+  fn lint_program_with_ast_view<'view>(
     &self,
     context: &mut Context<'view>,
-    program: ProgramRef<'view>,
+    program: Program<'view>,
   ) {
+    let program = program_ref(program);
     let mut visitor = NoDupeClassMembersVisitor::new(context);
     match program {
       ProgramRef::Module(m) => visitor.visit_module(m),

--- a/src/rules/no_dupe_else_if.rs
+++ b/src/rules/no_dupe_else_if.rs
@@ -1,5 +1,7 @@
 // Copyright 2020-2021 the Deno authors. All rights reserved. MIT license.
+use super::program_ref;
 use super::{Context, LintRule};
+use crate::Program;
 use crate::ProgramRef;
 use deno_ast::swc::ast::{BinExpr, BinaryOp, Expr, IfStmt, ParenExpr, Stmt};
 use deno_ast::swc::utils::drop_span;
@@ -43,11 +45,12 @@ impl LintRule for NoDupeElseIf {
     CODE
   }
 
-  fn lint_program<'view>(
+  fn lint_program_with_ast_view<'view>(
     &self,
     context: &mut Context<'view>,
-    program: ProgramRef<'view>,
+    program: Program<'view>,
   ) {
+    let program = program_ref(program);
     let mut visitor = NoDupeElseIfVisitor::new(context);
     match program {
       ProgramRef::Module(m) => m.visit_all_with(&mut visitor),

--- a/src/rules/no_dupe_keys.rs
+++ b/src/rules/no_dupe_keys.rs
@@ -2,7 +2,7 @@
 use super::{Context, LintRule};
 use crate::handler::{Handler, Traverse};
 use crate::swc_util::StringRepr;
-use crate::{Program, ProgramRef};
+use crate::Program;
 use deno_ast::view::{
   GetterProp, KeyValueProp, MethodProp, ObjectLit, Prop, PropOrSpread,
   SetterProp,
@@ -41,10 +41,6 @@ impl LintRule for NoDupeKeys {
 
   fn code(&self) -> &'static str {
     CODE
-  }
-
-  fn lint_program(&self, _context: &mut Context, _program: ProgramRef) {
-    unreachable!();
   }
 
   fn lint_program_with_ast_view(

--- a/src/rules/no_duplicate_case.rs
+++ b/src/rules/no_duplicate_case.rs
@@ -1,5 +1,7 @@
 // Copyright 2020-2021 the Deno authors. All rights reserved. MIT license.
+use super::program_ref;
 use super::{Context, LintRule};
+use crate::Program;
 use crate::ProgramRef;
 use deno_ast::swc::ast::{Expr, SwitchStmt};
 use deno_ast::swc::utils::drop_span;
@@ -40,11 +42,12 @@ impl LintRule for NoDuplicateCase {
     CODE
   }
 
-  fn lint_program<'view>(
+  fn lint_program_with_ast_view<'view>(
     &self,
     context: &mut Context<'view>,
-    program: ProgramRef<'view>,
+    program: Program<'view>,
   ) {
+    let program = program_ref(program);
     let mut visitor = NoDuplicateCaseVisitor::new(context);
     match program {
       ProgramRef::Module(m) => m.visit_all_with(&mut visitor),

--- a/src/rules/no_empty.rs
+++ b/src/rules/no_empty.rs
@@ -1,7 +1,7 @@
 // Copyright 2020-2021 the Deno authors. All rights reserved. MIT license.
 use super::{Context, LintRule};
 use crate::handler::{Handler, Traverse};
-use crate::{Program, ProgramRef};
+use crate::Program;
 use deno_ast::view::{ArrowExpr, BlockStmt, Constructor, Function, SwitchStmt};
 use deno_ast::{SourceRanged, SourceRangedForSpanned};
 use std::sync::Arc;
@@ -22,10 +22,6 @@ impl LintRule for NoEmpty {
 
   fn code(&self) -> &'static str {
     CODE
-  }
-
-  fn lint_program(&self, _context: &mut Context, _program: ProgramRef) {
-    unreachable!();
   }
 
   fn lint_program_with_ast_view(

--- a/src/rules/no_empty_character_class.rs
+++ b/src/rules/no_empty_character_class.rs
@@ -1,7 +1,7 @@
 // Copyright 2020-2021 the Deno authors. All rights reserved. MIT license.
 use super::{Context, LintRule};
 use crate::handler::{Handler, Traverse};
-use crate::{Program, ProgramRef};
+use crate::Program;
 use deno_ast::view::Regex;
 use deno_ast::SourceRanged;
 use once_cell::sync::Lazy;
@@ -26,10 +26,6 @@ impl LintRule for NoEmptyCharacterClass {
 
   fn code(&self) -> &'static str {
     CODE
-  }
-
-  fn lint_program(&self, _context: &mut Context, _program: ProgramRef) {
-    unreachable!();
   }
 
   fn lint_program_with_ast_view(

--- a/src/rules/no_empty_enum.rs
+++ b/src/rules/no_empty_enum.rs
@@ -1,7 +1,7 @@
 // Copyright 2020-2021 the Deno authors. All rights reserved. MIT license.
 use super::{Context, LintRule};
 use crate::handler::{Handler, Traverse};
-use crate::{Program, ProgramRef};
+use crate::Program;
 use deno_ast::{view as ast_view, SourceRanged};
 use std::sync::Arc;
 
@@ -22,14 +22,6 @@ impl LintRule for NoEmptyEnum {
 
   fn code(&self) -> &'static str {
     CODE
-  }
-
-  fn lint_program<'view>(
-    &self,
-    _context: &mut Context<'view>,
-    _program: ProgramRef<'view>,
-  ) {
-    unreachable!();
   }
 
   fn lint_program_with_ast_view(

--- a/src/rules/no_empty_interface.rs
+++ b/src/rules/no_empty_interface.rs
@@ -1,7 +1,7 @@
 // Copyright 2020-2021 the Deno authors. All rights reserved. MIT license.
 use super::{Context, LintRule};
 use crate::handler::{Handler, Traverse};
-use crate::{Program, ProgramRef};
+use crate::Program;
 use deno_ast::view::TsInterfaceDecl;
 use deno_ast::SourceRanged;
 use derive_more::Display;
@@ -43,10 +43,6 @@ impl LintRule for NoEmptyInterface {
 
   fn code(&self) -> &'static str {
     CODE
-  }
-
-  fn lint_program(&self, _context: &mut Context, _program: ProgramRef) {
-    unreachable!();
   }
 
   fn lint_program_with_ast_view(

--- a/src/rules/no_empty_pattern.rs
+++ b/src/rules/no_empty_pattern.rs
@@ -1,5 +1,7 @@
 // Copyright 2020-2021 the Deno authors. All rights reserved. MIT license.
+use super::program_ref;
 use super::{Context, LintRule};
+use crate::Program;
 use crate::ProgramRef;
 use deno_ast::swc::ast::{ArrayPat, ObjectPat, ObjectPatProp};
 use deno_ast::swc::visit::noop_visit_type;
@@ -28,11 +30,12 @@ impl LintRule for NoEmptyPattern {
     CODE
   }
 
-  fn lint_program<'view>(
+  fn lint_program_with_ast_view<'view>(
     &self,
     context: &mut Context<'view>,
-    program: ProgramRef<'view>,
+    program: Program<'view>,
   ) {
+    let program = program_ref(program);
     let mut visitor = NoEmptyPatternVisitor::new(context);
     match program {
       ProgramRef::Module(m) => visitor.visit_module(m),

--- a/src/rules/no_eval.rs
+++ b/src/rules/no_eval.rs
@@ -2,7 +2,7 @@
 use super::{Context, LintRule};
 use crate::handler::{Handler, Traverse};
 use crate::swc_util::StringRepr;
-use crate::{Program, ProgramRef};
+use crate::Program;
 use deno_ast::view::{CallExpr, Callee, Expr, ParenExpr, VarDeclarator};
 use deno_ast::{SourceRange, SourceRanged};
 use std::sync::Arc;
@@ -21,10 +21,6 @@ impl LintRule for NoEval {
 
   fn code(&self) -> &'static str {
     CODE
-  }
-
-  fn lint_program(&self, _context: &mut Context, _program: ProgramRef) {
-    unreachable!();
   }
 
   fn lint_program_with_ast_view(

--- a/src/rules/no_ex_assign.rs
+++ b/src/rules/no_ex_assign.rs
@@ -1,7 +1,7 @@
 // Copyright 2020-2021 the Deno authors. All rights reserved. MIT license.
 use super::{Context, LintRule};
 use crate::handler::{Handler, Traverse};
-use crate::{Program, ProgramRef};
+use crate::Program;
 use deno_ast::view::{
   ArrayPat, AssignExpr, Expr, Ident, ObjectPat, ObjectPatProp, Pat, PatOrExpr,
 };
@@ -37,10 +37,6 @@ impl LintRule for NoExAssign {
 
   fn code(&self) -> &'static str {
     CODE
-  }
-
-  fn lint_program(&self, _context: &mut Context, _program: ProgramRef) {
-    unreachable!();
   }
 
   fn lint_program_with_ast_view(

--- a/src/rules/no_explicit_any.rs
+++ b/src/rules/no_explicit_any.rs
@@ -1,7 +1,7 @@
 // Copyright 2020-2021 the Deno authors. All rights reserved. MIT license.
 use super::{Context, LintRule};
 use crate::handler::{Handler, Traverse};
-use crate::{Program, ProgramRef};
+use crate::Program;
 use deno_ast::swc::ast::TsKeywordTypeKind::TsAnyKeyword;
 use deno_ast::view::TsKeywordType;
 use deno_ast::SourceRanged;
@@ -25,10 +25,6 @@ impl LintRule for NoExplicitAny {
 
   fn code(&self) -> &'static str {
     CODE
-  }
-
-  fn lint_program(&self, _context: &mut Context, _program: ProgramRef) {
-    unreachable!();
   }
 
   fn lint_program_with_ast_view(

--- a/src/rules/no_external_imports.rs
+++ b/src/rules/no_external_imports.rs
@@ -1,7 +1,7 @@
 // Copyright 2020-2021 the Deno authors. All rights reserved. MIT license.
 use super::{Context, LintRule};
 use crate::handler::{Handler, Traverse};
-use crate::{Program, ProgramRef};
+use crate::Program;
 use deno_ast::view::ImportDecl;
 use deno_ast::{ModuleSpecifier, SourceRanged};
 use derive_more::Display;
@@ -37,10 +37,6 @@ impl LintRule for NoExternalImport {
 
   fn code(&self) -> &'static str {
     CODE
-  }
-
-  fn lint_program(&self, _context: &mut Context, _program: ProgramRef) {
-    unreachable!();
   }
 
   fn lint_program_with_ast_view(

--- a/src/rules/no_extra_boolean_cast.rs
+++ b/src/rules/no_extra_boolean_cast.rs
@@ -1,7 +1,7 @@
 // Copyright 2020-2021 the Deno authors. All rights reserved. MIT license.
 use super::{Context, LintRule};
 use crate::handler::{Handler, Traverse};
-use crate::{Program, ProgramRef};
+use crate::Program;
 use deno_ast::view::{
   CallExpr, Callee, CondExpr, DoWhileStmt, Expr, ExprOrSpread, ForStmt, Ident,
   IfStmt, NewExpr, ParenExpr, UnaryExpr, UnaryOp, WhileStmt,
@@ -44,10 +44,6 @@ impl LintRule for NoExtraBooleanCast {
 
   fn code(&self) -> &'static str {
     CODE
-  }
-
-  fn lint_program(&self, _context: &mut Context, _program: ProgramRef) {
-    unreachable!();
   }
 
   fn lint_program_with_ast_view(

--- a/src/rules/no_extra_non_null_assertion.rs
+++ b/src/rules/no_extra_non_null_assertion.rs
@@ -4,7 +4,7 @@ use super::LintRule;
 use crate::handler::Handler;
 use crate::handler::Traverse;
 use crate::Program;
-use crate::ProgramRef;
+
 use deno_ast::view::Expr;
 use deno_ast::view::OptChainBase;
 use deno_ast::view::OptChainExpr;
@@ -42,10 +42,6 @@ impl LintRule for NoExtraNonNullAssertion {
 
   fn code(&self) -> &'static str {
     CODE
-  }
-
-  fn lint_program(&self, _context: &mut Context, _program: ProgramRef) {
-    unreachable!();
   }
 
   fn lint_program_with_ast_view(

--- a/src/rules/no_extra_semi.rs
+++ b/src/rules/no_extra_semi.rs
@@ -1,5 +1,7 @@
 // Copyright 2020-2021 the Deno authors. All rights reserved. MIT license.
+use super::program_ref;
 use super::{Context, LintRule};
+use crate::Program;
 use crate::ProgramRef;
 use deno_ast::swc::ast::{
   DoWhileStmt, EmptyStmt, ForInStmt, ForOfStmt, ForStmt, IfStmt, LabeledStmt,
@@ -40,11 +42,12 @@ impl LintRule for NoExtraSemi {
     CODE
   }
 
-  fn lint_program<'view>(
+  fn lint_program_with_ast_view<'view>(
     &self,
     context: &mut Context<'view>,
-    program: ProgramRef<'view>,
+    program: Program<'view>,
   ) {
+    let program = program_ref(program);
     let mut visitor = NoExtraSemiVisitor::new(context);
     match program {
       ProgramRef::Module(m) => m.visit_with(&mut visitor),

--- a/src/rules/no_fallthrough.rs
+++ b/src/rules/no_fallthrough.rs
@@ -1,5 +1,7 @@
 // Copyright 2020-2021 the Deno authors. All rights reserved. MIT license.
+use super::program_ref;
 use super::{Context, LintRule};
+use crate::Program;
 use crate::ProgramRef;
 use deno_ast::swc::common::comments::Comment;
 use deno_ast::swc::{
@@ -42,11 +44,12 @@ impl LintRule for NoFallthrough {
     CODE
   }
 
-  fn lint_program<'view>(
+  fn lint_program_with_ast_view<'view>(
     &self,
     context: &mut Context<'view>,
-    program: ProgramRef<'view>,
+    program: Program<'view>,
   ) {
+    let program = program_ref(program);
     let mut visitor = NoFallthroughVisitor { context };
     match program {
       ProgramRef::Module(m) => visitor.visit_module(m),

--- a/src/rules/no_func_assign.rs
+++ b/src/rules/no_func_assign.rs
@@ -1,6 +1,8 @@
 // Copyright 2020-2021 the Deno authors. All rights reserved. MIT license.
+use super::program_ref;
 use super::{Context, LintRule};
 use crate::swc_util::find_lhs_ids;
+use crate::Program;
 use crate::ProgramRef;
 use deno_ast::swc::ast::AssignExpr;
 use deno_ast::swc::visit::noop_visit_type;
@@ -42,11 +44,12 @@ impl LintRule for NoFuncAssign {
     CODE
   }
 
-  fn lint_program<'view>(
+  fn lint_program_with_ast_view<'view>(
     &self,
     context: &mut Context<'view>,
-    program: ProgramRef<'view>,
+    program: Program<'view>,
   ) {
+    let program = program_ref(program);
     let mut visitor = NoFuncAssignVisitor::new(context);
     match program {
       ProgramRef::Module(m) => m.visit_all_with(&mut visitor),

--- a/src/rules/no_global_assign.rs
+++ b/src/rules/no_global_assign.rs
@@ -1,5 +1,7 @@
 // Copyright 2020-2021 the Deno authors. All rights reserved. MIT license.
+use super::program_ref;
 use super::{Context, LintRule};
+use crate::Program;
 use crate::ProgramRef;
 use crate::{globals::GLOBALS, swc_util::find_lhs_ids};
 use deno_ast::swc::ast::Id;
@@ -42,11 +44,12 @@ impl LintRule for NoGlobalAssign {
     CODE
   }
 
-  fn lint_program<'view>(
+  fn lint_program_with_ast_view<'view>(
     &self,
     context: &mut Context<'view>,
-    program: ProgramRef<'view>,
+    program: Program<'view>,
   ) {
+    let program = program_ref(program);
     let mut visitor = NoGlobalAssignVisitor::new(context);
     match program {
       ProgramRef::Module(m) => m.visit_with(&mut visitor),

--- a/src/rules/no_implicit_declare_namespace_export.rs
+++ b/src/rules/no_implicit_declare_namespace_export.rs
@@ -1,7 +1,7 @@
 // Copyright 2020-2021 the Deno authors. All rights reserved. MIT license.
 use super::{Context, LintRule};
 use crate::handler::{Handler, Traverse};
-use crate::{Program, ProgramRef};
+use crate::Program;
 use deno_ast::{view as ast_view, SourceRanged};
 use std::sync::Arc;
 
@@ -25,10 +25,6 @@ impl LintRule for NoImplicitDeclareNamespaceExport {
 
   fn code(&self) -> &'static str {
     CODE
-  }
-
-  fn lint_program(&self, _context: &mut Context, _program: ProgramRef<'_>) {
-    unreachable!();
   }
 
   fn lint_program_with_ast_view(

--- a/src/rules/no_import_assign.rs
+++ b/src/rules/no_import_assign.rs
@@ -1,5 +1,7 @@
 // Copyright 2020-2021 the Deno authors. All rights reserved. MIT license.
+use super::program_ref;
 use super::{Context, LintRule};
+use crate::Program;
 use crate::ProgramRef;
 use deno_ast::BindingKind;
 use deno_ast::{
@@ -31,11 +33,12 @@ impl LintRule for NoImportAssign {
     CODE
   }
 
-  fn lint_program<'view>(
+  fn lint_program_with_ast_view<'view>(
     &self,
     context: &mut Context<'view>,
-    program: ProgramRef<'view>,
+    program: Program<'view>,
   ) {
+    let program = program_ref(program);
     let mut visitor = NoImportAssignVisitor::new(context);
     match program {
       ProgramRef::Module(m) => m.visit_with(&mut visitor),

--- a/src/rules/no_inferrable_types.rs
+++ b/src/rules/no_inferrable_types.rs
@@ -1,5 +1,7 @@
 // Copyright 2020-2021 the Deno authors. All rights reserved. MIT license.
+use super::program_ref;
 use super::{Context, LintRule};
+use crate::Program;
 use crate::ProgramRef;
 use deno_ast::swc::ast::{
   ArrowExpr, CallExpr, ClassProp, Expr, Function, Ident, Lit, NewExpr, OptCall,
@@ -43,11 +45,12 @@ impl LintRule for NoInferrableTypes {
     CODE
   }
 
-  fn lint_program<'view>(
+  fn lint_program_with_ast_view<'view>(
     &self,
     context: &mut Context<'view>,
-    program: ProgramRef<'view>,
+    program: Program<'view>,
   ) {
+    let program = program_ref(program);
     let mut visitor = NoInferrableTypesVisitor::new(context);
     match program {
       ProgramRef::Module(m) => m.visit_all_with(&mut visitor),

--- a/src/rules/no_inner_declarations.rs
+++ b/src/rules/no_inner_declarations.rs
@@ -1,5 +1,7 @@
 // Copyright 2020-2021 the Deno authors. All rights reserved. MIT license.
+use super::program_ref;
 use super::{Context, LintRule};
+use crate::Program;
 use crate::ProgramRef;
 use deno_ast::swc::ast::{
   ArrowExpr, BlockStmtOrExpr, Constructor, Decl, DefaultDecl, FnDecl, Function,
@@ -44,11 +46,12 @@ impl LintRule for NoInnerDeclarations {
     CODE
   }
 
-  fn lint_program<'view>(
+  fn lint_program_with_ast_view<'view>(
     &self,
     context: &mut Context<'view>,
-    program: ProgramRef<'view>,
+    program: Program<'view>,
   ) {
+    let program = program_ref(program);
     let mut valid_visitor = ValidDeclsVisitor::new();
     match program {
       ProgramRef::Module(m) => m.visit_all_with(&mut valid_visitor),

--- a/src/rules/no_invalid_regexp.rs
+++ b/src/rules/no_invalid_regexp.rs
@@ -1,6 +1,8 @@
 // Copyright 2020-2021 the Deno authors. All rights reserved. MIT license.
+use super::program_ref;
 use super::{Context, LintRule};
 use crate::js_regex::*;
+use crate::Program;
 use crate::ProgramRef;
 use deno_ast::swc::ast::Expr;
 use deno_ast::swc::ast::ExprOrSpread;
@@ -30,11 +32,12 @@ impl LintRule for NoInvalidRegexp {
     CODE
   }
 
-  fn lint_program<'view>(
+  fn lint_program_with_ast_view<'view>(
     &self,
     context: &mut Context<'view>,
-    program: ProgramRef<'view>,
+    program: Program<'view>,
   ) {
+    let program = program_ref(program);
     let mut visitor = NoInvalidRegexpVisitor::new(context);
     match program {
       ProgramRef::Module(m) => visitor.visit_module(m),

--- a/src/rules/no_invalid_triple_slash_reference.rs
+++ b/src/rules/no_invalid_triple_slash_reference.rs
@@ -1,6 +1,6 @@
 // Copyright 2020-2021 the Deno authors. All rights reserved. MIT license.
 use super::{Context, LintRule};
-use crate::{Program, ProgramRef};
+use crate::Program;
 use deno_ast::swc::common::comments::{Comment, CommentKind};
 use deno_ast::MediaType;
 use deno_ast::{SourceRange, SourceRangedForSpanned};
@@ -24,10 +24,6 @@ impl LintRule for NoInvalidTripleSlashReference {
 
   fn code(&self) -> &'static str {
     CODE
-  }
-
-  fn lint_program(&self, _context: &mut Context, _program: ProgramRef<'_>) {
-    unreachable!();
   }
 
   fn lint_program_with_ast_view(

--- a/src/rules/no_irregular_whitespace.rs
+++ b/src/rules/no_irregular_whitespace.rs
@@ -1,6 +1,6 @@
 // Copyright 2020-2021 the Deno authors. All rights reserved. MIT license.
 use super::{Context, LintRule};
-use crate::{Program, ProgramRef};
+use crate::Program;
 use deno_ast::{RootNode, SourceRangedForSpanned};
 use deno_ast::{SourceRange, SourceRanged};
 use derive_more::Display;
@@ -50,10 +50,6 @@ impl LintRule for NoIrregularWhitespace {
 
   fn code(&self) -> &'static str {
     CODE
-  }
-
-  fn lint_program(&self, _context: &mut Context, _program: ProgramRef<'_>) {
-    unreachable!();
   }
 
   fn lint_program_with_ast_view(

--- a/src/rules/no_misused_new.rs
+++ b/src/rules/no_misused_new.rs
@@ -1,7 +1,7 @@
 // Copyright 2020-2021 the Deno authors. All rights reserved. MIT license.
 use super::{Context, LintRule};
 use crate::handler::{Handler, Traverse};
-use crate::{Program, ProgramRef};
+use crate::Program;
 use deno_ast::view::{
   ClassDecl, ClassMember, Expr, Ident, PropName, TsEntityName, TsInterfaceDecl,
   TsType, TsTypeAliasDecl, TsTypeAnn,
@@ -39,10 +39,6 @@ enum NoMisusedNewHint {
 impl LintRule for NoMisusedNew {
   fn new() -> Arc<Self> {
     Arc::new(NoMisusedNew)
-  }
-
-  fn lint_program(&self, _context: &mut Context, _program: ProgramRef) {
-    unreachable!();
   }
 
   fn lint_program_with_ast_view(

--- a/src/rules/no_namespace.rs
+++ b/src/rules/no_namespace.rs
@@ -1,7 +1,7 @@
 // Copyright 2020-2021 the Deno authors. All rights reserved. MIT license.
 use super::{Context, LintRule};
 use crate::handler::{Handler, Traverse};
-use crate::{Program, ProgramRef};
+use crate::Program;
 use deno_ast::view::NodeTrait;
 use deno_ast::{view as ast_view, MediaType, SourceRanged};
 use std::sync::Arc;
@@ -26,10 +26,6 @@ impl LintRule for NoNamespace {
 
   fn code(&self) -> &'static str {
     CODE
-  }
-
-  fn lint_program(&self, _context: &mut Context, _program: ProgramRef<'_>) {
-    unreachable!();
   }
 
   fn lint_program_with_ast_view(

--- a/src/rules/no_new_symbol.rs
+++ b/src/rules/no_new_symbol.rs
@@ -1,7 +1,7 @@
 // Copyright 2020-2021 the Deno authors. All rights reserved. MIT license.
 use super::{Context, LintRule};
 use crate::handler::{Handler, Traverse};
-use crate::{Program, ProgramRef};
+use crate::Program;
 use deno_ast::view::{Expr, NewExpr};
 use deno_ast::SourceRanged;
 use if_chain::if_chain;
@@ -24,10 +24,6 @@ impl LintRule for NoNewSymbol {
 
   fn code(&self) -> &'static str {
     CODE
-  }
-
-  fn lint_program(&self, _context: &mut Context, _program: ProgramRef) {
-    unreachable!();
   }
 
   fn lint_program_with_ast_view(

--- a/src/rules/no_non_null_asserted_optional_chain.rs
+++ b/src/rules/no_non_null_asserted_optional_chain.rs
@@ -1,7 +1,7 @@
 // Copyright 2020-2021 the Deno authors. All rights reserved. MIT license.
 use super::{Context, LintRule};
 use crate::handler::{Handler, Traverse};
-use crate::{Program, ProgramRef};
+use crate::Program;
 use deno_ast::view::{Callee, Expr, TsNonNullExpr};
 use deno_ast::{SourceRange, SourceRanged};
 use derive_more::Display;
@@ -27,10 +27,6 @@ impl LintRule for NoNonNullAssertedOptionalChain {
 
   fn code(&self) -> &'static str {
     CODE
-  }
-
-  fn lint_program(&self, _context: &mut Context, _program: ProgramRef) {
-    unreachable!();
   }
 
   fn lint_program_with_ast_view(

--- a/src/rules/no_non_null_assertion.rs
+++ b/src/rules/no_non_null_assertion.rs
@@ -1,7 +1,7 @@
 // Copyright 2020-2021 the Deno authors. All rights reserved. MIT license.
 use super::{Context, LintRule};
 use crate::handler::{Handler, Traverse};
-use crate::{Program, ProgramRef};
+use crate::Program;
 use deno_ast::view::TsNonNullExpr;
 use deno_ast::SourceRanged;
 use derive_more::Display;
@@ -25,10 +25,6 @@ impl LintRule for NoNonNullAssertion {
 
   fn code(&self) -> &'static str {
     CODE
-  }
-
-  fn lint_program(&self, _context: &mut Context, _program: ProgramRef) {
-    unreachable!();
   }
 
   fn lint_program_with_ast_view(

--- a/src/rules/no_obj_calls.rs
+++ b/src/rules/no_obj_calls.rs
@@ -1,7 +1,7 @@
 // Copyright 2020-2021 the Deno authors. All rights reserved. MIT license.
 use super::{Context, LintRule};
 use crate::handler::{Handler, Traverse};
-use crate::{Program, ProgramRef};
+use crate::Program;
 use deno_ast::view::{CallExpr, Callee, Expr, Ident, NewExpr};
 use deno_ast::{SourceRange, SourceRanged};
 use std::sync::Arc;
@@ -26,10 +26,6 @@ impl LintRule for NoObjCalls {
 
   fn code(&self) -> &'static str {
     CODE
-  }
-
-  fn lint_program(&self, _context: &mut Context, _program: ProgramRef) {
-    unreachable!();
   }
 
   fn lint_program_with_ast_view(

--- a/src/rules/no_octal.rs
+++ b/src/rules/no_octal.rs
@@ -1,7 +1,7 @@
 // Copyright 2020-2021 the Deno authors. All rights reserved. MIT license.
 use super::{Context, LintRule};
 use crate::handler::{Handler, Traverse};
-use crate::{Program, ProgramRef};
+use crate::Program;
 use deno_ast::view::Number;
 use deno_ast::SourceRanged;
 use once_cell::sync::Lazy;
@@ -26,10 +26,6 @@ impl LintRule for NoOctal {
 
   fn code(&self) -> &'static str {
     CODE
-  }
-
-  fn lint_program(&self, _context: &mut Context, _program: ProgramRef) {
-    unreachable!();
   }
 
   fn lint_program_with_ast_view(

--- a/src/rules/no_prototype_builtins.rs
+++ b/src/rules/no_prototype_builtins.rs
@@ -1,7 +1,7 @@
 // Copyright 2020-2021 the Deno authors. All rights reserved. MIT license.
 use super::{Context, LintRule};
 use crate::handler::{Handler, Traverse};
-use crate::{Program, ProgramRef};
+use crate::Program;
 use deno_ast::view::{CallExpr, Callee, Expr, MemberProp};
 use deno_ast::SourceRanged;
 use std::sync::Arc;
@@ -32,10 +32,6 @@ impl LintRule for NoPrototypeBuiltins {
 
   fn code(&self) -> &'static str {
     CODE
-  }
-
-  fn lint_program(&self, _context: &mut Context, _program: ProgramRef) {
-    unreachable!();
   }
 
   fn lint_program_with_ast_view(

--- a/src/rules/no_redeclare.rs
+++ b/src/rules/no_redeclare.rs
@@ -1,5 +1,7 @@
 // Copyright 2020-2021 the Deno authors. All rights reserved. MIT license.
+use super::program_ref;
 use super::{Context, LintRule};
+use crate::Program;
 use crate::ProgramRef;
 use deno_ast::swc::ast::Id;
 use deno_ast::swc::visit::noop_visit_type;
@@ -30,11 +32,12 @@ impl LintRule for NoRedeclare {
     CODE
   }
 
-  fn lint_program<'view>(
+  fn lint_program_with_ast_view<'view>(
     &self,
     context: &mut Context<'view>,
-    program: ProgramRef<'view>,
+    program: Program<'view>,
   ) {
+    let program = program_ref(program);
     let mut visitor = NoRedeclareVisitor {
       context,
       bindings: Default::default(),

--- a/src/rules/no_regex_spaces.rs
+++ b/src/rules/no_regex_spaces.rs
@@ -2,7 +2,7 @@
 use super::{Context, LintRule};
 use crate::handler::{Handler, Traverse};
 use crate::swc_util::extract_regex;
-use crate::{Program, ProgramRef};
+use crate::Program;
 use deno_ast::view::{CallExpr, Callee, Expr, NewExpr, Regex};
 use deno_ast::{SourceRange, SourceRanged};
 use once_cell::sync::Lazy;
@@ -26,10 +26,6 @@ impl LintRule for NoRegexSpaces {
 
   fn code(&self) -> &'static str {
     CODE
-  }
-
-  fn lint_program(&self, _context: &mut Context, _program: ProgramRef) {
-    unreachable!();
   }
 
   fn lint_program_with_ast_view(

--- a/src/rules/no_self_assign.rs
+++ b/src/rules/no_self_assign.rs
@@ -1,6 +1,8 @@
 // Copyright 2020-2021 the Deno authors. All rights reserved. MIT license.
+use super::program_ref;
 use super::{Context, LintRule};
 use crate::swc_util::StringRepr;
+use crate::Program;
 use crate::ProgramRef;
 use std::sync::Arc;
 
@@ -54,11 +56,12 @@ impl LintRule for NoSelfAssign {
     CODE
   }
 
-  fn lint_program<'view>(
+  fn lint_program_with_ast_view<'view>(
     &self,
     context: &mut Context<'view>,
-    program: ProgramRef<'view>,
+    program: Program<'view>,
   ) {
+    let program = program_ref(program);
     let mut visitor = NoSelfAssignVisitor::new(context);
     match program {
       ProgramRef::Module(m) => m.visit_all_with(&mut visitor),

--- a/src/rules/no_setter_return.rs
+++ b/src/rules/no_setter_return.rs
@@ -1,7 +1,7 @@
 // Copyright 2020-2021 the Deno authors. All rights reserved. MIT license.
 use super::{Context, LintRule};
 use crate::handler::{Handler, Traverse};
-use crate::{Program, ProgramRef};
+use crate::Program;
 use deno_ast::view::NodeTrait;
 use deno_ast::{view as ast_view, SourceRanged};
 use std::sync::Arc;
@@ -23,10 +23,6 @@ impl LintRule for NoSetterReturn {
 
   fn code(&self) -> &'static str {
     CODE
-  }
-
-  fn lint_program(&self, _context: &mut Context, _program: ProgramRef<'_>) {
-    unreachable!()
   }
 
   fn lint_program_with_ast_view(

--- a/src/rules/no_shadow_restricted_names.rs
+++ b/src/rules/no_shadow_restricted_names.rs
@@ -1,7 +1,7 @@
 // Copyright 2020-2021 the Deno authors. All rights reserved. MIT license.
 use super::{Context, LintRule};
 use crate::handler::{Handler, Traverse};
-use crate::{Program, ProgramRef};
+use crate::Program;
 use deno_ast::view::{
   ArrowExpr, AssignExpr, CatchClause, Expr, FnDecl, FnExpr, Ident,
   ObjectPatProp, Pat, PatOrExpr, VarDecl,
@@ -32,10 +32,6 @@ impl LintRule for NoShadowRestrictedNames {
 
   fn code(&self) -> &'static str {
     CODE
-  }
-
-  fn lint_program(&self, _context: &mut Context, _program: ProgramRef) {
-    unreachable!();
   }
 
   fn lint_program_with_ast_view(

--- a/src/rules/no_sparse_arrays.rs
+++ b/src/rules/no_sparse_arrays.rs
@@ -1,7 +1,7 @@
 // Copyright 2020-2021 the Deno authors. All rights reserved. MIT license.
 use super::{Context, LintRule};
 use crate::handler::{Handler, Traverse};
-use crate::{Program, ProgramRef};
+use crate::Program;
 use deno_ast::view::ArrayLit;
 use deno_ast::SourceRanged;
 use derive_more::Display;
@@ -25,10 +25,6 @@ impl LintRule for NoSparseArrays {
 
   fn code(&self) -> &'static str {
     CODE
-  }
-
-  fn lint_program(&self, _context: &mut Context, _program: ProgramRef) {
-    unreachable!();
   }
 
   fn lint_program_with_ast_view(

--- a/src/rules/no_this_alias.rs
+++ b/src/rules/no_this_alias.rs
@@ -1,7 +1,7 @@
 // Copyright 2020-2021 the Deno authors. All rights reserved. MIT license.
 use super::{Context, LintRule};
 use crate::handler::{Handler, Traverse};
-use crate::{Program, ProgramRef};
+use crate::Program;
 use deno_ast::view::{Expr, Pat, VarDecl};
 use deno_ast::SourceRanged;
 use if_chain::if_chain;
@@ -24,10 +24,6 @@ impl LintRule for NoThisAlias {
 
   fn code(&self) -> &'static str {
     CODE
-  }
-
-  fn lint_program(&self, _context: &mut Context, _program: ProgramRef) {
-    unreachable!();
   }
 
   fn lint_program_with_ast_view(

--- a/src/rules/no_this_before_super.rs
+++ b/src/rules/no_this_before_super.rs
@@ -1,7 +1,7 @@
 // Copyright 2020-2021 the Deno authors. All rights reserved. MIT license.
 use super::{Context, LintRule};
 use crate::handler::{Handler, Traverse};
-use crate::{Program, ProgramRef};
+use crate::Program;
 use deno_ast::view::NodeTrait;
 use deno_ast::{view as ast_view, SourceRange, SourceRanged};
 use std::sync::Arc;
@@ -24,10 +24,6 @@ impl LintRule for NoThisBeforeSuper {
 
   fn code(&self) -> &'static str {
     CODE
-  }
-
-  fn lint_program(&self, _context: &mut Context, _program: ProgramRef<'_>) {
-    unreachable!();
   }
 
   fn lint_program_with_ast_view(

--- a/src/rules/no_throw_literal.rs
+++ b/src/rules/no_throw_literal.rs
@@ -1,7 +1,7 @@
 // Copyright 2020-2021 the Deno authors. All rights reserved. MIT license.
 use super::{Context, LintRule};
 use crate::handler::{Handler, Traverse};
-use crate::{Program, ProgramRef};
+use crate::Program;
 use deno_ast::view::{Expr, ThrowStmt};
 use deno_ast::SourceRanged;
 use derive_more::Display;
@@ -28,10 +28,6 @@ impl LintRule for NoThrowLiteral {
 
   fn code(&self) -> &'static str {
     CODE
-  }
-
-  fn lint_program(&self, _context: &mut Context, _program: ProgramRef) {
-    unreachable!();
   }
 
   fn lint_program_with_ast_view(

--- a/src/rules/no_top_level_await.rs
+++ b/src/rules/no_top_level_await.rs
@@ -1,7 +1,7 @@
 // Copyright 2020-2022 the Deno authors. All rights reserved. MIT license.
 use super::{Context, LintRule};
 use crate::handler::{Handler, Traverse};
-use crate::{Program, ProgramRef};
+use crate::Program;
 use deno_ast::view::NodeTrait;
 use deno_ast::view::{self as ast_view};
 use deno_ast::SourceRanged;
@@ -21,10 +21,6 @@ impl LintRule for NoTopLevelAwait {
 
   fn code(&self) -> &'static str {
     CODE
-  }
-
-  fn lint_program(&self, _context: &mut Context, _program: ProgramRef<'_>) {
-    unreachable!();
   }
 
   fn lint_program_with_ast_view(

--- a/src/rules/no_undef.rs
+++ b/src/rules/no_undef.rs
@@ -1,6 +1,8 @@
 // Copyright 2020-2021 the Deno authors. All rights reserved. MIT license.
+use super::program_ref;
 use super::{Context, LintRule};
 use crate::globals::GLOBALS;
+use crate::Program;
 use crate::ProgramRef;
 use deno_ast::swc::{
   ast::*,
@@ -21,11 +23,12 @@ impl LintRule for NoUndef {
     "no-undef"
   }
 
-  fn lint_program<'view>(
+  fn lint_program_with_ast_view<'view>(
     &self,
     context: &mut Context<'view>,
-    program: ProgramRef<'view>,
+    program: Program<'view>,
   ) {
+    let program = program_ref(program);
     let mut visitor = NoUndefVisitor::new(context);
     match program {
       ProgramRef::Module(m) => m.visit_with(&mut visitor),

--- a/src/rules/no_unreachable.rs
+++ b/src/rules/no_unreachable.rs
@@ -1,6 +1,8 @@
 // Copyright 2020-2021 the Deno authors. All rights reserved. MIT license.
+use super::program_ref;
 use super::Context;
 use super::LintRule;
+use crate::Program;
 use crate::ProgramRef;
 use deno_ast::swc::ast::Decl;
 use deno_ast::swc::ast::Stmt;
@@ -29,11 +31,12 @@ impl LintRule for NoUnreachable {
     CODE
   }
 
-  fn lint_program<'view>(
+  fn lint_program_with_ast_view<'view>(
     &self,
     context: &mut Context<'view>,
-    program: ProgramRef<'view>,
+    program: Program<'view>,
   ) {
+    let program = program_ref(program);
     let mut visitor = NoUnreachableVisitor::new(context);
     match program {
       ProgramRef::Module(m) => visitor.visit_module(m),

--- a/src/rules/no_unsafe_finally.rs
+++ b/src/rules/no_unsafe_finally.rs
@@ -1,7 +1,7 @@
 // Copyright 2020-2021 the Deno authors. All rights reserved. MIT license.
 use super::{Context, LintRule};
 use crate::handler::{Handler, Traverse};
-use crate::{Program, ProgramRef};
+use crate::Program;
 use deno_ast::view::NodeTrait;
 use deno_ast::{view as ast_view, SourceRange, SourceRanged};
 use derive_more::Display;
@@ -48,10 +48,6 @@ impl LintRule for NoUnsafeFinally {
 
   fn code(&self) -> &'static str {
     CODE
-  }
-
-  fn lint_program(&self, _context: &mut Context, _program: ProgramRef<'_>) {
-    unreachable!();
   }
 
   fn lint_program_with_ast_view(

--- a/src/rules/no_unsafe_negation.rs
+++ b/src/rules/no_unsafe_negation.rs
@@ -1,7 +1,7 @@
 // Copyright 2020-2021 the Deno authors. All rights reserved. MIT license.
 use super::{Context, LintRule};
 use crate::handler::{Handler, Traverse};
-use crate::{Program, ProgramRef};
+use crate::Program;
 use deno_ast::{view as ast_view, SourceRanged};
 use derive_more::Display;
 use if_chain::if_chain;
@@ -31,10 +31,6 @@ impl LintRule for NoUnsafeNegation {
 
   fn code(&self) -> &'static str {
     CODE
-  }
-
-  fn lint_program(&self, _context: &mut Context, _program: ProgramRef<'_>) {
-    unreachable!();
   }
 
   fn lint_program_with_ast_view(

--- a/src/rules/no_unused_labels.rs
+++ b/src/rules/no_unused_labels.rs
@@ -1,7 +1,7 @@
 // Copyright 2020-2021 the Deno authors. All rights reserved. MIT license.
 use super::{Context, LintRule};
 use crate::handler::{Handler, Traverse};
-use crate::{Program, ProgramRef};
+use crate::Program;
 use deno_ast::{view as ast_view, SourceRanged};
 use derive_more::Display;
 use if_chain::if_chain;
@@ -29,10 +29,6 @@ impl LintRule for NoUnusedLabels {
 
   fn code(&self) -> &'static str {
     CODE
-  }
-
-  fn lint_program(&self, _context: &mut Context, _program: ProgramRef<'_>) {
-    unreachable!();
   }
 
   fn lint_program_with_ast_view(

--- a/src/rules/no_unused_vars.rs
+++ b/src/rules/no_unused_vars.rs
@@ -1,5 +1,7 @@
 // Copyright 2020-2021 the Deno authors. All rights reserved. MIT license.
+use super::program_ref;
 use super::{Context, LintRule};
+use crate::Program;
 use crate::ProgramRef;
 use deno_ast::swc::ast::Id;
 use deno_ast::swc::ast::{
@@ -62,11 +64,12 @@ impl LintRule for NoUnusedVars {
     CODE
   }
 
-  fn lint_program<'view>(
+  fn lint_program_with_ast_view<'view>(
     &self,
     context: &mut Context<'view>,
-    program: ProgramRef<'view>,
+    program: Program<'view>,
   ) {
+    let program = program_ref(program);
     // Skip linting this file to avoid emitting false positives about `jsxFactory` and `jsxFragmentFactory`
     // if it's a JSX or TSX file.
     // See https://github.com/denoland/deno_lint/pull/664#discussion_r614692736

--- a/src/rules/no_var.rs
+++ b/src/rules/no_var.rs
@@ -1,7 +1,7 @@
 // Copyright 2020-2021 the Deno authors. All rights reserved. MIT license.
 use super::{Context, LintRule};
 use crate::handler::{Handler, Traverse};
-use crate::{Program, ProgramRef};
+use crate::Program;
 use deno_ast::view::{VarDecl, VarDeclKind};
 use deno_ast::SourceRanged;
 use std::sync::Arc;
@@ -22,10 +22,6 @@ impl LintRule for NoVar {
 
   fn code(&self) -> &'static str {
     CODE
-  }
-
-  fn lint_program(&self, _context: &mut Context, _program: ProgramRef) {
-    unreachable!();
   }
 
   fn lint_program_with_ast_view(

--- a/src/rules/no_window_prefix.rs
+++ b/src/rules/no_window_prefix.rs
@@ -4,7 +4,7 @@ use super::LintRule;
 use crate::handler::Handler;
 use crate::handler::Traverse;
 use crate::Program;
-use crate::ProgramRef;
+
 use deno_ast::view as ast_view;
 use deno_ast::SourceRanged;
 use if_chain::if_chain;
@@ -31,10 +31,6 @@ impl LintRule for NoWindowPrefix {
 
   fn code(&self) -> &'static str {
     CODE
-  }
-
-  fn lint_program(&self, _context: &mut Context, _program: ProgramRef<'_>) {
-    unreachable!();
   }
 
   fn lint_program_with_ast_view(

--- a/src/rules/no_with.rs
+++ b/src/rules/no_with.rs
@@ -1,7 +1,7 @@
 // Copyright 2020-2021 the Deno authors. All rights reserved. MIT license.
 use super::{Context, LintRule};
 use crate::handler::{Handler, Traverse};
-use crate::{Program, ProgramRef};
+use crate::Program;
 use deno_ast::view as ast_view;
 use deno_ast::SourceRanged;
 use std::sync::Arc;
@@ -23,10 +23,6 @@ impl LintRule for NoWith {
 
   fn code(&self) -> &'static str {
     CODE
-  }
-
-  fn lint_program(&self, _context: &mut Context, _program: ProgramRef<'_>) {
-    unreachable!();
   }
 
   fn lint_program_with_ast_view(

--- a/src/rules/prefer_as_const.rs
+++ b/src/rules/prefer_as_const.rs
@@ -1,7 +1,7 @@
 // Copyright 2020-2021 the Deno authors. All rights reserved. MIT license.
 use super::{Context, LintRule};
 use crate::handler::{Handler, Traverse};
-use crate::{Program, ProgramRef};
+use crate::Program;
 use deno_ast::view::{
   ArrayPat, BindingIdent, Expr, Lit, ObjectPat, Pat, TsAsExpr, TsLit, TsType,
   TsTypeAnn, TsTypeAssertion, VarDecl,
@@ -40,10 +40,6 @@ impl LintRule for PreferAsConst {
 
   fn code(&self) -> &'static str {
     CODE
-  }
-
-  fn lint_program(&self, _context: &mut Context, _program: ProgramRef) {
-    unreachable!();
   }
 
   fn lint_program_with_ast_view(

--- a/src/rules/prefer_ascii.rs
+++ b/src/rules/prefer_ascii.rs
@@ -1,6 +1,6 @@
 // Copyright 2020-2021 the Deno authors. All rights reserved. MIT license.
 use super::{Context, LintRule};
-use crate::{Program, ProgramRef};
+use crate::Program;
 use deno_ast::SourceRange;
 use std::sync::Arc;
 
@@ -24,10 +24,6 @@ impl LintRule for PreferAscii {
 
   fn code(&self) -> &'static str {
     CODE
-  }
-
-  fn lint_program(&self, _context: &mut Context, _program: ProgramRef<'_>) {
-    unreachable!();
   }
 
   fn lint_program_with_ast_view(

--- a/src/rules/prefer_const.rs
+++ b/src/rules/prefer_const.rs
@@ -1,5 +1,7 @@
 // Copyright 2020-2021 the Deno authors. All rights reserved. MIT license.
+use super::program_ref;
 use super::{Context, LintRule};
+use crate::Program;
 use crate::ProgramRef;
 use deno_ast::swc::ast::{
   ArrowExpr, AssignExpr, BlockStmt, BlockStmtOrExpr, CatchClause, Class,
@@ -52,11 +54,12 @@ impl LintRule for PreferConst {
     CODE
   }
 
-  fn lint_program<'view>(
+  fn lint_program_with_ast_view<'view>(
     &self,
     context: &mut Context<'view>,
-    program: ProgramRef<'view>,
+    program: Program<'view>,
   ) {
+    let program = program_ref(program);
     let mut collector = VariableCollector::new();
     match program {
       ProgramRef::Module(m) => collector.visit_module(m),

--- a/src/rules/prefer_namespace_keyword.rs
+++ b/src/rules/prefer_namespace_keyword.rs
@@ -1,7 +1,7 @@
 // Copyright 2020-2021 the Deno authors. All rights reserved. MIT license.
 use super::{Context, LintRule};
 use crate::handler::{Handler, Traverse};
-use crate::{Program, ProgramRef};
+use crate::Program;
 use deno_ast::view::{TsModuleDecl, TsModuleName};
 use deno_ast::SourceRanged;
 use once_cell::sync::Lazy;
@@ -24,10 +24,6 @@ impl LintRule for PreferNamespaceKeyword {
 
   fn code(&self) -> &'static str {
     CODE
-  }
-
-  fn lint_program(&self, _context: &mut Context, _program: ProgramRef) {
-    unreachable!();
   }
 
   fn lint_program_with_ast_view(

--- a/src/rules/prefer_primordials.rs
+++ b/src/rules/prefer_primordials.rs
@@ -1,7 +1,7 @@
 // Copyright 2020-2021 the Deno authors. All rights reserved. MIT license.
 use super::{Context, LintRule};
 use crate::handler::{Handler, Traverse};
-use crate::{Program, ProgramRef};
+use crate::Program;
 use deno_ast::view::NodeTrait;
 use deno_ast::Scope;
 use deno_ast::{view as ast_view, SourceRanged};
@@ -55,10 +55,6 @@ impl LintRule for PreferPrimordials {
 
   fn code(&self) -> &'static str {
     CODE
-  }
-
-  fn lint_program(&self, _context: &mut Context, _program: ProgramRef<'_>) {
-    unreachable!();
   }
 
   fn lint_program_with_ast_view(

--- a/src/rules/require_await.rs
+++ b/src/rules/require_await.rs
@@ -2,7 +2,6 @@
 use super::{Context, LintRule};
 use crate::handler::{Handler, Traverse};
 use crate::swc_util::StringRepr;
-use crate::ProgramRef;
 
 use deno_ast::view::{NodeTrait, Program};
 use deno_ast::SourceRange;
@@ -49,10 +48,6 @@ impl LintRule for RequireAwait {
 
   fn code(&self) -> &'static str {
     CODE
-  }
-
-  fn lint_program(&self, _context: &mut Context, _program: ProgramRef) {
-    unreachable!();
   }
 
   fn lint_program_with_ast_view(

--- a/src/rules/require_yield.rs
+++ b/src/rules/require_yield.rs
@@ -1,5 +1,7 @@
 // Copyright 2020-2021 the Deno authors. All rights reserved. MIT license.
+use super::program_ref;
 use super::{Context, LintRule};
+use crate::Program;
 use crate::ProgramRef;
 use deno_ast::swc::ast::ClassMethod;
 use deno_ast::swc::ast::FnDecl;
@@ -32,11 +34,12 @@ impl LintRule for RequireYield {
     CODE
   }
 
-  fn lint_program<'view>(
+  fn lint_program_with_ast_view<'view>(
     &self,
     context: &mut Context<'view>,
-    program: ProgramRef<'view>,
+    program: Program<'view>,
   ) {
+    let program = program_ref(program);
     let mut visitor = RequireYieldVisitor::new(context);
     match program {
       ProgramRef::Module(m) => visitor.visit_module(m),

--- a/src/rules/single_var_declarator.rs
+++ b/src/rules/single_var_declarator.rs
@@ -1,5 +1,7 @@
 // Copyright 2020-2021 the Deno authors. All rights reserved. MIT license.
+use super::program_ref;
 use super::{Context, LintRule};
+use crate::Program;
 use crate::ProgramRef;
 use deno_ast::swc::ast::VarDecl;
 use deno_ast::swc::visit::noop_visit_type;
@@ -28,11 +30,12 @@ impl LintRule for SingleVarDeclarator {
     CODE
   }
 
-  fn lint_program<'view>(
+  fn lint_program_with_ast_view<'view>(
     &self,
     context: &mut Context<'view>,
-    program: ProgramRef<'view>,
+    program: Program<'view>,
   ) {
+    let program = program_ref(program);
     let mut visitor = SingleVarDeclaratorVisitor::new(context);
     match program {
       ProgramRef::Module(m) => visitor.visit_module(m),

--- a/src/rules/triple_slash_reference.rs
+++ b/src/rules/triple_slash_reference.rs
@@ -1,6 +1,6 @@
 // Copyright 2020-2021 the Deno authors. All rights reserved. MIT license.
 use super::{Context, LintRule};
-use crate::ProgramRef;
+
 use deno_ast::swc::common::comments::Comment;
 use deno_ast::swc::common::comments::CommentKind;
 use deno_ast::SourceRange;
@@ -40,7 +40,11 @@ impl LintRule for TripleSlashReference {
     CODE
   }
 
-  fn lint_program(&self, context: &mut Context, _program: ProgramRef<'_>) {
+  fn lint_program_with_ast_view<'view>(
+    &self,
+    context: &mut Context<'view>,
+    _program: deno_ast::view::Program<'view>,
+  ) {
     let mut violated_comment_ranges = Vec::new();
 
     violated_comment_ranges.extend(context.all_comments().filter_map(|c| {

--- a/src/rules/use_isnan.rs
+++ b/src/rules/use_isnan.rs
@@ -1,7 +1,7 @@
 // Copyright 2020-2021 the Deno authors. All rights reserved. MIT license.
 use super::{Context, LintRule};
 use crate::handler::{Handler, Traverse};
-use crate::{Program, ProgramRef};
+use crate::Program;
 use deno_ast::view::{BinExpr, BinaryOp, Expr, Ident, SwitchStmt};
 use deno_ast::SourceRanged;
 use derive_more::Display;
@@ -39,10 +39,6 @@ impl LintRule for UseIsNaN {
 
   fn code(&self) -> &'static str {
     CODE
-  }
-
-  fn lint_program(&self, _context: &mut Context, _program: ProgramRef) {
-    unreachable!();
   }
 
   fn lint_program_with_ast_view(

--- a/src/rules/valid_typeof.rs
+++ b/src/rules/valid_typeof.rs
@@ -1,6 +1,8 @@
 // Copyright 2020-2021 the Deno authors. All rights reserved. MIT license.
+use super::program_ref;
 use super::{Context, LintRule};
 use crate::swc_util::StringRepr;
+use crate::Program;
 use crate::ProgramRef;
 use deno_ast::swc::ast::BinExpr;
 use deno_ast::swc::ast::BinaryOp::{EqEq, EqEqEq, NotEq, NotEqEq};
@@ -30,7 +32,12 @@ impl LintRule for ValidTypeof {
     CODE
   }
 
-  fn lint_program(&self, context: &mut Context, program: ProgramRef) {
+  fn lint_program_with_ast_view(
+    &self,
+    context: &mut Context,
+    program: Program,
+  ) {
+    let program = program_ref(program);
     let mut visitor = ValidTypeofVisitor::new(context);
     match program {
       ProgramRef::Module(m) => visitor.visit_module(m),

--- a/tools/scaffold.ts
+++ b/tools/scaffold.ts
@@ -98,7 +98,7 @@ export function genRustContent(
   return `// Copyright 2020-${now.getFullYear()} the Deno authors. All rights reserved. MIT license.
 use super::{Context, LintRule};
 use crate::handler::{Handler, Traverse};
-use crate::{Program, ProgramRef};
+use crate::Program;
 use deno_ast::SourceRanged;
 use deno_ast::view as ast_view;
 use std::sync::Arc;
@@ -117,10 +117,6 @@ impl LintRule for ${pascalCasedLintName} {
 
   fn code(&self) -> &'static str {
     CODE
-  }
-
-  fn lint_program(&self, _context: &mut Context, _program: ProgramRef<'_>) {
-    unreachable!();
   }
 
   fn lint_program_with_ast_view(

--- a/tools/tests/scaffold_test.ts
+++ b/tools/tests/scaffold_test.ts
@@ -90,7 +90,7 @@ Deno.test("the content of .rs", () => {
     `// Copyright 2020-2022 the Deno authors. All rights reserved. MIT license.
 use super::{Context, LintRule};
 use crate::handler::{Handler, Traverse};
-use crate::{Program, ProgramRef};
+use crate::Program;
 use deno_ast::SourceRanged;
 use deno_ast::view as ast_view;
 use std::sync::Arc;
@@ -109,10 +109,6 @@ impl LintRule for FooBarBaz {
 
   fn code(&self) -> &'static str {
     CODE
-  }
-
-  fn lint_program(&self, _context: &mut Context, _program: ProgramRef<'_>) {
-    unreachable!();
   }
 
   fn lint_program_with_ast_view(


### PR DESCRIPTION
If you like these changes please merge them without squashing.

Note that the last of the three commits is strictly speaking a breaking API change but I'd assume that the `LintRule` API is only used internally.