### PR TITLE
fix: Fix website background color

### DIFF
--- a/www/pages/ignoring-rules.tsx
+++ b/www/pages/ignoring-rules.tsx
@@ -8,7 +8,7 @@ function IgnoringRulesPage() {
   const html = renderMarkdown(md);
 
   return (
-    <div class={tw`dark:bg-[#0d1117] dark:text-white py-6 h-screen`}>
+    <div class={tw`dark:bg-[#0d1117] dark:text-white py-6 h-full`}>
       <div
         class={tw`mx-auto max-w-screen-md px-6 sm:px-6 md:px-8 `}
       >

--- a/www/pages/index.tsx
+++ b/www/pages/index.tsx
@@ -39,7 +39,7 @@ function IndexPage(props: PageProps) {
     .filter((rule: RuleData) => rule.code.includes(search));
 
   return (
-    <div class={tw`dark:bg-[#0d1117] dark:text-white py-6 h-screen`}>
+    <div class={tw`dark:bg-[#0d1117] dark:text-white py-6 h-full`}>
       <div class={tw`mx-auto max-w-screen-md px-6 sm:px-6 md:px-8`}>
         <Head>
           <link


### PR DESCRIPTION
08235828f96e42af56b8656cd6cab67825b9c594 changed the CSS classes to h-screen which Tailwind CSS defines as `heigth: 100vh;`[1], which isn't what we want ... we want `h-full` for 100% height.

This fixes https://lint.deno.land/ from looking like the following when you scroll down:

![](https://user-images.githubusercontent.com/23649474/219000935-e09b876c-97cc-44f7-9625-afda19ec82e7.png)

[1]: https://tailwindcss.com/docs/height