### PR TITLE
fix(prefer-primordials): Improve getter properties checking

### DIFF
--- a/src/rules/prefer_primordials.rs
+++ b/src/rules/prefer_primordials.rs
@@ -132,18 +132,6 @@ const GETTER_TARGETS: &[&str] = &[
   "byteOffset",
   // TypedArray: avoid false positives for Array
   // "length",
-  // RegExp: no problem when using SafeRegExp
-  // "dotAll",
-  // "flags",
-  // "global",
-  // "hasIndices",
-  // "ignoreCase",
-  // "multiline",
-  // "source",
-  // "sticky",
-  // "unicode",
-  // Map, Set: no problem when using SafeMap or SafeSet
-  // "size",
 ];
 
 struct PreferPrimordialsHandler;

--- a/src/rules/prefer_primordials.rs
+++ b/src/rules/prefer_primordials.rs
@@ -463,6 +463,18 @@ parseInt();
       r#"foo.description = 1"#,
       r#"foo.description()"#,
       r#"
+const { SafeRegExp } = primordials;
+const pattern = new SafeRegExp(/aaaa/u);
+pattern.source;
+      "#,
+      r#"
+const { SafeSet } = primordials;
+const set = new SafeSet();
+set.add(1);
+set.add(2);
+set.size;
+      "#,
+      r#"
 const { SafeArrayIterator } = primordials;
 [1, 2, ...new SafeArrayIterator(arr)];
 foo(1, 2, ...new SafeArrayIterator(arr));

--- a/src/rules/prefer_primordials.rs
+++ b/src/rules/prefer_primordials.rs
@@ -475,6 +475,10 @@ set.add(2);
 set.size;
       "#,
       r#"
+const foo = { size: 100 };
+foo.size;
+      "#,
+      r#"
 const { SafeArrayIterator } = primordials;
 [1, 2, ...new SafeArrayIterator(arr)];
 foo(1, 2, ...new SafeArrayIterator(arr));

--- a/src/rules/prefer_primordials.rs
+++ b/src/rules/prefer_primordials.rs
@@ -123,22 +123,26 @@ const GLOBAL_TARGETS: &[&str] = &[
 ];
 
 const GETTER_TARGETS: &[&str] = &[
+  // Symbol
   "description",
-  "dotAll",
-  "flags",
-  "global",
-  "hasIndices",
-  "ignoreCase",
-  "multiline",
-  "source",
-  "sticky",
-  "unicode",
+  // ArrayBuffer, TypedArray, DataView
   "buffer",
   "byteLength",
   "byteOffset",
-  // avoid false positives for Array
+  // TypedArray: avoid false positives for Array
   // "length",
-  "size",
+  // RegExp: no problem when using SafeRegExp
+  // "dotAll",
+  // "flags",
+  // "global",
+  // "hasIndices",
+  // "ignoreCase",
+  // "multiline",
+  // "source",
+  // "sticky",
+  // "unicode",
+  // Map, Set: no problem when using SafeMap or SafeSet
+  // "size",
 ];
 
 struct PreferPrimordialsHandler;
@@ -465,8 +469,8 @@ const parseInt = () => {};
 parseInt();
       "#,
       r#"const foo = { Error: 1 };"#,
-      r#"foo.size = 1"#,
-      r#"foo.size()"#,
+      r#"foo.description = 1"#,
+      r#"foo.description()"#,
       r#"
 const { SafeArrayIterator } = primordials;
 [1, 2, ...new SafeArrayIterator(arr)];
@@ -666,69 +670,6 @@ const noop = Function.prototype;
           hint: PreferPrimordialsHint::GlobalIntrinsic,
         },
       ],
-      r#"/aaaa/u.dotAll;"#: [
-        {
-          col: 0,
-          message: PreferPrimordialsMessage::GlobalIntrinsic,
-          hint: PreferPrimordialsHint::GlobalIntrinsic,
-        },
-      ],
-      r#"/aaaa/u.flags;"#: [
-        {
-          col: 0,
-          message: PreferPrimordialsMessage::GlobalIntrinsic,
-          hint: PreferPrimordialsHint::GlobalIntrinsic,
-        },
-      ],
-      r#"/aaaa/u.global;"#: [
-        {
-          col: 0,
-          message: PreferPrimordialsMessage::GlobalIntrinsic,
-          hint: PreferPrimordialsHint::GlobalIntrinsic,
-        },
-      ],
-      r#"/aaaa/u.hasIndices;"#: [
-        {
-          col: 0,
-          message: PreferPrimordialsMessage::GlobalIntrinsic,
-          hint: PreferPrimordialsHint::GlobalIntrinsic,
-        },
-      ],
-      r#"/aaaa/u.ignoreCase;"#: [
-        {
-          col: 0,
-          message: PreferPrimordialsMessage::GlobalIntrinsic,
-          hint: PreferPrimordialsHint::GlobalIntrinsic,
-        },
-      ],
-      r#"/aaaa/u.multiline;"#: [
-        {
-          col: 0,
-          message: PreferPrimordialsMessage::GlobalIntrinsic,
-          hint: PreferPrimordialsHint::GlobalIntrinsic,
-        },
-      ],
-      r#"/aaaa/u.source;"#: [
-        {
-          col: 0,
-          message: PreferPrimordialsMessage::GlobalIntrinsic,
-          hint: PreferPrimordialsHint::GlobalIntrinsic,
-        },
-      ],
-      r#"/aaaa/u.sticky;"#: [
-        {
-          col: 0,
-          message: PreferPrimordialsMessage::GlobalIntrinsic,
-          hint: PreferPrimordialsHint::GlobalIntrinsic,
-        },
-      ],
-      r#"/aaaa/u.unicode;"#: [
-        {
-          col: 0,
-          message: PreferPrimordialsMessage::GlobalIntrinsic,
-          hint: PreferPrimordialsHint::GlobalIntrinsic,
-        },
-      ],
       r#"
 const { Uint8Array } = primordials;
 new Uint8Array(10).buffer;
@@ -754,17 +695,6 @@ new ArrayBuffer(10).byteLength;
       r#"
 const { ArrayBuffer, DataView } = primordials;
 new DataView(new ArrayBuffer(10)).byteOffset;
-      "#: [
-        {
-          line: 3,
-          col: 0,
-          message: PreferPrimordialsMessage::GlobalIntrinsic,
-          hint: PreferPrimordialsHint::GlobalIntrinsic,
-        },
-      ],
-      r#"
-const { SafeSet } = primordials;
-new SafeSet().size;
       "#: [
         {
           line: 3,


### PR DESCRIPTION
There are two changes in this PR

## Stop checking getter properties for `RegExp`, `Map`, and `Set`

Due to my lack of consideration, I had [a lot of false positives](https://github.com/denoland/deno/pull/17715) in getting deno_lint into deno :bow:

And this can be solved by using the primordials Safe constructors (e.g. `SafeMap`); `SafeRegExp` is not in primordials yet, but I am working on getting it in https://github.com/denoland/deno/pull/17592.

## Check right sides of Assignment Expressions

This was not considered.