### PR TITLE
ci: update ubuntu to 22.04-xl

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     timeout-minutes: 30
     strategy:
       matrix:
-        os: [macOS-latest, ubuntu-20.04-xl, windows-2019]
+        os: [macOS-latest, ubuntu-22.04-xl, windows-2019]
 
     env:
       CARGO_INCREMENTAL: 0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ on:
 jobs:
   rust:
     name: release
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04-xl
     timeout-minutes: 30
 
     steps:


### PR DESCRIPTION
This commit updates CI to use ubuntu-22.04-xl runners as 20.04-xl will get shut down soon.