### PR TITLE
fix(prefer-const): avoid panic when scope analysis fails

### DIFF
--- a/src/rules/prefer_const.rs
+++ b/src/rules/prefer_const.rs
@@ -700,10 +700,7 @@ impl<'c, 'view> PreferConstVisitor<'c, 'view> {
   }
 
   fn get_scope(&self) -> Option<Scope> {
-    match self.scopes.get(&self.cur_scope) {
-      Some(s) => Some(Rc::clone(s)),
-      None => None,
-    }
+    self.scopes.get(&self.cur_scope).map(Rc::clone)
   }
 
   fn extract_assign_idents<'a>(

--- a/src/test_util.rs
+++ b/src/test_util.rs
@@ -379,6 +379,11 @@ pub fn assert_lint_ok(
   }
 }
 
+/// Just run the specified lint on the source code to make sure it doesn't panic.
+pub fn assert_lint_not_panic(rule: &'static dyn LintRule, source: &str) {
+  let _result = lint(rule, source, TEST_FILE_NAME);
+}
+
 const TEST_FILE_NAME: &str = "lint_test.ts";
 
 pub fn parse(source_code: &str) -> ParsedSource {


### PR DESCRIPTION
This commit prevents panics from happening when scope analysis fails in `prefer-const` rule.

Towards #1145 