### PR TITLE
refactor(prefer-primordials): Use `ObjectHasOwn` instead of `ObjectPrototypeHasOwnProperty`

### DIFF
--- a/src/rules/prefer_primordials.rs
+++ b/src/rules/prefer_primordials.rs
@@ -49,7 +49,7 @@ enum PreferPrimordialsHint {
   )]
   InstanceOf,
   #[display(
-    fmt = "Instead use either `ObjectPrototypeHasOwnProperty` or `ReflectHas` from the `primordials` object"
+    fmt = "Instead use either `ObjectHasOwn` or `ReflectHas` from the `primordials` object"
   )]
   In,
 }


### PR DESCRIPTION
related: https://github.com/denoland/deno/pull/18952