### PR TITLE
fix: Add support for v flag in regexp lints

### DIFF
--- a/src/js_regex/validator.rs
+++ b/src/js_regex/validator.rs
@@ -176,6 +176,7 @@ impl EcmaRegexValidator {
         || (flag == 'y' && self.ecma_version >= EcmaVersion::Es2015)
         || (flag == 's' && self.ecma_version >= EcmaVersion::Es2018)
         || (flag == 'd' && self.ecma_version >= EcmaVersion::Es2022)
+        || (flag == 'v' && self.ecma_version >= EcmaVersion::Es2022)
       {
         // do nothing
       } else {

--- a/src/rules/no_empty_character_class.rs
+++ b/src/rules/no_empty_character_class.rs
@@ -53,10 +53,10 @@ impl Handler for NoEmptyCharacterClassVisitor {
        * 2.1. `\\.`: an escape sequence
        * 2.2. `\[([^\\\]]|\\.)+\]`: a character class that isn't empty
        * 3. `\/` the `/` that ends the regexp
-       * 4. `[gimuy]*`: optional regexp flags
+       * 4. `[dgimsuvy]*`: optional regexp flags
        * 5. `$`: fix the match at the end of the string
        */
-      regex::Regex::new(r"(?u)^/([^\\\[]|\\.|\[([^\\\]]|\\.)+\])*/[gimuysd]*$")
+      regex::Regex::new(r"(?u)^/([^\\\[]|\\.|\[([^\\\]]|\\.)+\])*/[dgimsuvy]*$")
         .unwrap()
     });
 
@@ -86,7 +86,7 @@ mod tests {
     const foo = /[\-\[\]\/\{\}\(\)\*\+\?\.\\^\$\|]/g;
     const foo = /\[/g;
     const foo = /\]/i;
-    const foo = /\]/d;
+    const foo = /\]/dgimsuvy;
     "#,
     };
   }


### PR DESCRIPTION
`v` flag is still in proposal state, but available in the V8, so adding it sounds reasonable. The only think that should be updated later on is `EcmaVersion` check, as it's not accurate right now, yet there's no `> EcmaVersion::Next` available.

Note: flags in `src/rules/no_empty_character_class.rs` are now ordered, as this is the behavior of `.flags` getter as well.

Fixes https://github.com/denoland/deno_lint/issues/1157