### PR TITLE
fix(tools): print the outputs of external commands

### DIFF
--- a/tools/format.ts
+++ b/tools/format.ts
@@ -8,25 +8,25 @@ const checkArgs = check ? ["--check"] : [];
 const p1 = new Deno.Command("rustfmt", {
   args: [...checkArgs, "examples/dlint/main.rs"],
   stdin: "null",
-});
+}).spawn();
 
-const o1 = await p1.output();
+const result1 = await p1.status;
 
-if (o1.code !== 0) {
+if (!result1.success) {
   throw new Error(
-    `Failed: rustfmt ${check ? "--check" : ""} examples/dlint/main.rs`,
+    `Failed: rustfmt ${check ? "--check" : ""}`,
   );
 }
 
 const p2 = new Deno.Command("rustfmt", {
   args: [...checkArgs, "src/lib.rs"],
   stdin: "null",
-});
+}).spawn();
 
-const o2 = await p2.output();
+const result2 = await p2.status;
 
-if (o2.code !== 0) {
-  throw new Error(`Failed: rustfmt ${check ? "--check" : ""} src/lib.rs`);
+if (!result2.success) {
+  throw new Error(`Failed: rustfmt ${check ? "--check" : ""}`);
 }
 
 console.log("deno fmt");
@@ -42,12 +42,12 @@ const p3 = new Deno.Command("deno", {
     "README.md",
   ],
   stdin: "null",
-});
+}).spawn();
 
-const o3 = await p3.output();
+const result3 = await p3.status;
 
-if (o3.code !== 0) {
+if (!result3.success) {
   throw new Error(
-    `Failed: deno fmt ${check ? "--check" : ""} benchmarks/benchmarks.ts`,
+    `Failed: deno fmt ${check ? "--check" : ""}`,
   );
 }


### PR DESCRIPTION
This commit lets the outputs of external commands spawned in `tools/format.ts` printed out to stdout and stderr so that we can easily figure out what is wrong with formatting.

Without this patch, the following message is shown to us from which we can identify that there is a format issue somewhere, but it's hard to figure out where the issue is.

```
$ ./tools/format.ts --check
rustfmt
deno fmt
error: Uncaught (in promise) Error: Failed: deno fmt --check benchmarks/benchmarks.ts
  throw new Error(
        ^
    at file:///Users/yusuktan/Repo/github.com/magurotuna/deno_lint/tools/format.ts:50:9
    at eventLoopTick (ext:core/01_core.js:182:11)
```

With this patch, it will become easy to spot the problematic place:

```
$ ./tools/format.ts --check
rustfmt
deno fmt

from /Users/yusuktan/Repo/github.com/magurotuna/deno_lint/README.md:
  6 | -A Rust crate for writing fast JavaScript and TypeScript linters.This crate powers [`deno lint`](https://deno.land/manual/tools/linter), but is
  7 | -not Deno specific and can be used to write linters for Node as well.
  6 | +A Rust crate for writing fast JavaScript and TypeScript linters.This crate
  7 | +powers [`deno lint`](https://deno.land/manual/tools/linter), but is not Deno
  8 | +specific and can be used to write linters for Node as well.

error: Found 1 not formatted file in 102 files
error: Uncaught (in promise) Error: Failed: deno fmt --check
  throw new Error(
        ^
    at file:///Users/yusuktan/Repo/github.com/magurotuna/deno_lint/tools/format.ts:50:9
    at eventLoopTick (ext:core/01_core.js:182:11)
```