### PR TITLE
feat: add fresh-handler-export rule

### DIFF
--- a/docs/rules/fresh_handler_export.md
+++ b/docs/rules/fresh_handler_export.md
@@ -1,0 +1,28 @@
+Checks correct naming for named fresh middleware export
+
+Files inside the `routes/` folder can export middlewares that run before any
+rendering happens. They are expected to be available as a named export called
+`handler`. This rule checks for when the export was incorrectly named `handlers`
+instead of `handler`.
+
+### Invalid:
+
+```js
+export const handlers = {
+  GET() {},
+  POST() {},
+};
+export function handlers() {}
+export async function handlers() {}
+```
+
+### Valid:
+
+```jsx
+export const handler = {
+  GET() {},
+  POST() {},
+};
+export function handler() {}
+export async function handler() {}
+```

--- a/src/rules.rs
+++ b/src/rules.rs
@@ -19,6 +19,7 @@ pub mod eqeqeq;
 pub mod explicit_function_return_type;
 pub mod explicit_module_boundary_types;
 pub mod for_direction;
+pub mod fresh_handler_export;
 pub mod fresh_server_event_handlers;
 pub mod getter_return;
 pub mod guard_for_in;
@@ -236,6 +237,7 @@ fn get_all_rules_raw() -> Vec<&'static dyn LintRule> {
     &explicit_function_return_type::ExplicitFunctionReturnType,
     &explicit_module_boundary_types::ExplicitModuleBoundaryTypes,
     &for_direction::ForDirection,
+    &fresh_handler_export::FreshHandlerExport,
     &fresh_server_event_handlers::FreshServerEventHandlers,
     &getter_return::GetterReturn,
     &guard_for_in::GuardForIn,

--- a/src/rules/fresh_handler_export.rs
+++ b/src/rules/fresh_handler_export.rs
@@ -1,0 +1,136 @@
+use std::path::Path;
+
+// Copyright 2020-2023 the Deno authors. All rights reserved. MIT license.
+use super::{Context, LintRule};
+use crate::handler::{Handler, Traverse};
+
+use deno_ast::view::{Decl, Pat, Program};
+use deno_ast::SourceRanged;
+
+#[derive(Debug)]
+pub struct FreshHandlerExport;
+
+const CODE: &str = "fresh-handler-export";
+const MESSAGE: &str =
+  "Fresh middlewares must be exported as \"handler\" but got \"handlers\" instead.";
+const HINT: &str = "Did you mean \"handler\"?";
+
+impl LintRule for FreshHandlerExport {
+  fn tags(&self) -> &'static [&'static str] {
+    &["fresh"]
+  }
+
+  fn code(&self) -> &'static str {
+    CODE
+  }
+
+  fn lint_program_with_ast_view(
+    &self,
+    context: &mut Context,
+    program: Program,
+  ) {
+    Visitor.traverse(program, context);
+  }
+
+  #[cfg(feature = "docs")]
+  fn docs(&self) -> &'static str {
+    include_str!("../../docs/rules/fresh_handler_export.md")
+  }
+}
+
+struct Visitor;
+
+impl Handler for Visitor {
+  fn export_decl(
+    &mut self,
+    export_decl: &deno_ast::view::ExportDecl,
+    ctx: &mut Context,
+  ) {
+    // Fresh only considers components in the routes/ folder to be
+    // server components.
+    let path = Path::new(ctx.file_name());
+    if !path
+      .components()
+      .map(|comp| comp.as_os_str())
+      .any(|comp| comp == "routes")
+    {
+      return;
+    }
+
+    let id = match export_decl.decl {
+      Decl::Var(var_decl) => {
+        if let Some(first) = var_decl.decls.first() {
+          let Pat::Ident(name_ident) = first.name else {return};
+          name_ident.id
+        } else {
+          return;
+        }
+      }
+      Decl::Fn(fn_decl) => fn_decl.ident,
+      _ => return,
+    };
+
+    // Fresh middleware handler must be exported as "handler" not "handlers"
+    if id.sym().eq("handlers") {
+      ctx.add_diagnostic_with_hint(id.range(), CODE, MESSAGE, HINT);
+    }
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use crate::test_util::assert_lint_ok;
+
+  #[test]
+  fn fresh_handler_export_name() {
+    assert_lint_ok(&FreshHandlerExport, "const handler = {}", "foo.jsx");
+    assert_lint_ok(&FreshHandlerExport, "function handler() {}", "foo.jsx");
+    assert_lint_ok(&FreshHandlerExport, "export const handler = {}", "foo.jsx");
+    assert_lint_ok(
+      &FreshHandlerExport,
+      "export const handlers = {}",
+      "foo.jsx",
+    );
+    assert_lint_ok(
+      &FreshHandlerExport,
+      "export function handlers() {}",
+      "foo.jsx",
+    );
+
+    assert_lint_ok(
+      &FreshHandlerExport,
+      "export const handler = {}",
+      "routes/foo.jsx",
+    );
+    assert_lint_ok(
+      &FreshHandlerExport,
+      "export function handler() {}",
+      "routes/foo.jsx",
+    );
+    assert_lint_ok(
+      &FreshHandlerExport,
+      "export async function handler() {}",
+      "routes/foo.jsx",
+    );
+
+    assert_lint_err!(FreshHandlerExport, filename: "routes/index.tsx",  r#"export const handlers = {}"#: [
+    {
+      col: 13,
+      message: MESSAGE,
+      hint: HINT,
+    }]);
+    assert_lint_err!(FreshHandlerExport, filename: "routes/index.tsx",  r#"export function handlers() {}"#: [
+    {
+      col: 16,
+      message: MESSAGE,
+      hint: HINT,
+    }]);
+    assert_lint_err!(FreshHandlerExport, filename: "routes/index.tsx",  r#"export async function handlers() {}"#: [
+    {
+      col: 22,
+      message: MESSAGE,
+      hint: HINT,
+    }]);
+  }
+}

--- a/www/static/docs.json
+++ b/www/static/docs.json
@@ -86,6 +86,13 @@
     ]
   },
   {
+    "code": "fresh-handler-export",
+    "docs": "Checks correct naming for named fresh middleware export\n\nFiles inside the `routes/` folder can export middlewares that run before any\nrendering happens. They are expected to be available as a named export called\n`handler`. This rule checks for when the export was incorrectly named `handlers`\ninstead of `handler`.\n\n### Invalid:\n\n```js\nexport const handlers = {\n  GET() {},\n  POST() {},\n};\nexport function handlers() {}\nexport async function handlers() {}\n```\n\n### Valid:\n\n```jsx\nexport const handler = {\n  GET() {},\n  POST() {},\n};\nexport function handler() {}\nexport async function handler() {}\n```\n",
+    "tags": [
+      "fresh"
+    ]
+  },
+  {
     "code": "fresh-server-event-handlers",
     "docs": "Disallows event handlers in fresh server components\n\nComponents inside the `routes/` folder in a fresh app are exclusively rendered\non the server. They are not rendered in the client and setting an event handler\nwill have no effect.\n\nNote that this rule only applies to server components inside the `routes/`\nfolder, not to fresh islands or any other components.\n\n### Invalid:\n\n```jsx\n<button onClick={() => {}} />\n<button onclick={() => {}} />\n<my-custom-element foo={() => {}} />\n```\n\n### Valid:\n\n```jsx\n<button />\n<my-custom-element />\n```\n",
     "tags": [


### PR DESCRIPTION
This adds a new lint rule which helps when fresh users accidentally export middlewares under `handlers` instead of `handler`.

See https://github.com/denoland/fresh/issues/1350