### PR TITLE
feat(rules): add no console log rule

### DIFF
--- a/docs/rules/no_console_log.md
+++ b/docs/rules/no_console_log.md
@@ -17,10 +17,6 @@ function log() { console.log("Log"); }
 ### Valid
 
 ```typescript
-let foo = 0;
-
-const bar = 1;
-
 console.error("Error message");
 
 function log_error(message: string) {

--- a/docs/rules/no_console_log.md
+++ b/docs/rules/no_console_log.md
@@ -2,7 +2,11 @@
 
 Disallows the use of `console.log`.
 
-Oftentimes, developers are guilty of committing `console.log` statements accidentally, left in particularly after debugging. Moreover, using `console.log` in code may leak sensitive information to the output or clutter the console with unnecessary information. This rule helps maintain clean and secure code by disallowing the use of `console.log`.
+Oftentimes, developers are guilty of committing `console.log` statements
+accidentally, left in particularly after debugging. Moreover, using
+`console.log` in code may leak sensitive information to the output or clutter
+the console with unnecessary information. This rule helps maintain clean and
+secure code by disallowing the use of `console.log`.
 
 ### Invalid
 
@@ -20,6 +24,6 @@ function log() { console.log("Log"); }
 console.error("Error message");
 
 function log_error(message: string) {
-    console.warn(message);
+  console.warn(message);
 }
 ```

--- a/docs/rules/no_console_log.md
+++ b/docs/rules/no_console_log.md
@@ -2,20 +2,22 @@
 
 Disallows the use of `console.log`.
 
-Oftentimes, developers are guilty of committing `console.log` statements
-accidentally, left in particularly after debugging. Moreover, using
-`console.log` in code may leak sensitive information to the output or clutter
-the console with unnecessary information. This rule helps maintain clean and
-secure code by disallowing the use of `console.log`.
+Oftentimes, developers accidentally commit `console.log` statements, left in
+particularly after debugging. Moreover, using `console.log` in code may leak
+sensitive information to the output or clutter the console with unnecessary
+information. This rule helps maintain clean and secure code by disallowing the
+use of `console.log`.
 
 ### Invalid
 
 ```typescript
 console.log("Debug message");
 
-if debug { console.log("Debugging"); }
+if (debug) console.log("Debugging");
 
-function log() { console.log("Log"); }
+function log() {
+  console.log("Log");
+}
 ```
 
 ### Valid

--- a/docs/rules/no_console_log.md
+++ b/docs/rules/no_console_log.md
@@ -1,0 +1,29 @@
+# no_console_log
+
+Disallows the use of `console.log`.
+
+Oftentimes, developers are guilty of committing `console.log` statements accidentally, left in particularly after debugging. Moreover, using `console.log` in code may leak sensitive information to the output or clutter the console with unnecessary information. This rule helps maintain clean and secure code by disallowing the use of `console.log`.
+
+### Invalid
+
+```rust
+console.log("Debug message");
+
+if debug { console.log("Debugging"); }
+
+fn log() { console.log("Log"); }
+```
+
+### Valid
+
+```rust
+let foo = 0;
+
+const bar = 1;
+
+console.error("Error message");
+
+fn log_error(message: &str) {
+    eprintln!("{}", message);
+}
+```

--- a/docs/rules/no_console_log.md
+++ b/docs/rules/no_console_log.md
@@ -6,24 +6,24 @@ Oftentimes, developers are guilty of committing `console.log` statements acciden
 
 ### Invalid
 
-```rust
+```typescript
 console.log("Debug message");
 
 if debug { console.log("Debugging"); }
 
-fn log() { console.log("Log"); }
+function log() { console.log("Log"); }
 ```
 
 ### Valid
 
-```rust
+```typescript
 let foo = 0;
 
 const bar = 1;
 
 console.error("Error message");
 
-fn log_error(message: &str) {
-    eprintln!("{}", message);
+function log_error(message: string) {
+    console.warn(message);
 }
 ```

--- a/src/rules.rs
+++ b/src/rules.rs
@@ -31,6 +31,7 @@ pub mod no_case_declarations;
 pub mod no_class_assign;
 pub mod no_compare_neg_zero;
 pub mod no_cond_assign;
+pub mod no_console_log;
 pub mod no_const_assign;
 pub mod no_constant_condition;
 pub mod no_control_regex;

--- a/src/rules/no_console_log.rs
+++ b/src/rules/no_console_log.rs
@@ -1,0 +1,63 @@
+use super::{ Context, LintRule };
+use crate::handler::{ Handler, Traverse };
+use crate::Program;
+use deno_ast::view::{ CallExpr, Expr };
+
+#[derive(Debug)]
+pub struct NoConsoleLog;
+
+const MESSAGE: &str = "'console.log` calls are not allowed.";
+const CODE: &str = "no-console";
+
+impl LintRule for NoConsoleLog {
+    fn tags(&self) -> &'static [&'static str] {
+        &["recommended"]
+    }
+
+    fn code(&self) -> &'static str {
+        CODE
+    }
+
+    fn lint_program_with_ast_view(
+        &self,
+        context: &mut Context,
+        program: Program,
+    ) {
+        NoConsoleLogHandler.traverse(program, context);
+    }
+
+    #[cfg(feature = "docs")]
+    fn docs(&self) -> &'static str {
+        include_str!("../../docs/rules/no_console_log.md")
+    }
+}
+
+struct NoConsoleLogHandler;
+
+impl Handler for NoConsoleLogHandler {
+    fn call_expr(&mut self, call_expr: &CallExpr, ctx: &mut Context) {
+        if let Expr::Member(member_expr) = call_expr.callee() {
+            if member_expr.object().as_ident().unwrap().raw() == "console" 
+                && member_expr.prop().as_ident().unwrap().raw() == "log" 
+            {
+                ctx.add_diagnostic(call_expr.range(), CODE, MESSAGE);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn no_console_log_valid() {
+        // Test cases where a console.log call is not present
+        assert_lint_ok!(NoConsoleLog,
+            r#"let foo = 0; const bar = 1;"#,
+            r#"console.error('Error message');"#
+        )
+    }
+
+    #[test]
+}

--- a/src/rules/no_console_log.rs
+++ b/src/rules/no_console_log.rs
@@ -1,8 +1,8 @@
-use super::{ Context, LintRule };
-use crate::handler::{ Handler, Traverse };
+use super::{Context, LintRule};
+use crate::handler::{Handler, Traverse};
 use crate::Program;
+use deno_ast::view::{CallExpr, Expr, MemberProp};
 use deno_ast::SourceRanged;
-use deno_ast::view::{ CallExpr, Expr, MemberProp };
 
 #[derive(Debug)]
 pub struct NoConsoleLog;
@@ -11,76 +11,79 @@ const MESSAGE: &str = "'console.log` calls are not allowed.";
 const CODE: &str = "no-console";
 
 impl LintRule for NoConsoleLog {
-    fn tags(&self) -> &'static [&'static str] {
-        &["recommended"]
-    }
+  fn tags(&self) -> &'static [&'static str] {
+    &["recommended"]
+  }
 
-    fn code(&self) -> &'static str {
-        CODE
-    }
+  fn code(&self) -> &'static str {
+    CODE
+  }
 
-    fn lint_program_with_ast_view(
-        &self,
-        context: &mut Context,
-        program: Program,
-    ) {
-        NoConsoleLogHandler.traverse(program, context);
-    }
+  fn lint_program_with_ast_view(
+    &self,
+    context: &mut Context,
+    program: Program,
+  ) {
+    NoConsoleLogHandler.traverse(program, context);
+  }
 
-    #[cfg(feature = "docs")]
-    fn docs(&self) -> &'static str {
-        include_str!("../../docs/rules/no_console_log.md")
-    }
+  #[cfg(feature = "docs")]
+  fn docs(&self) -> &'static str {
+    include_str!("../../docs/rules/no_console_log.md")
+  }
 }
 
 struct NoConsoleLogHandler;
 
 impl Handler for NoConsoleLogHandler {
-    fn call_expr(&mut self, call_expr: &CallExpr, ctx: &mut Context) {
-        if let deno_ast::view::Callee::Expr(Expr::Member(member_expr)) = &call_expr.callee {
-            if let Expr::Ident(obj_ident) = &member_expr.obj {
-                if obj_ident.sym().as_ref() == "console" {
-                    if let MemberProp::Ident(prop_ident) = &member_expr.prop {
-                        if prop_ident.sym().as_ref() == "log" {
-                            ctx.add_diagnostic(call_expr.range(), CODE, MESSAGE);
-                        }
-                    }
-                }
+  fn call_expr(&mut self, call_expr: &CallExpr, ctx: &mut Context) {
+    if let deno_ast::view::Callee::Expr(Expr::Member(member_expr)) =
+      &call_expr.callee
+    {
+      if let Expr::Ident(obj_ident) = &member_expr.obj {
+        if obj_ident.sym().as_ref() == "console" {
+          if let MemberProp::Ident(prop_ident) = &member_expr.prop {
+            if prop_ident.sym().as_ref() == "log" {
+              ctx.add_diagnostic(call_expr.range(), CODE, MESSAGE);
             }
+          }
         }
+      }
     }
+  }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+  use super::*;
 
-    #[test]
-    fn no_console_log_valid() {
-        // Test cases where a console.log call is not present
-        assert_lint_ok!(NoConsoleLog,
-            r#"let foo = 0; const bar = 1;"#,
-            r#"console.error('Error message');"#
-        );
-    }
+  #[test]
+  fn no_console_log_valid() {
+    // Test cases where a console.log call is not present
+    assert_lint_ok!(
+      NoConsoleLog,
+      r#"let foo = 0; const bar = 1;"#,
+      r#"console.error('Error message');"#
+    );
+  }
 
-    #[test]
-    fn no_console_log_invalid() {
-        // Test cases where console.log is present
-        assert_lint_err!(
-            NoConsoleLog,
-            r#"console.log('Debug message');"#: [{
-                col: 0,
-                message: MESSAGE,
-            }],
-            r#"if (debug) { console.log('Debugging'); }"#: [{
-                col: 13,
-                message: MESSAGE,
-            }],
-            r#"function log() { console.log('Log'); }"#: [{
-                col: 17,
-                message: MESSAGE,
-            }]
-        );
-    }
+  #[test]
+  fn no_console_log_invalid() {
+    // Test cases where console.log is present
+    assert_lint_err!(
+        NoConsoleLog,
+        r#"console.log('Debug message');"#: [{
+            col: 0,
+            message: MESSAGE,
+        }],
+        r#"if (debug) { console.log('Debugging'); }"#: [{
+            col: 13,
+            message: MESSAGE,
+        }],
+        r#"function log() { console.log('Log'); }"#: [{
+            col: 17,
+            message: MESSAGE,
+        }]
+    );
+  }
 }


### PR DESCRIPTION
The goal of this PR is to address the [this issue](https://github.com/denoland/deno/issues/20187) presented in the main Deno GitHub repository, which proposes the implementation of a `no-console` rule similar to that of [eslint](https://eslint.org/docs/latest/rules/no-console). In order to add such a rule to `deno lint` in the main Deno repository, we need a rule defined in the linter itself.

This PR achieves that goal by adding in a `NoConsoleLog` lint rule that checks whether a `console.log()` statement is in the specified code