### PR TITLE
refactor: Linter, Context and more

### DIFF
--- a/examples/dlint/main.rs
+++ b/examples/dlint/main.rs
@@ -6,6 +6,7 @@ use clap::Command;
 use deno_ast::MediaType;
 use deno_ast::SourceTextInfo;
 use deno_lint::diagnostic::LintDiagnostic;
+use deno_lint::linter::LintFileOptions;
 use deno_lint::linter::LinterBuilder;
 use deno_lint::rules::{get_filtered_rules, get_recommended_rules};
 use log::debug;
@@ -109,11 +110,11 @@ fn run_linter(
 
       let linter = linter_builder.build();
 
-      let (parsed_source, diagnostics) = linter.lint(
-        file_path.to_string_lossy().to_string(),
+      let (parsed_source, diagnostics) = linter.lint_file(LintFileOptions {
+        filename: file_path.to_string_lossy().to_string(),
         source_code,
-        MediaType::from_path(file_path),
-      )?;
+        media_type: MediaType::from_path(file_path),
+      })?;
 
       error_counts.fetch_add(diagnostics.len(), Ordering::Relaxed);
 

--- a/examples/dlint/main.rs
+++ b/examples/dlint/main.rs
@@ -109,11 +109,12 @@ fn run_linter(
     .try_for_each(|file_path| -> Result<(), AnyError> {
       let source_code = std::fs::read_to_string(file_path)?;
 
-      let (parsed_source, diagnostics) = linter.clone().lint_file(LintFileOptions {
-        filename: file_path.to_string_lossy().to_string(),
-        source_code,
-        media_type: MediaType::from_path(file_path),
-      })?;
+      let (parsed_source, diagnostics) =
+        linter.clone().lint_file(LintFileOptions {
+          filename: file_path.to_string_lossy().to_string(),
+          source_code,
+          media_type: MediaType::from_path(file_path),
+        })?;
 
       error_counts.fetch_add(diagnostics.len(), Ordering::Relaxed);
 

--- a/examples/dlint/main.rs
+++ b/examples/dlint/main.rs
@@ -105,13 +105,15 @@ fn run_linter(
         bail!("There's no rule to be run!");
       }
 
-      let linter_builder = LinterBuilder::default()
-        .rules(rules.clone());
+      let linter_builder = LinterBuilder::default().rules(rules.clone());
 
       let linter = linter_builder.build();
 
-      let (parsed_source, diagnostics) =
-        linter.lint(file_path.to_string_lossy().to_string(), source_code, MediaType::from_path(file_path))?;
+      let (parsed_source, diagnostics) = linter.lint(
+        file_path.to_string_lossy().to_string(),
+        source_code,
+        MediaType::from_path(file_path),
+      )?;
 
       error_counts.fetch_add(diagnostics.len(), Ordering::Relaxed);
 

--- a/examples/dlint/main.rs
+++ b/examples/dlint/main.rs
@@ -98,10 +98,10 @@ fn run_linter(
   let linter_builder = LinterBuilder::default().rules(rules.clone());
 
   let linter = linter_builder.build();
-  debug!("Configured rules: {}", rules.len());
-
   if rules.is_empty() {
-    bail!("There's no rule to be run!");
+    bail!("No lint rules configured");
+  } else {
+    debug!("Configured rules: {}", rules.len());
   }
 
   paths
@@ -110,7 +110,7 @@ fn run_linter(
       let source_code = std::fs::read_to_string(file_path)?;
 
       let (parsed_source, diagnostics) =
-        linter.clone().lint_file(LintFileOptions {
+        linter.lint_file(LintFileOptions {
           filename: file_path.to_string_lossy().to_string(),
           source_code,
           media_type: MediaType::from_path(file_path),

--- a/examples/dlint/main.rs
+++ b/examples/dlint/main.rs
@@ -109,12 +109,11 @@ fn run_linter(
     .try_for_each(|file_path| -> Result<(), AnyError> {
       let source_code = std::fs::read_to_string(file_path)?;
 
-      let (parsed_source, diagnostics) =
-        linter.lint_file(LintFileOptions {
-          filename: file_path.to_string_lossy().to_string(),
-          source_code,
-          media_type: MediaType::from_path(file_path),
-        })?;
+      let (parsed_source, diagnostics) = linter.lint_file(LintFileOptions {
+        filename: file_path.to_string_lossy().to_string(),
+        source_code,
+        media_type: MediaType::from_path(file_path),
+      })?;
 
       error_counts.fetch_add(diagnostics.len(), Ordering::Relaxed);
 

--- a/examples/dlint/main.rs
+++ b/examples/dlint/main.rs
@@ -106,13 +106,12 @@ fn run_linter(
       }
 
       let linter_builder = LinterBuilder::default()
-        .rules(rules.clone())
-        .media_type(MediaType::from_path(file_path));
+        .rules(rules.clone());
 
       let linter = linter_builder.build();
 
       let (parsed_source, diagnostics) =
-        linter.lint(file_path.to_string_lossy().to_string(), source_code)?;
+        linter.lint(file_path.to_string_lossy().to_string(), source_code, MediaType::from_path(file_path))?;
 
       error_counts.fetch_add(diagnostics.len(), Ordering::Relaxed);
 

--- a/src/ast_parser.rs
+++ b/src/ast_parser.rs
@@ -1,17 +1,18 @@
 // Copyright 2020-2021 the Deno authors. All rights reserved. MIT license.
-use deno_ast::swc::parser::Syntax;
+use deno_ast::get_syntax;
 use deno_ast::Diagnostic;
 use deno_ast::MediaType;
 use deno_ast::ParsedSource;
 
 pub(crate) fn parse_program(
   file_name: &str,
-  syntax: Syntax,
+  media_type: MediaType,
   source_code: String,
 ) -> Result<ParsedSource, Diagnostic> {
+  let syntax = get_syntax(media_type);
   deno_ast::parse_program(deno_ast::ParseParams {
     specifier: file_name.to_string(),
-    media_type: MediaType::Unknown,
+    media_type,
     text_info: deno_ast::SourceTextInfo::from_string(source_code),
     capture_tokens: true,
     maybe_syntax: Some(syntax),

--- a/src/context.rs
+++ b/src/context.rs
@@ -42,9 +42,9 @@ impl<'view> Context<'view> {
       &linter_ctx.ignore_diagnostic_directive,
       program,
     );
-    // TODO(bartlomieju): both of these should use either `program` or `parsed_source`.
     let scope = Scope::analyze(program);
-    let control_flow = ControlFlow::analyze(&parsed_source);
+    let control_flow =
+      ControlFlow::analyze(program, parsed_source.unresolved_context());
 
     Self {
       file_ignore_directive,

--- a/src/context.rs
+++ b/src/context.rs
@@ -2,10 +2,8 @@
 use crate::control_flow::ControlFlow;
 use crate::diagnostic::{LintDiagnostic, Position, Range};
 use crate::ignore_directives::{
-  parse_file_ignore_directives, parse_line_ignore_directives,
-};
-use crate::ignore_directives::{
-  CodeStatus, FileIgnoreDirective, LineIgnoreDirective,
+  parse_line_ignore_directives, CodeStatus, FileIgnoreDirective,
+  LineIgnoreDirective,
 };
 use crate::linter::LinterContext;
 use crate::rules::{self, get_all_rules, LintRule};

--- a/src/context.rs
+++ b/src/context.rs
@@ -42,6 +42,7 @@ impl<'view> Context<'view> {
     control_flow: ControlFlow,
     check_unknown_rules: bool,
   ) -> Self {
+    eprintln!("media type {:?}", parsed_source.media_type());
     let media_type = parsed_source.media_type();
     Self {
       parsed_source,

--- a/src/context.rs
+++ b/src/context.rs
@@ -21,7 +21,6 @@ use std::time::Instant;
 /// `Context` stores all data needed to perform linting of a particular file.
 pub struct Context<'view> {
   parsed_source: ParsedSource,
-  media_type: MediaType,
   diagnostics: Vec<LintDiagnostic>,
   program: ast_view::Program<'view>,
   file_ignore_directive: Option<FileIgnoreDirective>,
@@ -39,7 +38,6 @@ impl<'view> Context<'view> {
     program: ast_view::Program<'view>,
     file_ignore_directive: Option<FileIgnoreDirective>,
   ) -> Self {
-    let media_type = parsed_source.media_type();
     let line_ignore_directives = parse_line_ignore_directives(
       &linter_ctx.ignore_diagnostic_directive,
       program,
@@ -49,7 +47,6 @@ impl<'view> Context<'view> {
     let control_flow = ControlFlow::analyze(&parsed_source);
 
     Self {
-      media_type,
       file_ignore_directive,
       line_ignore_directives,
       scope,
@@ -70,7 +67,7 @@ impl<'view> Context<'view> {
   /// The media type which linter was configured with. Can be used
   /// to skip checking some rules.
   pub fn media_type(&self) -> MediaType {
-    self.media_type
+    self.parsed_source.media_type()
   }
 
   /// Stores diagnostics that are generated while linting

--- a/src/context.rs
+++ b/src/context.rs
@@ -42,7 +42,6 @@ impl<'view> Context<'view> {
     control_flow: ControlFlow,
     check_unknown_rules: bool,
   ) -> Self {
-    eprintln!("media type {:?}", parsed_source.media_type());
     let media_type = parsed_source.media_type();
     Self {
       parsed_source,

--- a/src/context.rs
+++ b/src/context.rs
@@ -35,7 +35,6 @@ impl<'view> Context<'view> {
   #[allow(clippy::too_many_arguments)]
   pub(crate) fn new(
     parsed_source: ParsedSource,
-    media_type: MediaType,
     program: ast_view::Program<'view>,
     file_ignore_directive: Option<FileIgnoreDirective>,
     line_ignore_directives: HashMap<usize, LineIgnoreDirective>,
@@ -43,6 +42,7 @@ impl<'view> Context<'view> {
     control_flow: ControlFlow,
     check_unknown_rules: bool,
   ) -> Self {
+    let media_type = parsed_source.media_type();
     Self {
       parsed_source,
       media_type,

--- a/src/control_flow/analyze_test.rs
+++ b/src/control_flow/analyze_test.rs
@@ -3,9 +3,12 @@ use super::{ControlFlow, End, Metadata};
 use crate::test_util;
 use deno_ast::StartSourcePos;
 
-fn analyze_flow(src: &str) -> ControlFlow {
+fn analyze_flow(src: &str, callback: impl Fn(ControlFlow)) {
   let parsed_source = test_util::parse(src);
-  ControlFlow::analyze(&parsed_source)
+  parsed_source.with_view(|pg| {
+    let flow = ControlFlow::analyze(pg, parsed_source.unresolved_context());
+    callback(flow);
+  });
 }
 
 macro_rules! assert_flow {
@@ -30,10 +33,11 @@ function foo() {
   return 1;
 }
       "#;
-  let flow = analyze_flow(src);
-  assert_flow!(flow, 16, false, Some(End::forced_return())); // BlockStmt of `foo`
-  assert_flow!(flow, 30, false, Some(End::Continue)); // BlockStmt of while
-  assert_flow!(flow, 49, false, Some(End::forced_return())); // return stmt
+  analyze_flow(src, |flow| {
+    assert_flow!(flow, 16, false, Some(End::forced_return())); // BlockStmt of `foo`
+    assert_flow!(flow, 30, false, Some(End::Continue)); // BlockStmt of while
+    assert_flow!(flow, 49, false, Some(End::forced_return())); // return stmt
+  });
 }
 
 #[test]
@@ -46,10 +50,11 @@ function foo() {
   bar();
 }
       "#;
-  let flow = analyze_flow(src);
-  assert_flow!(flow, 16, false, Some(End::Continue)); // BlockStmt of `foo`
-  assert_flow!(flow, 30, false, Some(End::Continue)); // BlockStmt of while
-  assert_flow!(flow, 49, false, None); // `bar();`
+  analyze_flow(src, |flow| {
+    assert_flow!(flow, 16, false, Some(End::Continue)); // BlockStmt of `foo`
+    assert_flow!(flow, 30, false, Some(End::Continue)); // BlockStmt of while
+    assert_flow!(flow, 49, false, None); // `bar();`
+  });
 }
 
 #[test]
@@ -62,11 +67,12 @@ function foo() {
   baz();
 }
       "#;
-  let flow = analyze_flow(src);
-  assert_flow!(flow, 16, false, Some(End::Continue)); // BlockStmt of `foo`
-  assert_flow!(flow, 30, false, Some(End::Continue)); // BlockStmt of while
-  assert_flow!(flow, 36, false, None); // `bar();`
-  assert_flow!(flow, 49, false, None); // `baz();`
+  analyze_flow(src, |flow| {
+    assert_flow!(flow, 16, false, Some(End::Continue)); // BlockStmt of `foo`
+    assert_flow!(flow, 30, false, Some(End::Continue)); // BlockStmt of while
+    assert_flow!(flow, 36, false, None); // `bar();`
+    assert_flow!(flow, 49, false, None); // `baz();`
+  });
 }
 
 #[test]
@@ -79,16 +85,17 @@ function foo() {
   baz();
 }
       "#;
-  let flow = analyze_flow(src);
-  assert_flow!(flow, 16, false, Some(End::Continue)); // BlockStmt of `foo`
+  analyze_flow(src, |flow| {
+    assert_flow!(flow, 16, false, Some(End::Continue)); // BlockStmt of `foo`
 
-  // BlockStmt of while
-  // This block contains `return 1;` but whether entering the block depends on the specific value
-  // of `a`, so we treat it as `End::Continue`.
-  assert_flow!(flow, 30, false, Some(End::Continue));
+    // BlockStmt of while
+    // This block contains `return 1;` but whether entering the block depends on the specific value
+    // of `a`, so we treat it as `End::Continue`.
+    assert_flow!(flow, 30, false, Some(End::Continue));
 
-  assert_flow!(flow, 36, false, Some(End::forced_return())); // return stmt
-  assert_flow!(flow, 52, false, None); // `baz();`
+    assert_flow!(flow, 36, false, Some(End::forced_return())); // return stmt
+    assert_flow!(flow, 52, false, None); // `baz();`
+  });
 }
 
 #[test]
@@ -101,15 +108,16 @@ function foo() {
   baz();
 }
       "#;
-  let flow = analyze_flow(src);
-  assert_flow!(flow, 16, false, Some(End::forced_return())); // BlockStmt of `foo`
+  analyze_flow(src, |flow| {
+    assert_flow!(flow, 16, false, Some(End::forced_return())); // BlockStmt of `foo`
 
-  // BlockStmt of while
-  // This block contains `return 1;` and it returns `1` _unconditionally_.
-  assert_flow!(flow, 33, false, Some(End::forced_return()));
+    // BlockStmt of while
+    // This block contains `return 1;` and it returns `1` _unconditionally_.
+    assert_flow!(flow, 33, false, Some(End::forced_return()));
 
-  assert_flow!(flow, 39, false, Some(End::forced_return())); // return stmt
-  assert_flow!(flow, 55, true, None); // `baz();`
+    assert_flow!(flow, 39, false, Some(End::forced_return())); // return stmt
+    assert_flow!(flow, 55, true, None); // `baz();`
+  });
 }
 
 // https://github.com/denoland/deno_lint/issues/674
@@ -124,14 +132,15 @@ while (true) {
 }
 foo();
       "#;
-  let flow = analyze_flow(src);
-  assert_flow!(flow, 1, false, None); // while stmt
-  assert_flow!(flow, 14, false, Some(End::Continue)); // BlockStmt of while
-  assert_flow!(flow, 18, false, Some(End::Continue)); // if stmt
-  assert_flow!(flow, 32, false, Some(End::Break)); // BlockStmt of if
-  assert_flow!(flow, 38, false, Some(End::Break)); // break stmt
-  assert_flow!(flow, 51, false, Some(End::forced_throw())); // throw stmt
-  assert_flow!(flow, 79, false, None); // `foo();` (which is _reachable_ if `x` equals `42`)
+  analyze_flow(src, |flow| {
+    assert_flow!(flow, 1, false, None); // while stmt
+    assert_flow!(flow, 14, false, Some(End::Continue)); // BlockStmt of while
+    assert_flow!(flow, 18, false, Some(End::Continue)); // if stmt
+    assert_flow!(flow, 32, false, Some(End::Break)); // BlockStmt of if
+    assert_flow!(flow, 38, false, Some(End::Break)); // break stmt
+    assert_flow!(flow, 51, false, Some(End::forced_throw())); // throw stmt
+    assert_flow!(flow, 79, false, None); // `foo();` (which is _reachable_ if `x` equals `42`)
+  });
 }
 
 #[test]
@@ -144,10 +153,11 @@ function foo() {
   return 1;
 }
       "#;
-  let flow = analyze_flow(src);
-  assert_flow!(flow, 16, false, Some(End::forced_return())); // BlockStmt of `foo`
-  assert_flow!(flow, 23, false, Some(End::Continue)); // BlockStmt of do-while
-  assert_flow!(flow, 53, false, Some(End::forced_return())); // return stmt
+  analyze_flow(src, |flow| {
+    assert_flow!(flow, 16, false, Some(End::forced_return())); // BlockStmt of `foo`
+    assert_flow!(flow, 23, false, Some(End::Continue)); // BlockStmt of do-while
+    assert_flow!(flow, 53, false, Some(End::forced_return())); // return stmt
+  });
 }
 
 #[test]
@@ -160,10 +170,11 @@ function foo() {
   bar();
 }
       "#;
-  let flow = analyze_flow(src);
-  assert_flow!(flow, 16, false, Some(End::Continue)); // BlockStmt of `foo`
-  assert_flow!(flow, 23, false, Some(End::Continue)); // BlockStmt of do-while
-  assert_flow!(flow, 53, false, None); // `bar();`
+  analyze_flow(src, |flow| {
+    assert_flow!(flow, 16, false, Some(End::Continue)); // BlockStmt of `foo`
+    assert_flow!(flow, 23, false, Some(End::Continue)); // BlockStmt of do-while
+    assert_flow!(flow, 53, false, None); // `bar();`
+  });
 }
 
 #[test]
@@ -176,10 +187,11 @@ function foo() {
   baz();
 }
       "#;
-  let flow = analyze_flow(src);
-  assert_flow!(flow, 16, false, Some(End::Continue)); // BlockStmt of `foo`
-  assert_flow!(flow, 23, false, Some(End::Continue)); // BlockStmt of do-while
-  assert_flow!(flow, 53, false, None); // `bar();`
+  analyze_flow(src, |flow| {
+    assert_flow!(flow, 16, false, Some(End::Continue)); // BlockStmt of `foo`
+    assert_flow!(flow, 23, false, Some(End::Continue)); // BlockStmt of do-while
+    assert_flow!(flow, 53, false, None); // `bar();`
+  });
 }
 
 #[test]
@@ -193,19 +205,20 @@ function foo() {
   return 1;
 }
       "#;
-  let flow = analyze_flow(src);
-  assert_flow!(flow, 16, false, Some(End::forced_infinite_loop())); // BlockStmt of `foo`
-  assert_flow!(flow, 23, false, Some(End::forced_infinite_loop())); // BlockStmt of do-while
-  assert_flow!(
-    flow,
-    56,
-    true,
-    Some(End::Forced {
-      ret: true,
-      throw: false,
-      infinite_loop: true
-    })
-  ); // return stmt
+  analyze_flow(src, |flow| {
+    assert_flow!(flow, 16, false, Some(End::forced_infinite_loop())); // BlockStmt of `foo`
+    assert_flow!(flow, 23, false, Some(End::forced_infinite_loop())); // BlockStmt of do-while
+    assert_flow!(
+      flow,
+      56,
+      true,
+      Some(End::Forced {
+        ret: true,
+        throw: false,
+        infinite_loop: true
+      })
+    ); // return stmt
+  });
 }
 
 #[test]
@@ -218,10 +231,11 @@ function foo() {
   return 1;
 }
       "#;
-  let flow = analyze_flow(src);
-  assert_flow!(flow, 16, false, Some(End::forced_return())); // BlockStmt of `foo`
-  assert_flow!(flow, 23, false, Some(End::forced_return())); // BlockStmt of do-while
-  assert_flow!(flow, 56, true, Some(End::forced_return())); // return stmt
+  analyze_flow(src, |flow| {
+    assert_flow!(flow, 16, false, Some(End::forced_return())); // BlockStmt of `foo`
+    assert_flow!(flow, 23, false, Some(End::forced_return())); // BlockStmt of do-while
+    assert_flow!(flow, 56, true, Some(End::forced_return())); // return stmt
+  });
 }
 
 #[test]
@@ -234,19 +248,20 @@ function foo() {
   return 1;
 }
       "#;
-  let flow = analyze_flow(src);
-  assert_flow!(flow, 16, false, Some(End::forced_throw())); // BlockStmt of `foo`
-  assert_flow!(flow, 23, false, Some(End::forced_throw())); // BlockStmt of do-while
-  assert_flow!(
-    flow,
-    59,
-    true,
-    Some(End::Forced {
-      ret: true,
-      throw: true,
-      infinite_loop: false
-    })
-  ); // return stmt
+  analyze_flow(src, |flow| {
+    assert_flow!(flow, 16, false, Some(End::forced_throw())); // BlockStmt of `foo`
+    assert_flow!(flow, 23, false, Some(End::forced_throw())); // BlockStmt of do-while
+    assert_flow!(
+      flow,
+      59,
+      true,
+      Some(End::Forced {
+        ret: true,
+        throw: true,
+        infinite_loop: false
+      })
+    ); // return stmt
+  });
 }
 
 #[test]
@@ -259,20 +274,21 @@ function foo() {
   return 1;
 }
       "#;
-  let flow = analyze_flow(src);
-  assert_flow!(flow, 16, false, Some(End::forced_throw())); // BlockStmt of `foo`
-  assert_flow!(flow, 23, false, Some(End::forced_throw())); // BlockStmt of do-while
-  assert_flow!(flow, 29, false, Some(End::forced_throw())); // throw stmt
-  assert_flow!(
-    flow,
-    55,
-    true,
-    Some(End::Forced {
-      ret: true,
-      throw: true,
-      infinite_loop: false
-    })
-  ); // return stmt
+  analyze_flow(src, |flow| {
+    assert_flow!(flow, 16, false, Some(End::forced_throw())); // BlockStmt of `foo`
+    assert_flow!(flow, 23, false, Some(End::forced_throw())); // BlockStmt of do-while
+    assert_flow!(flow, 29, false, Some(End::forced_throw())); // throw stmt
+    assert_flow!(
+      flow,
+      55,
+      true,
+      Some(End::Forced {
+        ret: true,
+        throw: true,
+        infinite_loop: false
+      })
+    ); // return stmt
+  });
 }
 
 // https://github.com/denoland/deno_lint/issues/674
@@ -287,14 +303,15 @@ do {
 } while (true);
 foo();
       "#;
-  let flow = analyze_flow(src);
-  assert_flow!(flow, 1, false, None); // do-while stmt
-  assert_flow!(flow, 4, false, Some(End::Continue)); // BlockStmt of do-while
-  assert_flow!(flow, 8, false, Some(End::Continue)); // if stmt
-  assert_flow!(flow, 22, false, Some(End::Break)); // BlockStmt of if
-  assert_flow!(flow, 28, false, Some(End::Break)); // break stmt
-  assert_flow!(flow, 41, false, Some(End::forced_throw())); // throw stmt
-  assert_flow!(flow, 83, false, None); // `foo();` (which is _reachable_ if `x` equals `42`)
+  analyze_flow(src, |flow| {
+    assert_flow!(flow, 1, false, None); // do-while stmt
+    assert_flow!(flow, 4, false, Some(End::Continue)); // BlockStmt of do-while
+    assert_flow!(flow, 8, false, Some(End::Continue)); // if stmt
+    assert_flow!(flow, 22, false, Some(End::Break)); // BlockStmt of if
+    assert_flow!(flow, 28, false, Some(End::Break)); // break stmt
+    assert_flow!(flow, 41, false, Some(End::forced_throw())); // throw stmt
+    assert_flow!(flow, 83, false, None); // `foo();` (which is _reachable_ if `x` equals `42`)
+  });
 }
 
 #[test]
@@ -307,16 +324,17 @@ function foo() {
   bar();
 }
     "#;
-  let flow = analyze_flow(src);
-  assert_flow!(flow, 16, false, Some(End::Continue)); // BlockStmt of `foo`
+  analyze_flow(src, |flow| {
+    assert_flow!(flow, 16, false, Some(End::Continue)); // BlockStmt of `foo`
 
-  // BlockStmt of for statement
-  // This is marked as `End::Continue` because it's quite difficult to decide statically whether
-  // the program enters the block or not.
-  assert_flow!(flow, 46, false, Some(End::Continue));
+    // BlockStmt of for statement
+    // This is marked as `End::Continue` because it's quite difficult to decide statically whether
+    // the program enters the block or not.
+    assert_flow!(flow, 46, false, Some(End::Continue));
 
-  assert_flow!(flow, 52, false, Some(End::forced_return())); // return stmt
-  assert_flow!(flow, 68, false, None); // `bar();`
+    assert_flow!(flow, 52, false, Some(End::forced_return())); // return stmt
+    assert_flow!(flow, 68, false, None); // `bar();`
+  });
 }
 
 #[test]
@@ -330,11 +348,12 @@ function foo() {
   bar();
 }
     "#;
-  let flow = analyze_flow(src);
-  assert_flow!(flow, 16, false, Some(End::forced_return())); // BlockStmt of `foo`
-  assert_flow!(flow, 47, false, Some(End::forced_return())); // BlockStmt of for statement
-  assert_flow!(flow, 53, false, Some(End::forced_return())); // return stmt
-  assert_flow!(flow, 69, true, None); // `bar();`
+  analyze_flow(src, |flow| {
+    assert_flow!(flow, 16, false, Some(End::forced_return())); // BlockStmt of `foo`
+    assert_flow!(flow, 47, false, Some(End::forced_return())); // BlockStmt of for statement
+    assert_flow!(flow, 53, false, Some(End::forced_return())); // return stmt
+    assert_flow!(flow, 69, true, None); // `bar();`
+  });
 }
 
 #[test]
@@ -348,11 +367,12 @@ function foo() {
   bar();
 }
     "#;
-  let flow = analyze_flow(src);
-  assert_flow!(flow, 16, false, Some(End::forced_return())); // BlockStmt of `foo`
-  assert_flow!(flow, 42, false, Some(End::forced_return())); // BlockStmt of for statement
-  assert_flow!(flow, 48, false, Some(End::forced_return())); // return stmt
-  assert_flow!(flow, 64, true, None); // `bar();`
+  analyze_flow(src, |flow| {
+    assert_flow!(flow, 16, false, Some(End::forced_return())); // BlockStmt of `foo`
+    assert_flow!(flow, 42, false, Some(End::forced_return())); // BlockStmt of for statement
+    assert_flow!(flow, 48, false, Some(End::forced_return())); // return stmt
+    assert_flow!(flow, 64, true, None); // `bar();`
+  });
 }
 
 #[test]
@@ -366,11 +386,12 @@ function foo() {
   bar();
 }
     "#;
-  let flow = analyze_flow(src);
-  assert_flow!(flow, 16, false, Some(End::Continue)); // BlockStmt of `foo`
-  assert_flow!(flow, 48, false, Some(End::Continue)); // BlockStmt of for statement
-  assert_flow!(flow, 54, false, Some(End::forced_return())); // return stmt
-  assert_flow!(flow, 70, false, None); // `bar();`
+  analyze_flow(src, |flow| {
+    assert_flow!(flow, 16, false, Some(End::Continue)); // BlockStmt of `foo`
+    assert_flow!(flow, 48, false, Some(End::Continue)); // BlockStmt of for statement
+    assert_flow!(flow, 54, false, Some(End::forced_return())); // return stmt
+    assert_flow!(flow, 70, false, None); // `bar();`
+  });
 }
 
 // https://github.com/denoland/deno_lint/issues/674
@@ -385,14 +406,15 @@ for (let i = 0; true; i++) {
 }
 foo();
       "#;
-  let flow = analyze_flow(src);
-  assert_flow!(flow, 1, false, None); // for stmt
-  assert_flow!(flow, 28, false, Some(End::Continue)); // BlockStmt of for
-  assert_flow!(flow, 32, false, Some(End::Continue)); // if stmt
-  assert_flow!(flow, 42, false, Some(End::Break)); // BlockStmt of if
-  assert_flow!(flow, 48, false, Some(End::Break)); // break stmt
-  assert_flow!(flow, 61, false, Some(End::forced_throw())); // throw stmt
-  assert_flow!(flow, 89, false, None); // `foo();` (which is _reachable_ if `f(i)` is truthy)
+  analyze_flow(src, |flow| {
+    assert_flow!(flow, 1, false, None); // for stmt
+    assert_flow!(flow, 28, false, Some(End::Continue)); // BlockStmt of for
+    assert_flow!(flow, 32, false, Some(End::Continue)); // if stmt
+    assert_flow!(flow, 42, false, Some(End::Break)); // BlockStmt of if
+    assert_flow!(flow, 48, false, Some(End::Break)); // break stmt
+    assert_flow!(flow, 61, false, Some(End::forced_throw())); // throw stmt
+    assert_flow!(flow, 89, false, None); // `foo();` (which is _reachable_ if `f(i)` is truthy)
+  });
 }
 
 #[test]
@@ -405,11 +427,12 @@ function foo() {
   bar();
 }
     "#;
-  let flow = analyze_flow(src);
-  assert_flow!(flow, 16, false, Some(End::Continue)); // BlockStmt of `foo`
-  assert_flow!(flow, 38, false, Some(End::Continue)); // BlockStmt of for-in
-  assert_flow!(flow, 44, false, Some(End::forced_return())); // return stmt
-  assert_flow!(flow, 60, false, None); // `bar();`
+  analyze_flow(src, |flow| {
+    assert_flow!(flow, 16, false, Some(End::Continue)); // BlockStmt of `foo`
+    assert_flow!(flow, 38, false, Some(End::Continue)); // BlockStmt of for-in
+    assert_flow!(flow, 44, false, Some(End::forced_return())); // return stmt
+    assert_flow!(flow, 60, false, None); // `bar();`
+  });
 }
 
 #[test]
@@ -422,11 +445,12 @@ function foo() {
   bar();
 }
     "#;
-  let flow = analyze_flow(src);
-  assert_flow!(flow, 16, false, Some(End::Continue)); // BlockStmt of `foo`
-  assert_flow!(flow, 38, false, Some(End::Continue)); // BlockStmt of for-in
-  assert_flow!(flow, 44, false, Some(End::Break)); // return stmt
-  assert_flow!(flow, 57, false, None); // `bar();`
+  analyze_flow(src, |flow| {
+    assert_flow!(flow, 16, false, Some(End::Continue)); // BlockStmt of `foo`
+    assert_flow!(flow, 38, false, Some(End::Continue)); // BlockStmt of for-in
+    assert_flow!(flow, 44, false, Some(End::Break)); // return stmt
+    assert_flow!(flow, 57, false, None); // `bar();`
+  });
 }
 
 #[test]
@@ -439,11 +463,12 @@ function foo() {
   bar();
 }
     "#;
-  let flow = analyze_flow(src);
-  assert_flow!(flow, 16, false, Some(End::Continue)); // BlockStmt of `foo`
-  assert_flow!(flow, 38, false, Some(End::Continue)); // BlockStmt of for-of
-  assert_flow!(flow, 44, false, Some(End::forced_return())); // return stmt
-  assert_flow!(flow, 60, false, None); // `bar();`
+  analyze_flow(src, |flow| {
+    assert_flow!(flow, 16, false, Some(End::Continue)); // BlockStmt of `foo`
+    assert_flow!(flow, 38, false, Some(End::Continue)); // BlockStmt of for-of
+    assert_flow!(flow, 44, false, Some(End::forced_return())); // return stmt
+    assert_flow!(flow, 60, false, None); // `bar();`
+  });
 }
 
 #[test]
@@ -456,11 +481,12 @@ function foo() {
   bar();
 }
     "#;
-  let flow = analyze_flow(src);
-  assert_flow!(flow, 16, false, Some(End::Continue)); // BlockStmt of `foo`
-  assert_flow!(flow, 38, false, Some(End::Continue)); // BlockStmt of for-of
-  assert_flow!(flow, 44, false, Some(End::Break)); // return stmt
-  assert_flow!(flow, 57, false, None); // `bar();`
+  analyze_flow(src, |flow| {
+    assert_flow!(flow, 16, false, Some(End::Continue)); // BlockStmt of `foo`
+    assert_flow!(flow, 38, false, Some(End::Continue)); // BlockStmt of for-of
+    assert_flow!(flow, 44, false, Some(End::Break)); // return stmt
+    assert_flow!(flow, 57, false, None); // `bar();`
+  });
 }
 
 #[test]
@@ -474,13 +500,14 @@ function foo() {
   }
 }
 "#;
-  let flow = analyze_flow(src);
-  assert_flow!(flow, 16, false, Some(End::forced_return())); // BlockStmt of `foo`
-  assert_flow!(flow, 20, false, Some(End::forced_return())); // TryStmt
-  assert_flow!(flow, 24, false, Some(End::forced_return())); // BlockStmt of try
-  assert_flow!(flow, 30, false, Some(End::forced_return())); // return stmt
-  assert_flow!(flow, 52, false, Some(End::Continue)); // BlockStmt of finally
-  assert_flow!(flow, 58, false, None); // `bar();`
+  analyze_flow(src, |flow| {
+    assert_flow!(flow, 16, false, Some(End::forced_return())); // BlockStmt of `foo`
+    assert_flow!(flow, 20, false, Some(End::forced_return())); // TryStmt
+    assert_flow!(flow, 24, false, Some(End::forced_return())); // BlockStmt of try
+    assert_flow!(flow, 30, false, Some(End::forced_return())); // return stmt
+    assert_flow!(flow, 52, false, Some(End::Continue)); // BlockStmt of finally
+    assert_flow!(flow, 58, false, None); // `bar();`
+  });
 }
 
 #[test]
@@ -495,24 +522,25 @@ function foo() {
   bar();
 }
 "#;
-  let flow = analyze_flow(src);
-  assert_flow!(flow, 16, false, Some(End::forced_return())); // BlockStmt of `foo`
-  assert_flow!(
-    flow,
-    20,
-    false,
-    Some(End::Forced {
-      ret: true,
-      throw: false,
-      infinite_loop: false
-    })
-  ); // TryStmt
-  assert_flow!(flow, 24, false, Some(End::forced_throw())); // BlockStmt of try
-  assert_flow!(flow, 30, false, Some(End::forced_throw())); // throw stmt
-  assert_flow!(flow, 43, false, Some(End::forced_return())); // catch
-  assert_flow!(flow, 53, false, Some(End::forced_return())); // BlockStmt of catch
-  assert_flow!(flow, 59, false, Some(End::forced_return())); // return stmt
-  assert_flow!(flow, 75, true, None); // `bar();`
+  analyze_flow(src, |flow| {
+    assert_flow!(flow, 16, false, Some(End::forced_return())); // BlockStmt of `foo`
+    assert_flow!(
+      flow,
+      20,
+      false,
+      Some(End::Forced {
+        ret: true,
+        throw: false,
+        infinite_loop: false
+      })
+    ); // TryStmt
+    assert_flow!(flow, 24, false, Some(End::forced_throw())); // BlockStmt of try
+    assert_flow!(flow, 30, false, Some(End::forced_throw())); // throw stmt
+    assert_flow!(flow, 43, false, Some(End::forced_return())); // catch
+    assert_flow!(flow, 53, false, Some(End::forced_return())); // BlockStmt of catch
+    assert_flow!(flow, 59, false, Some(End::forced_return())); // return stmt
+    assert_flow!(flow, 75, true, None); // `bar();`
+  });
 }
 
 #[test]
@@ -527,15 +555,16 @@ function foo() {
   baz();
 }
 "#;
-  let flow = analyze_flow(src);
-  assert_flow!(flow, 16, false, Some(End::Continue)); // BlockStmt of `foo`
-  assert_flow!(flow, 20, false, Some(End::Continue)); // TryStmt
-  assert_flow!(flow, 24, false, Some(End::forced_throw())); // BlockStmt of try
-  assert_flow!(flow, 30, false, Some(End::forced_throw())); // throw stmt
-  assert_flow!(flow, 43, false, Some(End::Continue)); // catch
-  assert_flow!(flow, 53, false, Some(End::Continue)); // BlockStmt of catch
-  assert_flow!(flow, 59, false, None); // `bar();`
-  assert_flow!(flow, 72, false, None); // `baz();`
+  analyze_flow(src, |flow| {
+    assert_flow!(flow, 16, false, Some(End::Continue)); // BlockStmt of `foo`
+    assert_flow!(flow, 20, false, Some(End::Continue)); // TryStmt
+    assert_flow!(flow, 24, false, Some(End::forced_throw())); // BlockStmt of try
+    assert_flow!(flow, 30, false, Some(End::forced_throw())); // throw stmt
+    assert_flow!(flow, 43, false, Some(End::Continue)); // catch
+    assert_flow!(flow, 53, false, Some(End::Continue)); // BlockStmt of catch
+    assert_flow!(flow, 59, false, None); // `bar();`
+    assert_flow!(flow, 72, false, None); // `baz();`
+  });
 }
 
 #[test]
@@ -551,16 +580,17 @@ function foo() {
   }
 }
 "#;
-  let flow = analyze_flow(src);
-  assert_flow!(flow, 16, false, Some(End::Continue)); // BlockStmt of `foo`
-  assert_flow!(flow, 20, false, Some(End::Continue)); // TryStmt
-  assert_flow!(flow, 24, false, Some(End::forced_throw())); // BlockStmt of try
-  assert_flow!(flow, 30, false, Some(End::forced_throw())); // throw stmt
-  assert_flow!(flow, 43, false, Some(End::Continue)); // catch
-  assert_flow!(flow, 53, false, Some(End::Continue)); // BlockStmt of catch
-  assert_flow!(flow, 59, false, None); // `bar();`
-  assert_flow!(flow, 78, false, Some(End::Continue)); // BlockStmt of finally
-  assert_flow!(flow, 84, false, None); // `baz();`
+  analyze_flow(src, |flow| {
+    assert_flow!(flow, 16, false, Some(End::Continue)); // BlockStmt of `foo`
+    assert_flow!(flow, 20, false, Some(End::Continue)); // TryStmt
+    assert_flow!(flow, 24, false, Some(End::forced_throw())); // BlockStmt of try
+    assert_flow!(flow, 30, false, Some(End::forced_throw())); // throw stmt
+    assert_flow!(flow, 43, false, Some(End::Continue)); // catch
+    assert_flow!(flow, 53, false, Some(End::Continue)); // BlockStmt of catch
+    assert_flow!(flow, 59, false, None); // `bar();`
+    assert_flow!(flow, 78, false, Some(End::Continue)); // BlockStmt of finally
+    assert_flow!(flow, 84, false, None); // `baz();`
+  });
 }
 
 #[test]
@@ -577,26 +607,27 @@ function foo() {
   baz();
 }
 "#;
-  let flow = analyze_flow(src);
-  assert_flow!(flow, 16, false, Some(End::forced_return())); // BlockStmt of `foo`
-  assert_flow!(
-    flow,
-    20,
-    false,
-    Some(End::Forced {
-      ret: true,
-      throw: false,
-      infinite_loop: false
-    })
-  ); // TryStmt
-  assert_flow!(flow, 24, false, Some(End::forced_throw())); // BlockStmt of try
-  assert_flow!(flow, 30, false, Some(End::forced_throw())); // throw stmt
-  assert_flow!(flow, 43, false, Some(End::forced_return())); // catch
-  assert_flow!(flow, 53, false, Some(End::forced_return())); // BlockStmt of catch
-  assert_flow!(flow, 59, false, Some(End::forced_return())); // return stmt
-  assert_flow!(flow, 81, false, Some(End::Continue)); // BlockStmt of finally
-  assert_flow!(flow, 87, false, None); // `bar();`
-  assert_flow!(flow, 100, true, None); // `baz();`
+  analyze_flow(src, |flow| {
+    assert_flow!(flow, 16, false, Some(End::forced_return())); // BlockStmt of `foo`
+    assert_flow!(
+      flow,
+      20,
+      false,
+      Some(End::Forced {
+        ret: true,
+        throw: false,
+        infinite_loop: false
+      })
+    ); // TryStmt
+    assert_flow!(flow, 24, false, Some(End::forced_throw())); // BlockStmt of try
+    assert_flow!(flow, 30, false, Some(End::forced_throw())); // throw stmt
+    assert_flow!(flow, 43, false, Some(End::forced_return())); // catch
+    assert_flow!(flow, 53, false, Some(End::forced_return())); // BlockStmt of catch
+    assert_flow!(flow, 59, false, Some(End::forced_return())); // return stmt
+    assert_flow!(flow, 81, false, Some(End::Continue)); // BlockStmt of finally
+    assert_flow!(flow, 87, false, None); // `bar();`
+    assert_flow!(flow, 100, true, None); // `baz();`
+  });
 }
 
 #[test]
@@ -607,11 +638,12 @@ finally {
   break;
 }
 "#;
-  let flow = analyze_flow(src);
-  assert_flow!(flow, 1, false, Some(End::Break)); // try stmt
-  assert_flow!(flow, 5, false, Some(End::Continue)); // BlockStmt of try
-  assert_flow!(flow, 16, false, Some(End::Break)); // BlockStmt of finally
-  assert_flow!(flow, 20, false, Some(End::Break)); // break stmt
+  analyze_flow(src, |flow| {
+    assert_flow!(flow, 1, false, Some(End::Break)); // try stmt
+    assert_flow!(flow, 5, false, Some(End::Continue)); // BlockStmt of try
+    assert_flow!(flow, 16, false, Some(End::Break)); // BlockStmt of finally
+    assert_flow!(flow, 20, false, Some(End::Break)); // break stmt
+  });
 }
 
 #[test]
@@ -623,13 +655,14 @@ try {
   break;
 }
 "#;
-  let flow = analyze_flow(src);
-  assert_flow!(flow, 1, false, Some(End::Break)); // try stmt
-  assert_flow!(flow, 5, false, Some(End::forced_throw())); // BlockStmt of try
-  assert_flow!(flow, 9, false, Some(End::forced_throw())); // throw stmt
-  assert_flow!(flow, 20, false, Some(End::Break)); // catch
-  assert_flow!(flow, 30, false, Some(End::Break)); // BloskStmt of catch
-  assert_flow!(flow, 34, false, Some(End::Break)); // break stmt
+  analyze_flow(src, |flow| {
+    assert_flow!(flow, 1, false, Some(End::Break)); // try stmt
+    assert_flow!(flow, 5, false, Some(End::forced_throw())); // BlockStmt of try
+    assert_flow!(flow, 9, false, Some(End::forced_throw())); // throw stmt
+    assert_flow!(flow, 20, false, Some(End::Break)); // catch
+    assert_flow!(flow, 30, false, Some(End::Break)); // BloskStmt of catch
+    assert_flow!(flow, 34, false, Some(End::Break)); // break stmt
+  });
 }
 
 #[test]
@@ -639,11 +672,12 @@ try {
   break;
 } finally {}
 "#;
-  let flow = analyze_flow(src);
-  assert_flow!(flow, 1, false, Some(End::Break)); // try stmt
-  assert_flow!(flow, 5, false, Some(End::Break)); // BlockStmt of try
-  assert_flow!(flow, 9, false, Some(End::Break)); // break stmt
-  assert_flow!(flow, 26, false, Some(End::Continue)); // finally
+  analyze_flow(src, |flow| {
+    assert_flow!(flow, 1, false, Some(End::Break)); // try stmt
+    assert_flow!(flow, 5, false, Some(End::Break)); // BlockStmt of try
+    assert_flow!(flow, 9, false, Some(End::Break)); // break stmt
+    assert_flow!(flow, 26, false, Some(End::Continue)); // finally
+  });
 }
 
 #[test]
@@ -660,17 +694,18 @@ try {
 }
 bar();
 "#;
-  let flow = analyze_flow(src);
-  assert_flow!(flow, 1, false, Some(End::Continue)); // 1st try stmt
-  assert_flow!(flow, 5, false, Some(End::forced_throw())); // BlockStmt of 1st try
-  assert_flow!(flow, 9, false, Some(End::forced_throw())); // 2nd try stmt
-  assert_flow!(flow, 13, false, Some(End::forced_throw())); // BlockStmt of 2nd try
-  assert_flow!(flow, 19, false, Some(End::forced_throw())); // throw 1;
-  assert_flow!(flow, 32, false, Some(End::forced_throw())); // 1st catch
-  assert_flow!(flow, 44, false, Some(End::forced_throw())); // throw 2;
-  assert_flow!(flow, 59, false, Some(End::Continue)); // 2nd catch
-  assert_flow!(flow, 69, false, None); // `foo();`
-  assert_flow!(flow, 78, false, None); // `bar();`
+  analyze_flow(src, |flow| {
+    assert_flow!(flow, 1, false, Some(End::Continue)); // 1st try stmt
+    assert_flow!(flow, 5, false, Some(End::forced_throw())); // BlockStmt of 1st try
+    assert_flow!(flow, 9, false, Some(End::forced_throw())); // 2nd try stmt
+    assert_flow!(flow, 13, false, Some(End::forced_throw())); // BlockStmt of 2nd try
+    assert_flow!(flow, 19, false, Some(End::forced_throw())); // throw 1;
+    assert_flow!(flow, 32, false, Some(End::forced_throw())); // 1st catch
+    assert_flow!(flow, 44, false, Some(End::forced_throw())); // throw 2;
+    assert_flow!(flow, 59, false, Some(End::Continue)); // 2nd catch
+    assert_flow!(flow, 69, false, None); // `foo();`
+    assert_flow!(flow, 78, false, None); // `bar();`
+  });
 }
 
 #[test]
@@ -687,17 +722,18 @@ try {
 }
 bar();
 "#;
-  let flow = analyze_flow(src);
-  assert_flow!(flow, 1, false, Some(End::Continue)); // 1st try stmt
-  assert_flow!(flow, 5, false, Some(End::Continue)); // BlockStmt of 1st try
-  assert_flow!(flow, 9, false, Some(End::Continue)); // 2nd try stmt
-  assert_flow!(flow, 13, false, Some(End::forced_throw())); // BlockStmt of 2nd try
-  assert_flow!(flow, 19, false, Some(End::forced_throw())); // throw 1;
-  assert_flow!(flow, 32, false, Some(End::Continue)); // 1st catch
-  assert_flow!(flow, 44, false, None); // `someF();`;
-  assert_flow!(flow, 55, false, Some(End::Continue)); // 2nd catch
-  assert_flow!(flow, 65, false, None); // `foo();`
-  assert_flow!(flow, 74, false, None); // `bar();`
+  analyze_flow(src, |flow| {
+    assert_flow!(flow, 1, false, Some(End::Continue)); // 1st try stmt
+    assert_flow!(flow, 5, false, Some(End::Continue)); // BlockStmt of 1st try
+    assert_flow!(flow, 9, false, Some(End::Continue)); // 2nd try stmt
+    assert_flow!(flow, 13, false, Some(End::forced_throw())); // BlockStmt of 2nd try
+    assert_flow!(flow, 19, false, Some(End::forced_throw())); // throw 1;
+    assert_flow!(flow, 32, false, Some(End::Continue)); // 1st catch
+    assert_flow!(flow, 44, false, None); // `someF();`;
+    assert_flow!(flow, 55, false, Some(End::Continue)); // 2nd catch
+    assert_flow!(flow, 65, false, None); // `foo();`
+    assert_flow!(flow, 74, false, None); // `bar();`
+  });
 }
 
 #[test]
@@ -711,15 +747,16 @@ try {
   return;
 }
 "#;
-  let flow = analyze_flow(src);
-  assert_flow!(flow, 1, false, Some(End::forced_return())); // try stmt
-  assert_flow!(flow, 5, false, Some(End::forced_throw())); // BlockStmt of try
-  assert_flow!(flow, 9, false, Some(End::forced_throw())); // throw stmt
-  assert_flow!(flow, 20, false, Some(End::Break)); // catch
-  assert_flow!(flow, 30, false, Some(End::Break)); // BloskStmt of catch
-  assert_flow!(flow, 34, false, Some(End::Break)); // break stmt
-  assert_flow!(flow, 51, false, Some(End::forced_return())); // finally
-  assert_flow!(flow, 55, false, Some(End::forced_return())); // return stmt
+  analyze_flow(src, |flow| {
+    assert_flow!(flow, 1, false, Some(End::forced_return())); // try stmt
+    assert_flow!(flow, 5, false, Some(End::forced_throw())); // BlockStmt of try
+    assert_flow!(flow, 9, false, Some(End::forced_throw())); // throw stmt
+    assert_flow!(flow, 20, false, Some(End::Break)); // catch
+    assert_flow!(flow, 30, false, Some(End::Break)); // BloskStmt of catch
+    assert_flow!(flow, 34, false, Some(End::Break)); // break stmt
+    assert_flow!(flow, 51, false, Some(End::forced_return())); // finally
+    assert_flow!(flow, 55, false, Some(End::forced_return())); // return stmt
+  });
 }
 
 #[test]
@@ -732,12 +769,13 @@ function foo() {
   bar();
 }
 "#;
-  let flow = analyze_flow(src);
-  assert_flow!(flow, 16, false, Some(End::Continue)); // BlockStmt of `foo`
-  assert_flow!(flow, 20, false, Some(End::Continue)); // if
-  assert_flow!(flow, 27, false, Some(End::forced_return())); // BloskStmt of if
-  assert_flow!(flow, 33, false, Some(End::forced_return())); // return stmt
-  assert_flow!(flow, 49, false, None); // `bar();`
+  analyze_flow(src, |flow| {
+    assert_flow!(flow, 16, false, Some(End::Continue)); // BlockStmt of `foo`
+    assert_flow!(flow, 20, false, Some(End::Continue)); // if
+    assert_flow!(flow, 27, false, Some(End::forced_return())); // BloskStmt of if
+    assert_flow!(flow, 33, false, Some(End::forced_return())); // return stmt
+    assert_flow!(flow, 49, false, None); // `bar();`
+  });
 }
 
 #[test]
@@ -752,14 +790,15 @@ function foo() {
   baz();
 }
 "#;
-  let flow = analyze_flow(src);
-  assert_flow!(flow, 16, false, Some(End::Continue)); // BlockStmt of `foo`
-  assert_flow!(flow, 20, false, Some(End::Continue)); // if
-  assert_flow!(flow, 27, false, Some(End::Continue)); // BloskStmt of if
-  assert_flow!(flow, 33, false, None); // `bar();`
-  assert_flow!(flow, 49, false, Some(End::forced_return())); // else
-  assert_flow!(flow, 55, false, Some(End::forced_return())); // return stmt
-  assert_flow!(flow, 71, false, None); // `baz();`
+  analyze_flow(src, |flow| {
+    assert_flow!(flow, 16, false, Some(End::Continue)); // BlockStmt of `foo`
+    assert_flow!(flow, 20, false, Some(End::Continue)); // if
+    assert_flow!(flow, 27, false, Some(End::Continue)); // BloskStmt of if
+    assert_flow!(flow, 33, false, None); // `bar();`
+    assert_flow!(flow, 49, false, Some(End::forced_return())); // else
+    assert_flow!(flow, 55, false, Some(End::forced_return())); // return stmt
+    assert_flow!(flow, 71, false, None); // `baz();`
+  });
 }
 
 #[test]
@@ -774,14 +813,15 @@ function foo() {
   return 0;
 }
 "#;
-  let flow = analyze_flow(src);
-  assert_flow!(flow, 16, false, Some(End::forced_return())); // BlockStmt of `foo`
-  assert_flow!(flow, 20, false, Some(End::Continue)); // if
-  assert_flow!(flow, 27, false, Some(End::forced_return())); // BloskStmt of if
-  assert_flow!(flow, 33, false, Some(End::forced_return())); // `return 1;`
-  assert_flow!(flow, 52, false, Some(End::Continue)); // else
-  assert_flow!(flow, 58, false, None); // `bar();`
-  assert_flow!(flow, 71, false, Some(End::forced_return())); // `return 0;`
+  analyze_flow(src, |flow| {
+    assert_flow!(flow, 16, false, Some(End::forced_return())); // BlockStmt of `foo`
+    assert_flow!(flow, 20, false, Some(End::Continue)); // if
+    assert_flow!(flow, 27, false, Some(End::forced_return())); // BloskStmt of if
+    assert_flow!(flow, 33, false, Some(End::forced_return())); // `return 1;`
+    assert_flow!(flow, 52, false, Some(End::Continue)); // else
+    assert_flow!(flow, 58, false, None); // `bar();`
+    assert_flow!(flow, 71, false, Some(End::forced_return())); // `return 0;`
+  });
 }
 
 #[test]
@@ -799,17 +839,18 @@ switch (foo) {
 }
 throw err;
 "#;
-  let flow = analyze_flow(src);
-  assert_flow!(flow, 1, false, Some(End::Continue)); // switch stmt
-  assert_flow!(flow, 18, false, Some(End::forced_return())); // `case 1`
-  assert_flow!(flow, 30, false, Some(End::forced_return())); // return stmt
-  assert_flow!(flow, 42, false, Some(End::Break)); // `default`
-  assert_flow!(flow, 51, false, Some(End::forced_return())); // BlockStmt of `default`
-  assert_flow!(flow, 57, false, Some(End::Continue)); // if
-  assert_flow!(flow, 66, false, Some(End::Break)); // BlockStmt of if
-  assert_flow!(flow, 74, false, Some(End::Break)); // break stmt
-  assert_flow!(flow, 91, false, Some(End::forced_return())); // return stmt
-  assert_flow!(flow, 107, false, Some(End::forced_throw())); // throw stmt
+  analyze_flow(src, |flow| {
+    assert_flow!(flow, 1, false, Some(End::Continue)); // switch stmt
+    assert_flow!(flow, 18, false, Some(End::forced_return())); // `case 1`
+    assert_flow!(flow, 30, false, Some(End::forced_return())); // return stmt
+    assert_flow!(flow, 42, false, Some(End::Break)); // `default`
+    assert_flow!(flow, 51, false, Some(End::forced_return())); // BlockStmt of `default`
+    assert_flow!(flow, 57, false, Some(End::Continue)); // if
+    assert_flow!(flow, 66, false, Some(End::Break)); // BlockStmt of if
+    assert_flow!(flow, 74, false, Some(End::Break)); // break stmt
+    assert_flow!(flow, 91, false, Some(End::forced_return())); // return stmt
+    assert_flow!(flow, 107, false, Some(End::forced_throw())); // throw stmt
+  });
 }
 
 #[test]
@@ -824,23 +865,24 @@ switch (foo) {
 }
 throw err;
 "#;
-  let flow = analyze_flow(src);
-  assert_flow!(flow, 1, false, Some(End::forced_return())); // switch stmt
-  assert_flow!(flow, 18, false, Some(End::forced_return())); // `case 1`
-  assert_flow!(flow, 30, false, Some(End::forced_return())); // return stmt
-  assert_flow!(flow, 42, false, Some(End::forced_return())); // `default`
-  assert_flow!(flow, 51, false, Some(End::forced_return())); // BlockStmt of `default`
-  assert_flow!(flow, 57, false, Some(End::forced_return())); // return stmt
-  assert_flow!(
-    flow,
-    73,
-    true,
-    Some(End::Forced {
-      ret: true,
-      throw: true,
-      infinite_loop: false
-    })
-  ); // throw stmt
+  analyze_flow(src, |flow| {
+    assert_flow!(flow, 1, false, Some(End::forced_return())); // switch stmt
+    assert_flow!(flow, 18, false, Some(End::forced_return())); // `case 1`
+    assert_flow!(flow, 30, false, Some(End::forced_return())); // return stmt
+    assert_flow!(flow, 42, false, Some(End::forced_return())); // `default`
+    assert_flow!(flow, 51, false, Some(End::forced_return())); // BlockStmt of `default`
+    assert_flow!(flow, 57, false, Some(End::forced_return())); // return stmt
+    assert_flow!(
+      flow,
+      73,
+      true,
+      Some(End::Forced {
+        ret: true,
+        throw: true,
+        infinite_loop: false
+      })
+    ); // throw stmt
+  });
 }
 
 #[test]
@@ -855,14 +897,15 @@ switch (foo) {
 }
 throw err;
 "#;
-  let flow = analyze_flow(src);
-  assert_flow!(flow, 1, false, Some(End::Continue)); // switch stmt
-  assert_flow!(flow, 18, false, Some(End::Break)); // `case 1`
-  assert_flow!(flow, 30, false, Some(End::Break)); // break stmt
-  assert_flow!(flow, 39, false, Some(End::forced_return())); // `default`
-  assert_flow!(flow, 48, false, Some(End::forced_return())); // BlockStmt of `default`
-  assert_flow!(flow, 54, false, Some(End::forced_return())); // return stmt
-  assert_flow!(flow, 70, false, Some(End::forced_throw())); // throw stmt
+  analyze_flow(src, |flow| {
+    assert_flow!(flow, 1, false, Some(End::Continue)); // switch stmt
+    assert_flow!(flow, 18, false, Some(End::Break)); // `case 1`
+    assert_flow!(flow, 30, false, Some(End::Break)); // break stmt
+    assert_flow!(flow, 39, false, Some(End::forced_return())); // `default`
+    assert_flow!(flow, 48, false, Some(End::forced_return())); // BlockStmt of `default`
+    assert_flow!(flow, 54, false, Some(End::forced_return())); // return stmt
+    assert_flow!(flow, 70, false, Some(End::forced_throw())); // throw stmt
+  });
 }
 
 // https://github.com/denoland/deno_lint/issues/823
@@ -880,15 +923,16 @@ switch (foo) {
     return 0;
   }
 }"#;
-  let flow = analyze_flow(src);
-  assert_flow!(flow, 1, false, Some(End::forced_return())); // switch foo stmt
-  assert_flow!(flow, 18, false, Some(End::forced_return())); // `switch foo case 1`
-  assert_flow!(flow, 30, false, Some(End::Continue)); // `switch bar stmt`
-  assert_flow!(flow, 51, false, Some(End::Break)); // `switch bar case1`
-  assert_flow!(flow, 67, false, Some(End::Break)); // `break stmt`
-  assert_flow!(flow, 84, false, Some(End::forced_return())); // `return stmt`
-  assert_flow!(flow, 96, false, Some(End::forced_return())); // `default`
-  assert_flow!(flow, 111, false, Some(End::forced_return())); // `return stmt`
+  analyze_flow(src, |flow| {
+    assert_flow!(flow, 1, false, Some(End::forced_return())); // switch foo stmt
+    assert_flow!(flow, 18, false, Some(End::forced_return())); // `switch foo case 1`
+    assert_flow!(flow, 30, false, Some(End::Continue)); // `switch bar stmt`
+    assert_flow!(flow, 51, false, Some(End::Break)); // `switch bar case1`
+    assert_flow!(flow, 67, false, Some(End::Break)); // `break stmt`
+    assert_flow!(flow, 84, false, Some(End::forced_return())); // `return stmt`
+    assert_flow!(flow, 96, false, Some(End::forced_return())); // `default`
+    assert_flow!(flow, 111, false, Some(End::forced_return())); // `return stmt`
+  });
 }
 
 // https://github.com/denoland/deno_lint/issues/644
@@ -905,7 +949,7 @@ function bar() {
 "#;
 
   // Confirms that no panic happens even if there's invalid `break` or `continue` statement
-  let _ = analyze_flow(src);
+  analyze_flow(src, |_flow| {});
 }
 
 #[test]
@@ -921,17 +965,18 @@ function foo() {
   }
 }
       "#;
-  let flow = analyze_flow(src);
-  assert_flow!(flow, 1, false, Some(End::Continue)); // function
-  assert_flow!(flow, 16, false, Some(End::Continue)); // BlockStmt of `foo`
-  assert_flow!(flow, 20, false, Some(End::Continue)); // if stmt
-  assert_flow!(flow, 30, false, Some(End::Continue)); // BlockStmt of if
-  assert_flow!(flow, 38, false, Some(End::Continue)); // BlockStmt of else
-  assert_flow!(flow, 43, false, Some(End::Continue)); // try stmt
-  assert_flow!(flow, 47, false, Some(End::forced_return())); // BlockStmt of try
-  assert_flow!(flow, 53, false, None); // `bar();`
-  assert_flow!(flow, 64, false, Some(End::forced_return())); // return stmt
-  assert_flow!(flow, 79, false, Some(End::Continue)); // catch clause
-  assert_flow!(flow, 91, false, Some(End::Continue)); // BlockStmt of catch
-  assert_flow!(flow, 97, false, None); // `console.error(err);`
+  analyze_flow(src, |flow| {
+    assert_flow!(flow, 1, false, Some(End::Continue)); // function
+    assert_flow!(flow, 16, false, Some(End::Continue)); // BlockStmt of `foo`
+    assert_flow!(flow, 20, false, Some(End::Continue)); // if stmt
+    assert_flow!(flow, 30, false, Some(End::Continue)); // BlockStmt of if
+    assert_flow!(flow, 38, false, Some(End::Continue)); // BlockStmt of else
+    assert_flow!(flow, 43, false, Some(End::Continue)); // try stmt
+    assert_flow!(flow, 47, false, Some(End::forced_return())); // BlockStmt of try
+    assert_flow!(flow, 53, false, None); // `bar();`
+    assert_flow!(flow, 64, false, Some(End::forced_return())); // return stmt
+    assert_flow!(flow, 79, false, Some(End::Continue)); // catch clause
+    assert_flow!(flow, 91, false, Some(End::Continue)); // BlockStmt of catch
+    assert_flow!(flow, 97, false, None); // `console.error(err);`
+  });
 }

--- a/src/control_flow/mod.rs
+++ b/src/control_flow/mod.rs
@@ -3,14 +3,16 @@
 #[cfg(test)]
 mod analyze_test;
 
+use deno_ast::view;
 use deno_ast::swc::ast::*;
+use deno_ast::swc::common::SyntaxContext;
 use deno_ast::swc::utils::ExprCtx;
 use deno_ast::swc::{
   utils::{ExprExt, Value},
   visit::{noop_visit_type, Visit, VisitWith},
 };
 use deno_ast::SourceRangedForSpanned;
-use deno_ast::{ParsedSource, SourcePos};
+use deno_ast::SourcePos;
 use std::{
   collections::{BTreeMap, HashSet},
   mem::take,
@@ -22,18 +24,21 @@ pub struct ControlFlow {
 }
 
 impl ControlFlow {
-  pub fn analyze(parsed_source: &ParsedSource) -> Self {
+  pub fn analyze(
+    program: view::Program,
+    unresolved_ctxt: SyntaxContext,
+  ) -> Self {
     let mut v = Analyzer {
       scope: Scope::new(None, BlockKind::Program),
       info: Default::default(),
       expr_ctxt: ExprCtx {
-        unresolved_ctxt: parsed_source.unresolved_context(),
+        unresolved_ctxt,
         is_unresolved_ref_safe: false,
       },
     };
-    match parsed_source.program_ref() {
-      Program::Module(module) => module.visit_with(&mut v),
-      Program::Script(script) => script.visit_with(&mut v),
+    match program {
+      view::Program::Module(module) => module.inner.visit_with(&mut v),
+      view::Program::Script(script) => script.inner.visit_with(&mut v),
     }
     ControlFlow { meta: v.info }
   }

--- a/src/control_flow/mod.rs
+++ b/src/control_flow/mod.rs
@@ -3,7 +3,6 @@
 #[cfg(test)]
 mod analyze_test;
 
-use deno_ast::view;
 use deno_ast::swc::ast::*;
 use deno_ast::swc::common::SyntaxContext;
 use deno_ast::swc::utils::ExprCtx;
@@ -11,8 +10,9 @@ use deno_ast::swc::{
   utils::{ExprExt, Value},
   visit::{noop_visit_type, Visit, VisitWith},
 };
-use deno_ast::SourceRangedForSpanned;
+use deno_ast::view;
 use deno_ast::SourcePos;
+use deno_ast::SourceRangedForSpanned;
 use std::{
   collections::{BTreeMap, HashSet},
   mem::take,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,7 +32,7 @@ mod lint_tests {
   use crate::linter::*;
   use crate::rules::{get_recommended_rules, LintRule};
   use crate::test_util::{assert_diagnostic, parse};
-  use deno_ast::ParsedSource;
+  use deno_ast::{ParsedSource, MediaType};
 
   fn lint(
     source: &str,
@@ -41,7 +41,7 @@ mod lint_tests {
     let linter = LinterBuilder::default().rules(rules).build();
 
     let (_, diagnostics) = linter
-      .lint("lint_test.ts".to_string(), source.to_string())
+      .lint("lint_test.ts".to_string(), source.to_string(), MediaType::TypeScript)
       .expect("Failed to lint");
     diagnostics
   }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,11 +41,11 @@ mod lint_tests {
     let linter = LinterBuilder::default().rules(rules).build();
 
     let (_, diagnostics) = linter
-      .lint(
-        "lint_test.ts".to_string(),
-        source.to_string(),
-        MediaType::TypeScript,
-      )
+      .lint_file(LintFileOptions {
+        filename: "lint_test.ts".to_string(),
+        source_code: source.to_string(),
+        media_type: MediaType::TypeScript,
+      })
       .expect("Failed to lint");
     diagnostics
   }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,7 +32,8 @@ mod lint_tests {
   use crate::linter::*;
   use crate::rules::{get_recommended_rules, LintRule};
   use crate::test_util::{assert_diagnostic, parse};
-  use deno_ast::{MediaType, ParsedSource};
+  use deno_ast::MediaType;
+  use deno_ast::ParsedSource;
 
   fn lint(
     source: &str,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,7 +32,7 @@ mod lint_tests {
   use crate::linter::*;
   use crate::rules::{get_recommended_rules, LintRule};
   use crate::test_util::{assert_diagnostic, parse};
-  use deno_ast::{ParsedSource, MediaType};
+  use deno_ast::{MediaType, ParsedSource};
 
   fn lint(
     source: &str,
@@ -41,7 +41,11 @@ mod lint_tests {
     let linter = LinterBuilder::default().rules(rules).build();
 
     let (_, diagnostics) = linter
-      .lint("lint_test.ts".to_string(), source.to_string(), MediaType::TypeScript)
+      .lint(
+        "lint_test.ts".to_string(),
+        source.to_string(),
+        MediaType::TypeScript,
+      )
       .expect("Failed to lint");
     diagnostics
   }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,7 @@ mod handler;
 mod ignore_directives;
 mod js_regex;
 pub mod linter;
+mod performance_mark;
 pub mod rules;
 pub mod swc_util;
 

--- a/src/linter.rs
+++ b/src/linter.rs
@@ -122,7 +122,7 @@ impl Linter {
   }
 
   pub fn lint_file(
-    mut self,
+    &self,
     options: LintFileOptions,
   ) -> Result<(ParsedSource, Vec<LintDiagnostic>), Diagnostic> {
     let _mark = PerformanceMark::new("Linter::lint");
@@ -139,7 +139,7 @@ impl Linter {
   }
 
   pub fn lint_with_ast(
-    mut self,
+    &self,
     parsed_source: &ParsedSource,
   ) -> Vec<LintDiagnostic> {
     let _mark = PerformanceMark::new("Linter::lint_with_ast");
@@ -162,7 +162,7 @@ impl Linter {
   }
 
   fn lint_program(
-    &mut self,
+    &self,
     parsed_source: &ParsedSource,
   ) -> Vec<LintDiagnostic> {
     let _mark = PerformanceMark::new("Linter::lint_program");

--- a/src/linter.rs
+++ b/src/linter.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 // Copyright 2020-2021 the Deno authors. All rights reserved. MIT license.
 use crate::ast_parser::parse_program;
 use crate::context::Context;
@@ -63,8 +65,10 @@ impl LinterBuilder {
   }
 }
 
+/// A linter instance. It can be cheaply cloned and shared between threads.
+#[derive(Clone)]
 pub struct Linter {
-  ctx: LinterContext,
+  ctx: Arc<LinterContext>,
 }
 
 /// TODO(bartlomieju): docstring
@@ -114,7 +118,7 @@ impl Linter {
       rules,
     );
 
-    Linter { ctx }
+    Linter { ctx: Arc::new(ctx) }
   }
 
   pub fn lint_file(

--- a/src/linter.rs
+++ b/src/linter.rs
@@ -67,7 +67,7 @@ pub struct Linter {
   ctx: LinterContext,
 }
 
-/// TODO
+/// TODO(bartlomieju): docstring
 pub struct LinterContext {
   ignore_file_directive: String,
   ignore_diagnostic_directive: String,

--- a/src/linter.rs
+++ b/src/linter.rs
@@ -1,5 +1,3 @@
-use std::sync::Arc;
-
 // Copyright 2020-2021 the Deno authors. All rights reserved. MIT license.
 use crate::ast_parser::parse_program;
 use crate::context::Context;
@@ -14,6 +12,7 @@ use deno_ast::Diagnostic;
 use deno_ast::MediaType;
 use deno_ast::ParsedSource;
 use deno_ast::Scope;
+use std::sync::Arc;
 
 pub struct LinterBuilder {
   ignore_file_directive: String,

--- a/src/linter.rs
+++ b/src/linter.rs
@@ -96,6 +96,12 @@ impl LinterContext {
   }
 }
 
+pub struct LintFileOptions {
+  pub filename: String,
+  pub source_code: String,
+  pub media_type: MediaType,
+}
+
 impl Linter {
   fn new(
     ignore_file_directive: String,
@@ -111,19 +117,15 @@ impl Linter {
     Linter { ctx }
   }
 
-  // TODO(bartlomieju): rename to `lint_file`, accept `LintOptions` instead
-  // of free floating args
-  pub fn lint(
+  pub fn lint_file(
     mut self,
-    file_name: String,
-    source_code: String,
-    media_type: MediaType,
+    options: LintFileOptions,
   ) -> Result<(ParsedSource, Vec<LintDiagnostic>), Diagnostic> {
     let _mark = PerformanceMark::new("Linter::lint");
 
     let parse_result = {
       let _mark = PerformanceMark::new("ast_parser.parse_program");
-      parse_program(&file_name, media_type, source_code)
+      parse_program(&options.filename, options.media_type, options.source_code)
     };
 
     let parsed_source = parse_result?;

--- a/src/linter.rs
+++ b/src/linter.rs
@@ -121,10 +121,9 @@ impl Linter {
   ) -> Result<(ParsedSource, Vec<LintDiagnostic>), Diagnostic> {
     let _mark = PerformanceMark::new("Linter::lint");
 
-    let syntax = deno_ast::get_syntax(media_type);
     let parse_result = {
       let _mark = PerformanceMark::new("ast_parser.parse_program");
-      parse_program(&file_name, syntax, source_code)
+      parse_program(&file_name, media_type, source_code)
     };
 
     let parsed_source = parse_result?;

--- a/src/performance_mark.rs
+++ b/src/performance_mark.rs
@@ -2,9 +2,9 @@
 
 use std::time::Instant;
 
-/// A struct to keep mesaure how long a function takes to execute.
+/// A struct to measure how long a function takes to execute.
 ///
-/// When the struct is dropped, `debug!` is used print the measurement.
+/// When the struct is dropped, `debug!` is used to print the measurement.
 pub struct PerformanceMark {
   name: String,
   start: Instant,

--- a/src/performance_mark.rs
+++ b/src/performance_mark.rs
@@ -1,0 +1,27 @@
+// Copyright 2020-2021 the Deno authors. All rights reserved. MIT license.
+
+use std::time::Instant;
+
+/// A struct to keep mesaure how long a function takes to execute.
+///
+/// When the struct is dropped, `debug!` is used print the measurement.
+pub struct PerformanceMark {
+  name: String,
+  start: Instant,
+}
+
+impl PerformanceMark {
+  pub fn new(name: &str) -> Self {
+    Self {
+      name: name.to_string(),
+      start: Instant::now(),
+    }
+  }
+}
+
+impl Drop for PerformanceMark {
+  fn drop(&mut self) {
+    let end = Instant::now();
+    debug!("{} took {:#?}", self.name, end - self.start);
+  }
+}

--- a/src/test_util.rs
+++ b/src/test_util.rs
@@ -285,11 +285,10 @@ fn lint(
   filename: &str,
 ) -> Vec<LintDiagnostic> {
   let linter = LinterBuilder::default()
-    .media_type(MediaType::from_path(Path::new(filename)))
     .rules(vec![rule])
     .build();
 
-  match linter.lint(filename.to_string(), source.to_string()) {
+  match linter.lint(filename.to_string(), source.to_string(), MediaType::from_path(Path::new(filename))) {
     Ok((_, diagnostics)) => diagnostics,
     Err(e) => panic!(
       "Failed to lint.\n[cause]\n{}\n\n[source code]\n{}",

--- a/src/test_util.rs
+++ b/src/test_util.rs
@@ -2,6 +2,7 @@
 
 use crate::ast_parser;
 use crate::diagnostic::LintDiagnostic;
+use crate::linter::LintFileOptions;
 use crate::linter::LinterBuilder;
 use crate::rules::LintRule;
 use deno_ast::view as ast_view;
@@ -286,11 +287,12 @@ fn lint(
 ) -> Vec<LintDiagnostic> {
   let linter = LinterBuilder::default().rules(vec![rule]).build();
 
-  match linter.lint(
-    filename.to_string(),
-    source.to_string(),
-    MediaType::from_path(Path::new(filename)),
-  ) {
+  let lint_result = linter.lint_file(LintFileOptions {
+    filename: filename.to_string(),
+    source_code: source.to_string(),
+    media_type: MediaType::from_path(Path::new(filename)),
+  });
+  match lint_result {
     Ok((_, diagnostics)) => diagnostics,
     Err(e) => panic!(
       "Failed to lint.\n[cause]\n{}\n\n[source code]\n{}",

--- a/src/test_util.rs
+++ b/src/test_util.rs
@@ -284,11 +284,13 @@ fn lint(
   source: &str,
   filename: &str,
 ) -> Vec<LintDiagnostic> {
-  let linter = LinterBuilder::default()
-    .rules(vec![rule])
-    .build();
+  let linter = LinterBuilder::default().rules(vec![rule]).build();
 
-  match linter.lint(filename.to_string(), source.to_string(), MediaType::from_path(Path::new(filename))) {
+  match linter.lint(
+    filename.to_string(),
+    source.to_string(),
+    MediaType::from_path(Path::new(filename)),
+  ) {
     Ok((_, diagnostics)) => diagnostics,
     Err(e) => panic!(
       "Failed to lint.\n[cause]\n{}\n\n[source code]\n{}",
@@ -372,6 +374,7 @@ pub fn assert_lint_ok(
 ) {
   let diagnostics = lint(rule, source, filename);
   if !diagnostics.is_empty() {
+    eprintln!("filename {:?}", filename);
     panic!(
       "Unexpected diagnostics found:\n{:#?}\n\nsource:\n{}\n",
       diagnostics, source
@@ -389,7 +392,7 @@ const TEST_FILE_NAME: &str = "lint_test.ts";
 pub fn parse(source_code: &str) -> ParsedSource {
   ast_parser::parse_program(
     TEST_FILE_NAME,
-    deno_ast::get_syntax(MediaType::TypeScript),
+    MediaType::TypeScript,
     source_code.to_string(),
   )
   .unwrap()


### PR DESCRIPTION
This is just a cleanup in preparation for another plugin system prototype.

With this commit "Linter" is a struct that should be created only once and used
to lint many files, instead of creating a new instance for every single file.

The API was changed to "Linter::lint_file" that accepts a "LintFileOptions".