### PR TITLE
fix: wrong hint for deprecated Deno APIs

### DIFF
--- a/src/rules/no_deprecated_deno_api.rs
+++ b/src/rules/no_deprecated_deno_api.rs
@@ -178,21 +178,16 @@ impl DeprecatedApi {
       Iter => Name(STREAMS_REDABLE_TS),
       IterSync => Name(STREAMS_REDABLE_TS),
       File => Name("Deno.FsFile"),
-      ReadAll => NameAndUrls(vec![
-        ("ReadableStream", STREAMS_REDABLE_TS),
-        ("toArrayBuffer()", STREAMS_TO_ARRAY_BUFFER_TS),
-      ]),
-      ReadAllSync => NameAndUrls(vec![
+      ReadAll | ReadAllSync => NameAndUrls(vec![
         ("ReadableStream", STREAMS_REDABLE_TS),
         ("toArrayBuffer()", STREAMS_TO_ARRAY_BUFFER_TS),
       ]),
       Run => NameAndUrl("Deno.Command", DENO_COMMAND_API),
-      WriteAll => NameAndUrls(vec![
+      WriteAll | WriteAllSync => NameAndUrls(vec![
         ("WritableStream", STREAMS_WRITEABLE_TS),
         ("ReadableStream.from", STREAMS_REDABLE_FROM_TS),
         ("ReadableStream.pipeTo", STREAMS_REDABLE_PIPE_TO_TS),
       ]),
-      WriteAllSync => NameAndUrl("writeAllSync", STREAMS_REDABLE_TS),
     }
   }
 }
@@ -582,7 +577,7 @@ Deno.readAll(reader);
       ("readAllSync", "Use `ReadableStream` from https://deno.land/api?s=ReadableStream and `toArrayBuffer()` from https://deno.land/std/streams/to_array_buffer.ts?s=toArrayBuffer instead"),
       ("run", "Use `Deno.Command` from https://deno.land/api?s=Deno.Command instead"),
       ("writeAll", "Use `WritableStream` from https://deno.land/api?s=WritableStream and `ReadableStream.from` from https://deno.land/api?s=ReadableStream#variable_ReadableStream and `ReadableStream.pipeTo` from https://deno.land/api?s=ReadableStream#method_pipeTo_4 instead"),
-      ("writeAllSync", "Use `writeAllSync` from https://deno.land/api?s=ReadableStream instead"),
+      ("writeAllSync", "Use `WritableStream` from https://deno.land/api?s=WritableStream and `ReadableStream.from` from https://deno.land/api?s=ReadableStream#variable_ReadableStream and `ReadableStream.pipeTo` from https://deno.land/api?s=ReadableStream#method_pipeTo_4 instead"),
     ];
 
     for test in tests {

--- a/src/rules/no_deprecated_deno_api.rs
+++ b/src/rules/no_deprecated_deno_api.rs
@@ -157,13 +157,14 @@ impl DeprecatedApi {
   }
 
   fn get_replacement(&self) -> Replacement {
-    const DENO_API: &str = "https://deno.land/api";
-    const BUFFER_TS: &str = "https://deno.land/std/io/buffer.ts";
+    const DENO_COMMAND_API: &str = "https://deno.land/api?s=Deno.Command";
+    const BUFFER_TS: &str =
+      "https://developer.mozilla.org/en-US/docs/Web/API/Streams_API";
     const STREAMS_REDABLE_TS: &str = "https://deno.land/api?s=ReadableStream";
     const STREAMS_REDABLE_PIPE_TO_TS: &str =
       "https://deno.land/api?s=ReadableStream#method_pipeTo_4";
     const STREAMS_REDABLE_FROM_TS: &str =
-      "https://deno.land/api@v1.39.2?s=ReadableStream#variable_ReadableStream";
+      "https://deno.land/api?s=ReadableStream#variable_ReadableStream";
     const STREAMS_WRITEABLE_TS: &str = "https://deno.land/api?s=WritableStream";
     const STREAMS_TO_ARRAY_BUFFER_TS: &str =
       "https://deno.land/std/streams/to_array_buffer.ts?s=toArrayBuffer";
@@ -171,7 +172,7 @@ impl DeprecatedApi {
     use DeprecatedApi::*;
     use Replacement::*;
     match *self {
-      Buffer => NameAndUrl("Buffer", BUFFER_TS),
+      Buffer => Name(BUFFER_TS),
       Copy => Name(STREAMS_REDABLE_PIPE_TO_TS),
       CustomInspect => Name("Symbol.for(\"Deno.customInspect\")"),
       Iter => Name(STREAMS_REDABLE_TS),
@@ -185,7 +186,7 @@ impl DeprecatedApi {
         ("ReadableStream", STREAMS_REDABLE_TS),
         ("toArrayBuffer()", STREAMS_TO_ARRAY_BUFFER_TS),
       ]),
-      Run => NameAndUrl("Deno.Command", DENO_API),
+      Run => NameAndUrl("Deno.Command", DENO_COMMAND_API),
       WriteAll => NameAndUrls(vec![
         ("WritableStream", STREAMS_WRITEABLE_TS),
         ("ReadableStream.from", STREAMS_REDABLE_FROM_TS),
@@ -562,6 +563,31 @@ Deno.readAll(reader);
           hint: ReadAll.hint()
         }
       ],
+    }
+  }
+
+  #[test]
+  fn expect_deprecated_api_hint() {
+    let tests = vec![
+      (
+        "Buffer",
+        "Use `https://developer.mozilla.org/en-US/docs/Web/API/Streams_API` instead",
+      ),
+      ("copy", "Use `https://deno.land/api?s=ReadableStream#method_pipeTo_4` instead"),
+      ("customInspect", "Use `Symbol.for(\"Deno.customInspect\")` instead"),
+      ("File", "Use `Deno.FsFile` instead"),
+      ("iter", "Use `https://deno.land/api?s=ReadableStream` instead"),
+      ("iterSync", "Use `https://deno.land/api?s=ReadableStream` instead"),
+      ("readAll", "Use `ReadableStream` from https://deno.land/api?s=ReadableStream and `toArrayBuffer()` from https://deno.land/std/streams/to_array_buffer.ts?s=toArrayBuffer instead"),
+      ("readAllSync", "Use `ReadableStream` from https://deno.land/api?s=ReadableStream and `toArrayBuffer()` from https://deno.land/std/streams/to_array_buffer.ts?s=toArrayBuffer instead"),
+      ("run", "Use `Deno.Command` from https://deno.land/api?s=Deno.Command instead"),
+      ("writeAll", "Use `WritableStream` from https://deno.land/api?s=WritableStream and `ReadableStream.from` from https://deno.land/api?s=ReadableStream#variable_ReadableStream and `ReadableStream.pipeTo` from https://deno.land/api?s=ReadableStream#method_pipeTo_4 instead"),
+      ("writeAllSync", "Use `writeAllSync` from https://deno.land/api?s=ReadableStream instead"),
+    ];
+
+    for test in tests {
+      let hint = DeprecatedApi::try_from(("Deno", test.0)).unwrap().hint();
+      assert_eq!(hint, test.1);
     }
   }
 }


### PR DESCRIPTION
fix https://github.com/denoland/deno_lint/issues/1221


The results
```sh
$ ./target/debug/examples/dlint run /Users/skanehira/dev/github.com/skanehira/sandbox/deno/stream/main.ts
no-deprecated-deno-api

  × `Deno.readAll` is deprecated and scheduled for removal in Deno 2.0
   ╭─[/Users/skanehira/dev/github.com/skanehira/sandbox/deno/stream/main.ts:2:7]
 2 │ const file = await Deno.open("./main.ts");
 3 │ await Deno.readAll(file);
   ·       ──────┬─────
   ·             ╰── Use `ReadableStream` from https://deno.land/api?s=ReadableStream and `toArrayBuffer()` from https://deno.land/std/streams/to_array_buffer.ts?s=toArrayBuffer instead
 4 │ Deno.iter(file);
   ╰────
  help: https://lint.deno.land/#no-deprecated-deno-api

no-deprecated-deno-api

  × `Deno.iter` is deprecated and scheduled for removal in Deno 2.0
   ╭─[/Users/skanehira/dev/github.com/skanehira/sandbox/deno/stream/main.ts:3:1]
 3 │ await Deno.readAll(file);
 4 │ Deno.iter(file);
   · ────┬────
   ·     ╰── Use `https://deno.land/api?s=ReadableStream` instead
 5 │ Deno.iterSync(file);
   ╰────
  help: https://lint.deno.land/#no-deprecated-deno-api

no-deprecated-deno-api

  × `Deno.iterSync` is deprecated and scheduled for removal in Deno 2.0
   ╭─[/Users/skanehira/dev/github.com/skanehira/sandbox/deno/stream/main.ts:4:1]
 4 │ Deno.iter(file);
 5 │ Deno.iterSync(file);
   · ──────┬──────
   ·       ╰── Use `https://deno.land/api?s=ReadableStream` instead
 6 │ Deno.readAllSync(file);
   ╰────
  help: https://lint.deno.land/#no-deprecated-deno-api

no-deprecated-deno-api

  × `Deno.readAllSync` is deprecated and scheduled for removal in Deno 2.0
   ╭─[/Users/skanehira/dev/github.com/skanehira/sandbox/deno/stream/main.ts:5:1]
 5 │ Deno.iterSync(file);
 6 │ Deno.readAllSync(file);
   · ────────┬───────
   ·         ╰── Use `ReadableStream` from https://deno.land/api?s=ReadableStream and `toArrayBuffer()` from https://deno.land/std/streams/to_array_buffer.ts?s=toArrayBuffer instead
 7 │ Deno.readAll(file);
   ╰────
  help: https://lint.deno.land/#no-deprecated-deno-api

no-deprecated-deno-api

  × `Deno.readAll` is deprecated and scheduled for removal in Deno 2.0
   ╭─[/Users/skanehira/dev/github.com/skanehira/sandbox/deno/stream/main.ts:6:1]
 6 │ Deno.readAllSync(file);
 7 │ Deno.readAll(file);
   · ──────┬─────
   ·       ╰── Use `ReadableStream` from https://deno.land/api?s=ReadableStream and `toArrayBuffer()` from https://deno.land/std/streams/to_array_buffer.ts?s=toArrayBuffer instead
 8 │ Deno.copy(file, file);
   ╰────
  help: https://lint.deno.land/#no-deprecated-deno-api

no-deprecated-deno-api

  × `Deno.copy` is deprecated and scheduled for removal in Deno 2.0
   ╭─[/Users/skanehira/dev/github.com/skanehira/sandbox/deno/stream/main.ts:7:1]
 7 │ Deno.readAll(file);
 8 │ Deno.copy(file, file);
   · ────┬────
   ·     ╰── Use `https://deno.land/api?s=ReadableStream#method_pipeTo_4` instead
 9 │ Deno.write(0, new Uint8Array(1));
   ╰────
  help: https://lint.deno.land/#no-deprecated-deno-api

no-deprecated-deno-api

  × `Deno.writeAll` is deprecated and scheduled for removal in Deno 2.0
    ╭─[/Users/skanehira/dev/github.com/skanehira/sandbox/deno/stream/main.ts:9:1]
  9 │ Deno.write(0, new Uint8Array(1));
 10 │ Deno.writeAll(file, new Uint8Array(1));
    · ──────┬──────
    ·       ╰── Use `WritableStream` from https://deno.land/api?s=WritableStream and `ReadableStream.from` from https://deno.land/api@v1.39.2?s=ReadableStream#variable_ReadableStream and `ReadableStream.pipeTo` from https://
deno.land/api?s=ReadableStream#method_pipeTo_4 instead
    ╰────
  help: https://lint.deno.land/#no-deprecated-deno-api

Found 7 problems
```