### PR TITLE
docs: fix missing features flag for build example

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ which provides programmatic API as well as Webpack loader for `deno_lint`.
 
 ```shell
 # Build standalone binary
-$ cargo build --example dlint
+$ cargo build --example dlint --features="docs"
 
 $ ./target/debug/examples/dlint --help
 


### PR DESCRIPTION
Fix missing features flag for build example