### PR TITLE
fix: incorrect lint assumptions  for `no-empty-interface`

### DIFF
--- a/docs/rules/no_empty_interface.md
+++ b/docs/rules/no_empty_interface.md
@@ -1,7 +1,7 @@
 Disallows the declaration of an empty interface
 
-An interface with no members serves no purpose.
-This rule will capture these situations as either unnecessary code or a mistaken empty implementation.
+An interface with no members serves no purpose. This rule will capture these
+situations as either unnecessary code or a mistaken empty implementation.
 
 ### Invalid:
 

--- a/docs/rules/no_empty_interface.md
+++ b/docs/rules/no_empty_interface.md
@@ -1,16 +1,12 @@
 Disallows the declaration of an empty interface
 
-An interface with no members serves no purpose. Either the interface extends
-another interface, in which case the supertype can be used, or it does not
-extend a supertype in which case it is the equivalent to an empty object. This
-rule will capture these situations as either unnecessary code or a mistaken
-empty implementation.
+An interface with no members serves no purpose.
+This rule will capture these situations as either unnecessary code or a mistaken empty implementation.
 
 ### Invalid:
 
 ```typescript
 interface Foo {}
-interface Foo extends Bar {}
 ```
 
 ### Valid:
@@ -24,6 +20,16 @@ interface Bar {
   age: number;
 }
 
-// Using an empty interface as a union type is allowed
+// Using an empty interface with at least one extension are allowed.
+
+// Using an empty interface to change the identity of Baz from type to interface.
+type Baz = { profession: string };
+interface Foo extends Baz {}
+
+// Using an empty interface to extend already existing Foo declaration
+// with members of the Bar interface
+interface Foo extends Bar {}
+
+// Using an empty interface as a union type
 interface Baz extends Foo, Bar {}
 ```

--- a/src/rules/no_empty_interface.rs
+++ b/src/rules/no_empty_interface.rs
@@ -55,13 +55,13 @@ impl Handler for NoEmptyInterfaceHandler {
     interface_decl: &TsInterfaceDecl,
     ctx: &mut Context,
   ) {
-    if interface_decl.extends.len() === 0 && interface_decl.body.body.is_empty()
+    if interface_decl.extends.is_empty() && interface_decl.body.body.is_empty()
     {
       ctx.add_diagnostic_with_hint(
         interface_decl.range(),
         CODE,
         NoEmptyInterfaceMessage::EmptyObject,
-        NoEmptyInterfaceHint::RemoveOrAddMember
+        NoEmptyInterfaceHint::RemoveOrAddMember,
       );
     }
   }

--- a/src/rules/no_empty_interface.rs
+++ b/src/rules/no_empty_interface.rs
@@ -16,20 +16,12 @@ const CODE: &str = "no-empty-interface";
 enum NoEmptyInterfaceMessage {
   #[display(fmt = "An empty interface is equivalent to `{{}}`.")]
   EmptyObject,
-  #[display(
-    fmt = "An interface declaring no members is equivalent to its supertype."
-  )]
-  Supertype,
 }
 
 #[derive(Display)]
 enum NoEmptyInterfaceHint {
   #[display(fmt = "Remove this interface or add members to this interface.")]
   RemoveOrAddMember,
-  #[display(
-    fmt = "Use the supertype instead, or add members to this interface."
-  )]
-  UseSuperTypeOrAddMember,
 }
 
 impl LintRule for NoEmptyInterface {
@@ -63,21 +55,13 @@ impl Handler for NoEmptyInterfaceHandler {
     interface_decl: &TsInterfaceDecl,
     ctx: &mut Context,
   ) {
-    if interface_decl.extends.len() <= 1 && interface_decl.body.body.is_empty()
+    if interface_decl.extends.len() === 0 && interface_decl.body.body.is_empty()
     {
       ctx.add_diagnostic_with_hint(
         interface_decl.range(),
         CODE,
-        if interface_decl.extends.is_empty() {
-          NoEmptyInterfaceMessage::EmptyObject
-        } else {
-          NoEmptyInterfaceMessage::Supertype
-        },
-        if interface_decl.extends.is_empty() {
-          NoEmptyInterfaceHint::RemoveOrAddMember
-        } else {
-          NoEmptyInterfaceHint::UseSuperTypeOrAddMember
-        },
+        NoEmptyInterfaceMessage::EmptyObject,
+        NoEmptyInterfaceHint::RemoveOrAddMember
       );
     }
   }
@@ -93,6 +77,13 @@ mod tests {
       NoEmptyInterface,
       "interface Foo { a: string }",
       "interface Foo { a: number }",
+
+      // This is valid, because:
+      //  - `Bar` can be a type, this makes it so `Foo` has the same members
+      //    as `Bar` but is an interface instead. Behaviour of types and interfaces
+      //    isn't always the same.
+      //  - `Foo` interface might already exist and extend it by the `Bar` members.
+      "interface Foo extends Bar {}",
 
       // This is valid because an interface with more than one supertype
       // can be used as a replacement of a union type.
@@ -118,79 +109,6 @@ mod tests {
           hint: NoEmptyInterfaceHint::RemoveOrAddMember,
         }
       ],
-      r#"
-interface Foo {
-  a: string;
-}
-
-interface Bar extends Foo {}
-"#: [
-        {
-          line: 6,
-          col: 0,
-          message: NoEmptyInterfaceMessage::Supertype,
-          hint: NoEmptyInterfaceHint::UseSuperTypeOrAddMember,
-        }
-      ],
-      "interface Foo extends Array<number> {}": [
-        {
-          col: 0,
-          message: NoEmptyInterfaceMessage::Supertype,
-          hint: NoEmptyInterfaceHint::UseSuperTypeOrAddMember,
-        }
-      ],
-      "interface Foo extends Array<number | {}> {}": [
-        {
-          col: 0,
-          message: NoEmptyInterfaceMessage::Supertype,
-          hint: NoEmptyInterfaceHint::UseSuperTypeOrAddMember,
-        }
-      ],
-      r#"
-interface Foo {
-  a: string;
-}
-
-interface Bar extends Array<Foo> {}
-"#: [
-        {
-          line: 6,
-          col: 0,
-          message: NoEmptyInterfaceMessage::Supertype,
-          hint: NoEmptyInterfaceHint::UseSuperTypeOrAddMember,
-        }
-      ],
-      r#"
-type R = Record<string, unknown>;
-interface Foo extends R {}
-"#: [
-        {
-          line: 3,
-          col: 0,
-          message: NoEmptyInterfaceMessage::Supertype,
-          hint: NoEmptyInterfaceHint::UseSuperTypeOrAddMember,
-        }
-      ],
-      "interface Foo<T> extends Bar<T> {}": [
-        {
-          col: 0,
-          message: NoEmptyInterfaceMessage::Supertype,
-          hint: NoEmptyInterfaceHint::UseSuperTypeOrAddMember,
-        }
-      ],
-      r#"
-declare module FooBar {
-  type Baz = typeof baz;
-  export interface Bar extends Baz {}
-}
-"#: [
-        {
-          line: 4,
-          col: 9,
-          message: NoEmptyInterfaceMessage::Supertype,
-          hint: NoEmptyInterfaceHint::UseSuperTypeOrAddMember,
-        }
-      ]
     };
   }
 }

--- a/www/static/docs.json
+++ b/www/static/docs.json
@@ -268,7 +268,7 @@
   },
   {
     "code": "no-empty-interface",
-    "docs": "Disallows the declaration of an empty interface\n\nAn interface with no members serves no purpose. Either the interface extends\nanother interface, in which case the supertype can be used, or it does not\nextend a supertype in which case it is the equivalent to an empty object. This\nrule will capture these situations as either unnecessary code or a mistaken\nempty implementation.\n\n### Invalid:\n\n```typescript\ninterface Foo {}\ninterface Foo extends Bar {}\n```\n\n### Valid:\n\n```typescript\ninterface Foo {\n  name: string;\n}\n\ninterface Bar {\n  age: number;\n}\n\n// Using an empty interface as a union type is allowed\ninterface Baz extends Foo, Bar {}\n```\n",
+    "docs": "Disallows the declaration of an empty interface\n\nAn interface with no members serves no purpose. This rule will capture these\nsituations as either unnecessary code or a mistaken empty implementation.\n\n### Invalid:\n\n```typescript\ninterface Foo {}\n```\n\n### Valid:\n\n```typescript\ninterface Foo {\n  name: string;\n}\n\ninterface Bar {\n  age: number;\n}\n\n// Using an empty interface with at least one extension are allowed.\n\n// Using an empty interface to change the identity of Baz from type to interface.\ntype Baz = { profession: string };\ninterface Foo extends Baz {}\n\n// Using an empty interface to extend already existing Foo declaration\n// with members of the Bar interface\ninterface Foo extends Bar {}\n\n// Using an empty interface as a union type\ninterface Baz extends Foo, Bar {}\n```\n",
     "tags": [
       "recommended"
     ]


### PR DESCRIPTION
This PR removes linting error for `interface ABC extends XYZ {}` while keeping lint errors for empty interfaces with no extends (`interface ABC {}`).

Fixes #1249