### PR TITLE
docs: fix link in README to deno repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ Found 7 problems
 ```
 
 For more concrete implementation visit
-[`deno`](https://github.com/denoland/deno/blob/main/cli/tools/lint.rs)
+[`deno`](https://github.com/denoland/deno/blob/main/cli/tools/lint/mod.rs)
 
 ## Developing
 


### PR DESCRIPTION
The referenced file was moved in https://github.com/denoland/deno/commit/66424032a2c78c6010c0a1a1b22a26d081166660
