### PR TITLE
fix: Make dlint report syntax/parsing errors

### DIFF
--- a/examples/dlint/main.rs
+++ b/examples/dlint/main.rs
@@ -127,8 +127,7 @@ fn run_linter(
 
       let mut number_of_errors = diagnostics.len();
       if !parsed_source.diagnostics().is_empty() {
-        number_of_errors =
-          number_of_errors + parsed_source.diagnostics().to_vec().len();
+        number_of_errors += parsed_source.diagnostics().to_vec().len();
         eprintln!(
           "{}",
           ParseDiagnosticsError(parsed_source.diagnostics().to_vec())

--- a/examples/dlint/main.rs
+++ b/examples/dlint/main.rs
@@ -125,13 +125,17 @@ fn run_linter(
         },
       })?;
 
+      let mut number_of_errors = diagnostics.len();
       if !parsed_source.diagnostics().is_empty() {
-        return Err(
-          ParseDiagnosticsError(parsed_source.diagnostics().to_vec()).into(),
-        );
+        number_of_errors =
+          number_of_errors + parsed_source.diagnostics().to_vec().len();
+        eprintln!(
+          "{}",
+          ParseDiagnosticsError(parsed_source.diagnostics().to_vec())
+        )
       }
 
-      error_counts.fetch_add(diagnostics.len(), Ordering::Relaxed);
+      error_counts.fetch_add(number_of_errors, Ordering::Relaxed);
 
       let mut lock = file_diagnostics.lock().unwrap();
 

--- a/examples/dlint/main.rs
+++ b/examples/dlint/main.rs
@@ -5,9 +5,9 @@ use anyhow::Error as AnyError;
 use clap::Arg;
 use clap::Command;
 use core::panic;
+use deno_ast::diagnostics::Diagnostic;
 use deno_ast::MediaType;
 use deno_ast::ModuleSpecifier;
-use deno_ast::ParseDiagnosticsError;
 use deno_lint::linter::LintConfig;
 use deno_lint::linter::LintFileOptions;
 use deno_lint::linter::LinterBuilder;
@@ -128,10 +128,11 @@ fn run_linter(
       let mut number_of_errors = diagnostics.len();
       if !parsed_source.diagnostics().is_empty() {
         number_of_errors += parsed_source.diagnostics().to_vec().len();
-        eprintln!(
-          "{}",
-          ParseDiagnosticsError(parsed_source.diagnostics().to_vec())
-        )
+        parsed_source.diagnostics().to_vec().iter().for_each(
+          |parsing_diagnostic| {
+            eprintln!("{}", parsing_diagnostic.display());
+          },
+        );
       }
 
       error_counts.fetch_add(number_of_errors, Ordering::Relaxed);


### PR DESCRIPTION
Supported dlint reporting of syntax/parsing errors.

The commit is made to address issue [23437 from deno repo](https://github.com/denoland/deno/issues/23437)

**Code changes**

Added check for `ParsedSource.diagnostics()` and when it's not empty, an object of `ParseDiagnosticsError` holding the vector of `ParseDiagnostic` objects is returned as an `Err` object within `fn run_linter()` in _deno_lint/examples/dlint/main.rs_ file.

PS: The change within this function was preffered over the suggested one in the issue discussion to maintain the types of returned Err in order to keep the same successful flow, since the run_linter function returns AnyError not some specific one like parse_program function, and also it's much simpler (doesn't need to append the ParseDiagnostic single object that returned from `deno_ast::parse_program` into a vector before returning it as an error).


@lucacasonato 