### PR TITLE
fix(no_invalid_regexp): expand invalid case

### DIFF
--- a/src/rules/no_invalid_regexp.rs
+++ b/src/rules/no_invalid_regexp.rs
@@ -132,13 +132,11 @@ impl<'c, 'view> Visit for NoInvalidRegexpVisitor<'c, 'view> {
   }
 
   fn visit_new_expr(&mut self, new_expr: &deno_ast::swc::ast::NewExpr) {
-    if new_expr.args.is_some() {
-      self.handle_call_or_new_expr(
-        &new_expr.callee,
-        new_expr.args.as_ref().unwrap(),
-        new_expr.range(),
-      );
-    }
+    self.handle_call_or_new_expr(
+      &new_expr.callee,
+      new_expr.args.as_ref().unwrap_or(&vec![]),
+      new_expr.range(),
+    );
   }
 }
 
@@ -215,6 +213,10 @@ let re = new RegExp('foo', x);",
         { line: 7, col: 2, message: MESSAGE, hint: HINT },
         { line: 8, col: 2, message: MESSAGE, hint: HINT },
         { line: 9, col: 2, message: MESSAGE, hint: HINT }],
+      r"
+new function () {
+  return /+/;
+};": [{ line: 3, col: 9, message: MESSAGE, hint: HINT }],
     }
   }
 }


### PR DESCRIPTION
Fixes https://github.com/denoland/deno_lint/issues/1269

To understand the issue better, I first modified the code to include debug output for inspecting the AST. Specifically, I added the following debug statement to the handle_call_or_new_expr function:

```diff
fn handle_call_or_new_expr(
  &mut self,
  callee: &Expr,
  args: &[ExprOrSpread],
  range: SourceRange,
) {
+  println!("{:?}", callee);
+  println!("{:?}", args);

  if let Expr::Ident(ident) = callee {
    if ident.sym != *"RegExp" || args.is_empty() {
      return;
    }
    if let Some(pattern) = &check_expr_for_string_literal(&args[0].expr) {
      if args.len() > 1 {
        if let Some(flags) = &check_expr_for_string_literal(&args[1].expr) {
          self.check_regex(pattern, flags, range);
          return;
        }
      }
      self.check_regex(pattern, "", range);
    }
  }
}
```

By examining the printed AST output, I thought checking for nested AST might be needed.

I ran lint on the following code snippet.

```typescript
((_) => [
  /+/,
  RegExp("+"),
  new RegExp("+"),
])([
  /+/,
  RegExp("+"),
  new RegExp("+"),
]);
```

`println` output:

```
// callee
Paren(ParenExpr { span: 1623..1676#0, expr: Arrow(ArrowExpr { span: 1624..1675#0, params: [Ident(BindingIdent { id: Ident { span: 1625..1626#3, sym: "_", optional: false }, type_ann: None })], body: Expr(Array(ArrayLit { span: 1631..1675#0, elems: [Some(ExprOrSpread { spread: None, expr: Lit(Regex(Regex { span: 1635..1638#0, exp: "+", flags: "" })) }), Some(ExprOrSpread { spread: None, expr: Call(CallExpr { span: 1642..1653#0, callee: Expr(Ident(Ident { span: 1642..1648#1, sym: "RegExp", optional: false })), args: [ExprOrSpread { spread: None, expr: Lit(Str(Str { span: 1649..1652#0, value: "+", raw: Some("\"+\"") })) }], type_args: None }) }), Some(ExprOrSpread { spread: None, expr: New(NewExpr { span: 1657..1672#0, callee: Ident(Ident { span: 1661..1667#1, sym: "RegExp", optional: false }), args: Some([ExprOrSpread { spread: None, expr: Lit(Str(Str { span: 1668..1671#0, value: "+", raw: Some("\"+\"") })) }]), type_args: None }) })] })), is_async: false, is_generator: false, type_params: None, return_type: None }) })

// args
[ExprOrSpread { spread: None, expr: Array(ArrayLit { span: 1677..1721#0, elems: [Some(ExprOrSpread { spread: None, expr: Lit(Regex(Regex { span: 1681..1684#0, exp: "+", flags: "" })) }), Some(ExprOrSpread { spread: None, expr: Call(CallExpr { span: 1688..1699#0, callee: Expr(Ident(Ident { span: 1688..1694#1, sym: "RegExp", optional: false })), args: [ExprOrSpread { spread: None, expr: Lit(Str(Str { span: 1695..1698#0, value: "+", raw: Some("\"+\"") })) }], type_args: None }) }), Some(ExprOrSpread { spread: None, expr: New(NewExpr { span: 1703..1718#0, callee: Ident(Ident { span: 1707..1713#1, sym: "RegExp", optional: false }), args: Some([ExprOrSpread { spread: None, expr: Lit(Str(Str { span: 1714..1717#0, value: "+", raw: Some("\"+\"") })) }]), type_args: None }) })] }) }]
```