### PR TITLE
fix(ban-types): Use `PropertyKey` type global in hint message

### DIFF
--- a/src/rules/ban_types.rs
+++ b/src/rules/ban_types.rs
@@ -49,7 +49,7 @@ impl BannedType {
         r#"If you want a type meaning "any object", use `object` instead. Or if you want a type meaning "any value", you probably want `unknown` instead."#
       }
       EmptyObjectLiteral => {
-        r#"If you want a type that means "empty object", use `Record<string | number | symbol, never>` instead"#
+        r#"If you want a type that means "empty object", use `Record<PropertyKey, never>` instead"#
       }
     }
   }


### PR DESCRIPTION
Maybe a lsp "quick fix" would be nice to add too