### PR TITLE
fix: Don't construct invalid `char`s in regex validator

### DIFF
--- a/src/js_regex/mod.rs
+++ b/src/js_regex/mod.rs
@@ -20,7 +20,7 @@ impl fmt::Display for UnicodeChar {
 }
 
 macro_rules! delegate_if_char {
-  ($($v: vis fn $fn: ident (&$self: ident $(,)? $($param: ident : $param_ty : ty),*) $(-> $ret: ty)?);+ $(;)?) => {
+  ($($v: vis fn $fn: ident ($self: ident $(,)? $($param: ident : $param_ty : ty),*) $(-> $ret: ty)?);+ $(;)?) => {
     $(
       $v fn $fn($self $(, $param : $param_ty)*) $(-> $ret)? {
         if $self.is_scalar() {
@@ -40,17 +40,14 @@ impl UnicodeChar {
     (v ^ 0xD800).wrapping_sub(0x800) < 0x110000 - 0x800
   }
   delegate_if_char! {
-    pub fn is_digit(&self, radix: u32) -> bool;
-    pub fn to_digit(&self, radix: u32) -> Option<u32>;
-    pub fn is_ascii_digit(&self) -> bool;
-    pub fn is_ascii_alphabetic(&self) -> bool;
-    pub fn is_ascii_hexdigit(&self) -> bool;
+    pub fn is_digit(self, radix: u32) -> bool;
+    pub fn to_digit(self, radix: u32) -> Option<u32>;
+    pub fn is_ascii_digit(self) -> bool;
+    pub fn is_ascii_alphabetic(self) -> bool;
+    pub fn is_ascii_hexdigit(self) -> bool;
   }
   pub fn to_char(self) -> Option<char> {
-    if self.is_scalar() {
-      return Some(unsafe { char::from_u32_unchecked(self.value) });
-    }
-    None
+    char::from_u32(self.value)
   }
 }
 

--- a/src/js_regex/mod.rs
+++ b/src/js_regex/mod.rs
@@ -4,7 +4,104 @@ mod reader;
 mod unicode;
 mod validator;
 
+use std::fmt;
+
 pub use validator::{EcmaRegexValidator, EcmaVersion};
+
+enum UnicodeCharRepr {
+  Char(char),
+  Surrogate(u32),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Copy)]
+pub struct UnicodeChar {
+  value: u32,
+  is_surrogate: bool,
+}
+
+impl fmt::Display for UnicodeChar {
+  fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    write!(f, "{}", self.value)
+  }
+}
+
+macro_rules! delegate_if_char {
+  ($($v: vis fn $fn: ident (&$self: ident $(,)? $($param: ident : $param_ty : ty),*) $(-> $ret: ty)?);+ $(;)?) => {
+    $(
+      $v fn $fn($self $(, $param : $param_ty)*) $(-> $ret)? {
+        if !$self.is_surrogate {
+          return unsafe { char::from_u32_unchecked($self.value) }.$fn($($param),*);
+        }
+        Default::default()
+      }
+    )+
+  };
+}
+
+impl UnicodeChar {
+  delegate_if_char! {
+    pub fn is_digit(&self, radix: u32) -> bool;
+    pub fn to_digit(&self, radix: u32) -> Option<u32>;
+    pub fn is_ascii_digit(&self) -> bool;
+    pub fn is_ascii_alphabetic(&self) -> bool;
+    pub fn is_ascii_hexdigit(&self) -> bool;
+  }
+  pub fn to_char(self) -> Option<char> {
+    if !self.is_surrogate {
+      return Some(unsafe { char::from_u32_unchecked(self.value) });
+    }
+    None
+  }
+}
+
+impl From<char> for UnicodeChar {
+  fn from(value: char) -> Self {
+    Self {
+      value: value as u32,
+      is_surrogate: false,
+    }
+  }
+}
+
+impl From<u32> for UnicodeChar {
+  fn from(value: u32) -> Self {
+    Self {
+      value,
+      is_surrogate: char::from_u32(value).is_none(),
+    }
+  }
+}
+
+impl PartialEq<char> for UnicodeChar {
+  fn eq(&self, other: &char) -> bool {
+    self.value == *other as u32
+  }
+}
+impl PartialEq<&char> for UnicodeChar {
+  fn eq(&self, other: &&char) -> bool {
+    self.value == **other as u32
+  }
+}
+
+impl PartialEq<u32> for UnicodeChar {
+  fn eq(&self, other: &u32) -> bool {
+    self.value == *other
+  }
+}
+impl PartialOrd<u32> for UnicodeChar {
+  fn partial_cmp(&self, other: &u32) -> Option<std::cmp::Ordering> {
+    self.value.partial_cmp(other)
+  }
+}
+
+impl UnicodeChar {
+  pub fn to_u32(self) -> u32 {
+    self.value
+  }
+  pub fn to_i64(self) -> i64 {
+    self.value as i64
+  }
+}
 
 #[cfg(test)]
 mod tests {

--- a/src/js_regex/reader.rs
+++ b/src/js_regex/reader.rs
@@ -169,19 +169,19 @@ mod tests {
     let mut reader = Reader::new();
     // without unicode flag
     reader.reset("Hello", 0, 5, false);
-    assert_eq!(reader.at(1).unwrap().to_u32(), 101);
+    assert_eq!(reader.at(1).unwrap(), 101);
     reader.reset("􀃃a🩢☃★♲", 0, 6, false);
-    assert_eq!(reader.at(0).unwrap().to_u32(), 56256);
+    assert_eq!(reader.at(0).unwrap(), 56256);
     reader.reset("􀃃ello", 0, 6, false);
-    assert_eq!(reader.at(0).unwrap().to_u32(), 56256);
+    assert_eq!(reader.at(0).unwrap(), 56256);
     reader.reset("􀃃ello", 0, 6, false);
-    assert_eq!(reader.at(1).unwrap().to_u32(), 56515);
+    assert_eq!(reader.at(1).unwrap(), 56515);
     // with unicode flag
     reader.reset("Hello", 0, 5, true);
-    assert_eq!(reader.at(1).unwrap().to_u32(), 101);
+    assert_eq!(reader.at(1).unwrap(), 101);
     reader.reset("􀃃a🩢☃★♲", 0, 6, true);
-    assert_eq!(reader.at(0).unwrap().to_u32(), 1048771);
+    assert_eq!(reader.at(0).unwrap(), 1048771);
     reader.reset("􀃃ello", 0, 6, true);
-    assert_eq!(reader.at(0).unwrap().to_u32(), 1048771);
+    assert_eq!(reader.at(0).unwrap(), 1048771);
   }
 }

--- a/src/js_regex/reader.rs
+++ b/src/js_regex/reader.rs
@@ -37,6 +37,10 @@ impl Reader {
     self.cps.get(offset).cloned()
   }
 
+  pub fn code_point_value_with_offset(&self, offset: usize) -> Option<u32> {
+    self.cps.get(offset).map(|cp| cp.to_u32())
+  }
+
   pub fn reset(
     &mut self,
     source: &str,

--- a/src/js_regex/unicode.rs
+++ b/src/js_regex/unicode.rs
@@ -3,7 +3,7 @@
 // This file was generated with ECMAScript specifications.
 // Originally from: https://github.com/mysticatea/regexpp
 
-use super::EcmaVersion;
+use super::{EcmaVersion, UnicodeChar};
 
 use once_cell::sync::Lazy;
 use std::collections::HashSet;
@@ -579,12 +579,12 @@ pub fn is_valid_lone_unicode_property(
       && BIN_PROPERTY_PATTERNS.es2019.contains(value))
 }
 
-pub fn is_large_id_start(cp: char) -> bool {
-  is_in_range(cp as u32, &LARGE_ID_START_RANGES)
+pub fn is_large_id_start(cp: UnicodeChar) -> bool {
+  is_in_range(cp.to_u32(), &LARGE_ID_START_RANGES)
 }
 
-pub fn is_large_id_continue(cp: char) -> bool {
-  is_in_range(cp as u32, &LARGE_ID_CONTINUE_RANGES)
+pub fn is_large_id_continue(cp: UnicodeChar) -> bool {
+  is_in_range(cp.to_u32(), &LARGE_ID_CONTINUE_RANGES)
 }
 
 fn is_in_range(cp: u32, ranges: &[u32]) -> bool {

--- a/src/js_regex/unicode.rs
+++ b/src/js_regex/unicode.rs
@@ -580,14 +580,14 @@ pub fn is_valid_lone_unicode_property(
 }
 
 pub fn is_large_id_start(cp: UnicodeChar) -> bool {
-  is_in_range(cp.to_u32(), &LARGE_ID_START_RANGES)
+  is_in_range(cp, &LARGE_ID_START_RANGES)
 }
 
 pub fn is_large_id_continue(cp: UnicodeChar) -> bool {
-  is_in_range(cp.to_u32(), &LARGE_ID_CONTINUE_RANGES)
+  is_in_range(cp, &LARGE_ID_CONTINUE_RANGES)
 }
 
-fn is_in_range(cp: u32, ranges: &[u32]) -> bool {
+fn is_in_range(cp: UnicodeChar, ranges: &[u32]) -> bool {
   let mut l = 0;
   let mut r = ranges.len() / 2;
   while l < r {

--- a/src/js_regex/validator.rs
+++ b/src/js_regex/validator.rs
@@ -504,9 +504,7 @@ impl EcmaRegexValidator {
 
     if self.ecma_version >= EcmaVersion::Es2018 {
       self.consume_group_specifier()?;
-    } else if self.code_point_with_offset(0).map(|c| c.to_u32())
-      == Some('?' as u32)
-    {
+    } else if self.code_point_value_with_offset(0) == Some('?' as u32) {
       return Err("Invalid group".to_string());
     }
 
@@ -549,8 +547,8 @@ impl EcmaRegexValidator {
   /// ```
   /// Returns `true` if it consumed the next characters successfully.
   fn consume_reverse_solidus_followed_by_c(&mut self) -> bool {
-    if self.code_point_with_offset(0).map(|c| c.to_u32()) == Some('\\' as u32)
-      && self.code_point_with_offset(1).map(|c| c.to_u32()) == Some('c' as u32)
+    if self.code_point_value_with_offset(0) == Some('\\' as u32)
+      && self.code_point_value_with_offset(1) == Some('c' as u32)
     {
       self.last_int_value = '\\' as i64;
       self.advance();
@@ -873,8 +871,7 @@ impl EcmaRegexValidator {
         return Ok(true);
       }
       if !self.strict
-        && self.code_point_with_offset(0).map(|c| c.to_u32())
-          == Some('c' as u32)
+        && self.code_point_value_with_offset(0) == Some('c' as u32)
       {
         self.last_int_value = '\\' as i64;
         return Ok(true);
@@ -916,7 +913,7 @@ impl EcmaRegexValidator {
     // [annexB][~U] `c` ClassControlLetter
     if !self.strict
       && !self.u_flag
-      && self.code_point_with_offset(0).map(|c| c.to_u32()) == Some('c' as u32)
+      && self.code_point_value_with_offset(0) == Some('c' as u32)
     {
       if let Some(cp) = self.code_point_with_offset(1) {
         if cp.is_ascii_digit() || cp == '_' {
@@ -1582,8 +1579,7 @@ impl EcmaRegexValidator {
         && !in_class
         && (self.code_point_with_offset(1).map(|c| c.to_u32())
           != Some('?' as u32)
-          || (self.code_point_with_offset(2).map(|c| c.to_u32())
-            == Some('<' as u32)
+          || (self.code_point_value_with_offset(2) == Some('<' as u32)
             && self.code_point_with_offset(3).map(|c| c.to_u32())
               != Some('=' as u32)
             && self.code_point_with_offset(3).map(|c| c.to_u32())

--- a/src/js_regex/validator.rs
+++ b/src/js_regex/validator.rs
@@ -861,7 +861,7 @@ impl EcmaRegexValidator {
     if let Some(cp) = self.code_point_with_offset(0) {
       if cp != '\\' && cp != ']' {
         self.advance();
-        self.last_int_value = cp.to_u32() as i64;
+        self.last_int_value = cp.to_i64();
         return Ok(true);
       }
     }
@@ -919,7 +919,7 @@ impl EcmaRegexValidator {
         if cp.is_ascii_digit() || cp == '_' {
           self.advance();
           self.advance();
-          self.last_int_value = cp.to_u32() as i64 % 0x20;
+          self.last_int_value = cp.to_i64() % 0x20;
           return Ok(true);
         }
       }
@@ -1094,7 +1094,7 @@ impl EcmaRegexValidator {
   /// ```
   /// Returns `true` if it ate the next characters successfully.
   fn eat_zero(&mut self) -> bool {
-    if self.code_point_with_offset(0).map(|c| c.to_u32()) != Some('0' as u32) {
+    if self.code_point_value_with_offset(0) != Some('0' as u32) {
       return false;
     } else if let Some(cp) = self.code_point_with_offset(1) {
       if cp.is_ascii_digit() {

--- a/src/js_regex/validator.rs
+++ b/src/js_regex/validator.rs
@@ -4,9 +4,9 @@ use std::collections::HashSet;
 use std::ops::{Deref, DerefMut};
 
 use super::reader::Reader;
-use super::unicode::*;
+use super::{unicode::*, UnicodeChar};
 
-fn is_syntax_character(cp: char) -> bool {
+fn is_syntax_character(cp: UnicodeChar) -> bool {
   cp == '^'
     || cp == '$'
     || cp == '\\'
@@ -23,19 +23,19 @@ fn is_syntax_character(cp: char) -> bool {
     || cp == '|'
 }
 
-fn is_unicode_property_name_character(cp: char) -> bool {
+fn is_unicode_property_name_character(cp: UnicodeChar) -> bool {
   cp.is_ascii_alphabetic() || cp == '_'
 }
 
-fn is_unicode_property_value_character(cp: char) -> bool {
+fn is_unicode_property_value_character(cp: UnicodeChar) -> bool {
   is_unicode_property_name_character(cp) || cp.is_ascii_digit()
 }
 
-fn is_regexp_identifier_start(cp: char) -> bool {
+fn is_regexp_identifier_start(cp: UnicodeChar) -> bool {
   is_id_start(cp) || cp == '$' || cp == '_'
 }
 
-fn is_regexp_identifier_part(cp: char) -> bool {
+fn is_regexp_identifier_part(cp: UnicodeChar) -> bool {
   is_id_continue(cp) ||
     cp == '$' ||
     cp == '_' ||
@@ -43,32 +43,32 @@ fn is_regexp_identifier_part(cp: char) -> bool {
     cp == '\u{200d}' // unicode zero-width joiner
 }
 
-fn is_id_start(cp: char) -> bool {
-  if (cp as u32) < 0x41 {
+fn is_id_start(cp: UnicodeChar) -> bool {
+  if cp < 0x41 {
     false
-  } else if (cp as u32) < 0x5b {
+  } else if cp < 0x5b {
     true
-  } else if (cp as u32) < 0x61 {
+  } else if cp < 0x61 {
     false
-  } else if (cp as u32) < 0x7b {
+  } else if cp < 0x7b {
     true
   } else {
     is_large_id_start(cp)
   }
 }
 
-fn is_id_continue(cp: char) -> bool {
-  if (cp as u32) < 0x30 {
+fn is_id_continue(cp: UnicodeChar) -> bool {
+  if cp < 0x30 {
     false
-  } else if (cp as u32) < 0x3a {
+  } else if cp < 0x3a {
     true
-  } else if (cp as u32) < 0x41 {
+  } else if cp < 0x41 {
     false
-  } else if (cp as u32) < 0x5b || (cp as u32) == 0x5f {
+  } else if cp < 0x5b || cp == 0x5f {
     true
-  } else if (cp as u32) < 0x61 {
+  } else if cp < 0x61 {
     false
-  } else if (cp as u32) < 0x7b {
+  } else if cp < 0x7b {
     true
   } else {
     is_large_id_start(cp) || is_large_id_continue(cp)
@@ -504,7 +504,9 @@ impl EcmaRegexValidator {
 
     if self.ecma_version >= EcmaVersion::Es2018 {
       self.consume_group_specifier()?;
-    } else if self.code_point_with_offset(0) == Some('?') {
+    } else if self.code_point_with_offset(0).map(|c| c.to_u32())
+      == Some('?' as u32)
+    {
       return Err("Invalid group".to_string());
     }
 
@@ -547,8 +549,8 @@ impl EcmaRegexValidator {
   /// ```
   /// Returns `true` if it consumed the next characters successfully.
   fn consume_reverse_solidus_followed_by_c(&mut self) -> bool {
-    if self.code_point_with_offset(0) == Some('\\')
-      && self.code_point_with_offset(1) == Some('c')
+    if self.code_point_with_offset(0).map(|c| c.to_u32()) == Some('\\' as u32)
+      && self.code_point_with_offset(1).map(|c| c.to_u32()) == Some('c' as u32)
     {
       self.last_int_value = '\\' as i64;
       self.advance();
@@ -861,7 +863,7 @@ impl EcmaRegexValidator {
     if let Some(cp) = self.code_point_with_offset(0) {
       if cp != '\\' && cp != ']' {
         self.advance();
-        self.last_int_value = cp as i64;
+        self.last_int_value = cp.to_u32() as i64;
         return Ok(true);
       }
     }
@@ -870,7 +872,10 @@ impl EcmaRegexValidator {
       if self.consume_class_escape()? {
         return Ok(true);
       }
-      if !self.strict && self.code_point_with_offset(0) == Some('c') {
+      if !self.strict
+        && self.code_point_with_offset(0).map(|c| c.to_u32())
+          == Some('c' as u32)
+      {
         self.last_int_value = '\\' as i64;
         return Ok(true);
       }
@@ -911,13 +916,13 @@ impl EcmaRegexValidator {
     // [annexB][~U] `c` ClassControlLetter
     if !self.strict
       && !self.u_flag
-      && self.code_point_with_offset(0) == Some('c')
+      && self.code_point_with_offset(0).map(|c| c.to_u32()) == Some('c' as u32)
     {
       if let Some(cp) = self.code_point_with_offset(1) {
         if cp.is_ascii_digit() || cp == '_' {
           self.advance();
           self.advance();
-          self.last_int_value = cp as i64 % 0x20;
+          self.last_int_value = cp.to_u32() as i64 % 0x20;
           return Ok(true);
         }
       }
@@ -993,22 +998,21 @@ impl EcmaRegexValidator {
       self.advance();
       let cp1 = self.code_point_with_offset(0);
       if cp == '\\' && self.eat_regexp_unicode_escape_sequence(force_u_flag)? {
-        cp = std::char::from_u32(self.last_int_value as u32).unwrap();
+        cp = (self.last_int_value as u32).into();
       } else if force_u_flag
-        && is_lead_surrogate(cp as i64)
+        && is_lead_surrogate(cp.to_i64())
         && cp1.is_some()
-        && is_trail_surrogate(cp1.unwrap() as i64)
+        && is_trail_surrogate(cp1.unwrap().to_i64())
       {
-        cp = std::char::from_u32(combine_surrogate_pair(
-          cp as i64,
-          cp1.unwrap() as i64,
-        ) as u32)
-        .unwrap();
+        cp = UnicodeChar::from(combine_surrogate_pair(
+          cp.to_i64(),
+          cp1.unwrap().to_i64(),
+        ) as u32);
         self.advance();
       }
 
       if is_regexp_identifier_start(cp) {
-        self.last_int_value = cp as i64;
+        self.last_int_value = cp.to_i64();
         return Ok(true);
       }
     }
@@ -1040,25 +1044,25 @@ impl EcmaRegexValidator {
     self.advance();
     let cp1 = self.code_point_with_offset(0);
 
-    if cp == Some('\\')
+    if cp == Some('\\'.into())
       && self.eat_regexp_unicode_escape_sequence(force_u_flag)?
     {
       // TODO: convert unicode code point to char
-      cp = std::char::from_u32(self.last_int_value as u32);
+      cp = Some((self.last_int_value as u32).into());
     } else if force_u_flag
-      && is_lead_surrogate(cp.unwrap() as i64)
-      && is_trail_surrogate(cp1.unwrap() as i64)
+      && is_lead_surrogate(cp.unwrap().to_i64())
+      && is_trail_surrogate(cp1.unwrap().to_i64())
     {
-      cp = std::char::from_u32(combine_surrogate_pair(
-        cp.unwrap() as i64,
-        cp1.unwrap() as i64,
-      ) as u32);
+      cp = Some(UnicodeChar::from(combine_surrogate_pair(
+        cp.unwrap().to_i64(),
+        cp1.unwrap().to_i64(),
+      ) as u32));
       self.advance();
     }
 
     if let Some(c) = cp {
       if is_regexp_identifier_part(c) {
-        self.last_int_value = c as i64;
+        self.last_int_value = c.to_i64();
         return Ok(true);
       }
     }
@@ -1093,7 +1097,7 @@ impl EcmaRegexValidator {
   /// ```
   /// Returns `true` if it ate the next characters successfully.
   fn eat_zero(&mut self) -> bool {
-    if self.code_point_with_offset(0) != Some('0') {
+    if self.code_point_with_offset(0).map(|c| c.to_u32()) != Some('0' as u32) {
       return false;
     } else if let Some(cp) = self.code_point_with_offset(1) {
       if cp.is_ascii_digit() {
@@ -1149,7 +1153,7 @@ impl EcmaRegexValidator {
     if let Some(cp) = self.code_point_with_offset(0) {
       if cp.is_ascii_alphabetic() {
         self.advance();
-        self.last_int_value = cp as i64 % 0x20;
+        self.last_int_value = cp.to_i64() % 0x20;
         return true;
       }
     }
@@ -1258,14 +1262,14 @@ impl EcmaRegexValidator {
   fn eat_identity_escape(&mut self) -> bool {
     if let Some(cp) = self.code_point_with_offset(0) {
       if self.is_valid_identity_escape(cp) {
-        self.last_int_value = cp as i64;
+        self.last_int_value = cp.to_i64();
         self.advance();
         return true;
       }
     }
     false
   }
-  fn is_valid_identity_escape(&self, cp: char) -> bool {
+  fn is_valid_identity_escape(&self, cp: UnicodeChar) -> bool {
     if self.u_flag {
       is_syntax_character(cp) || cp == '/'
     } else if self.strict {

--- a/src/js_regex/validator.rs
+++ b/src/js_regex/validator.rs
@@ -1373,7 +1373,7 @@ impl EcmaRegexValidator {
       if !is_unicode_property_name_character(cp) {
         break;
       }
-      self.last_str_value.push(cp);
+      self.last_str_value.push(cp.to_char().unwrap());
       self.advance();
     }
     !self.last_str_value.is_empty()
@@ -1392,7 +1392,7 @@ impl EcmaRegexValidator {
       if !is_unicode_property_value_character(cp) {
         break;
       }
-      self.last_str_value.push(cp);
+      self.last_str_value.push(cp.to_char().unwrap());
       self.advance();
     }
     !self.last_str_value.is_empty()
@@ -1580,10 +1580,14 @@ impl EcmaRegexValidator {
         in_class = false;
       } else if cp == '('
         && !in_class
-        && (self.code_point_with_offset(1) != Some('?')
-          || (self.code_point_with_offset(2) == Some('<')
-            && self.code_point_with_offset(3) != Some('=')
-            && self.code_point_with_offset(3) != Some('!')))
+        && (self.code_point_with_offset(1).map(|c| c.to_u32())
+          != Some('?' as u32)
+          || (self.code_point_with_offset(2).map(|c| c.to_u32())
+            == Some('<' as u32)
+            && self.code_point_with_offset(3).map(|c| c.to_u32())
+              != Some('=' as u32)
+            && self.code_point_with_offset(3).map(|c| c.to_u32())
+              != Some('!' as u32)))
       {
         count += 1
       }


### PR DESCRIPTION
Fixes https://github.com/denoland/deno_lint/issues/1052.

Instead of using a `char` to represent values, just store a `u32`. This way we never construct invalid `char`s, which is UB.