### PR TITLE
fix: remove process global check

### DIFF
--- a/docs/rules/no_node_globals.md
+++ b/docs/rules/no_node_globals.md
@@ -8,14 +8,14 @@ their defining modules as needed.
 
 ```typescript
 // foo.ts
-const foo = process.env.FOO; // process is not a global object in deno
+const buf = Buffer.from("foo", "utf-8"); // Buffer is not a global object in deno
 ```
 
 ### Valid:
 
 ```typescript
 // foo.ts
-import process from "node:process";
+import { Buffer } from "node:buffer";
 
-const foo = process.env.FOO;
+const foo = Buffer.from("foo", "utf-8");
 ```

--- a/src/rules/no_node_globals.rs
+++ b/src/rules/no_node_globals.rs
@@ -22,7 +22,6 @@ const CODE: &str = "no-node-globals";
 const MESSAGE: &str = "NodeJS globals are not available in Deno";
 
 static NODE_GLOBALS: phf::Map<&'static str, FixKind> = phf::phf_map! {
-  "process" => FixKind::Import { module: "node:process", import: "process" },
   "Buffer" => FixKind::Import { module: "node:buffer", import: "{ Buffer }" },
   "global" => FixKind::Replace("globalThis"),
   "setImmediate" => FixKind::Import { module: "node:timers", import: "{ setImmediate }" },
@@ -201,8 +200,6 @@ mod tests {
   fn valid() {
     assert_lint_ok! {
       NoNodeGlobals,
-      "import process from 'node:process';\nconst a = process.env;",
-      "const process = { env: {} };\nconst a = process.env;",
       "import { Buffer } from 'node:buffer';\nconst b = Buffer;",
       "const Buffer = {};\nconst b = Buffer;",
       "const global = globalThis;\nconst c = global;",
@@ -215,30 +212,6 @@ mod tests {
   fn invalid() {
     assert_lint_err! {
       NoNodeGlobals,
-      "import a from 'b';\nconst e = process.env;": [
-        {
-          col: 10,
-          line: 2,
-          message: MESSAGE,
-          hint: "Add `import process from \"node:process\";`",
-          fix: (
-            "Import from \"node:process\"",
-            "import a from 'b';\nimport process from \"node:process\";\nconst e = process.env;"
-          ),
-        }
-      ],
-      "const a = process;": [
-        {
-          col: 10,
-          line: 1,
-          message: MESSAGE,
-          hint: "Add `import process from \"node:process\";`",
-          fix: (
-            "Import from \"node:process\"",
-            "import process from \"node:process\";\nconst a = process;"
-          ),
-        }
-      ],
       "const b = Buffer;": [
         {
           col: 10,
@@ -287,15 +260,15 @@ mod tests {
           ),
         }
       ],
-      "const a = process.env;\nconst b = Buffer;": [
+      "const a = setImmediate;\nconst b = Buffer;": [
         {
           col: 10,
           line: 1,
           message: MESSAGE,
-          hint: "Add `import process from \"node:process\";`",
+          hint: "Add `import { setImmediate } from \"node:timers\";`",
           fix: (
-            "Import from \"node:process\"",
-            "import process from \"node:process\";\nconst a = process.env;\nconst b = Buffer;"
+            "Import from \"node:timers\"",
+            "import { setImmediate } from \"node:timers\";\nconst a = setImmediate;\nconst b = Buffer;"
           ),
         },
         {
@@ -305,19 +278,19 @@ mod tests {
           hint: "Add `import { Buffer } from \"node:buffer\";`",
           fix: (
             "Import from \"node:buffer\"",
-            "import { Buffer } from \"node:buffer\";\nconst a = process.env;\nconst b = Buffer;"
+            "import { Buffer } from \"node:buffer\";\nconst a = setImmediate;\nconst b = Buffer;"
           ),
         }
       ],
-      "// A copyright notice\n\nconst a = process.env;": [
+      "// A copyright notice\n\nconst a = setImmediate;": [
         {
           col: 10,
           line: 3,
           message: MESSAGE,
-          hint: "Add `import process from \"node:process\";`",
+          hint: "Add `import { setImmediate } from \"node:timers\";`",
           fix: (
-            "Import from \"node:process\"",
-            "// A copyright notice\n\nimport process from \"node:process\";\nconst a = process.env;"
+            "Import from \"node:timers\"",
+            "// A copyright notice\n\nimport { setImmediate } from \"node:timers\";\nconst a = setImmediate;"
           ),
         }
       ]

--- a/www/static/docs.json
+++ b/www/static/docs.json
@@ -419,7 +419,7 @@
   },
   {
     "code": "no-node-globals",
-    "docs": "Disallows the use of NodeJS global objects.\n\nNodeJS exposes a set of global objects that differs from deno (and the web), so\ncode should not assume they are available. Instead, import the objects from\ntheir defining modules as needed.\n\n### Invalid:\n\n```typescript\n// foo.ts\nconst foo = process.env.FOO; // process is not a global object in deno\n```\n\n### Valid:\n\n```typescript\n// foo.ts\nimport process from \"node:process\";\n\nconst foo = process.env.FOO;\n```\n",
+    "docs": "Disallows the use of NodeJS global objects.\n\nNodeJS exposes a set of global objects that differs from deno (and the web), so\ncode should not assume they are available. Instead, import the objects from\ntheir defining modules as needed.\n\n### Invalid:\n\n```typescript\n// foo.ts\nconst buf = Buffer.from(\"foo\", \"utf-8\"); // Buffer is not a global object in deno\n```\n\n### Valid:\n\n```typescript\n// foo.ts\nimport { Buffer } from \"node:buffer\";\n\nconst foo = Buffer.from(\"foo\", \"utf-8\");\n```\n",
     "tags": [
       "recommended"
     ]


### PR DESCRIPTION
Deno 2 will ship with the `process` global being available by default.

See https://github.com/denoland/deno/issues/25679