### PR TITLE
refactor: adjust rule code for `no-process-global` to ensure consistency

### DIFF
--- a/schemas/rules.v1.json
+++ b/schemas/rules.v1.json
@@ -70,7 +70,7 @@
     "no-non-null-assertion",
     "no-obj-calls",
     "no-octal",
-    "no-process-globals",
+    "no-process-global",
     "no-prototype-builtins",
     "no-redeclare",
     "no-regex-spaces",

--- a/src/rules/no_process_global.rs
+++ b/src/rules/no_process_global.rs
@@ -17,7 +17,7 @@ use deno_ast::SourceRangedForSpanned;
 #[derive(Debug)]
 pub struct NoProcessGlobal;
 
-const CODE: &str = "no-process-globals";
+const CODE: &str = "no-process-global";
 const MESSAGE: &str = "NodeJS process global is discouraged in Deno";
 
 impl LintRule for NoProcessGlobal {

--- a/www/static/docs.json
+++ b/www/static/docs.json
@@ -449,7 +449,7 @@
     ]
   },
   {
-    "code": "no-process-globals",
+    "code": "no-process-global",
     "docs": "Disallows the use of NodeJS `process` global.\n\nNodeJS and Deno expose `process` global but they are hard to statically analyze\nby tools, so code should not assume they are available. Instead,\n`import process from \"node:process\"`.\n\n### Invalid:\n\n```typescript\n// foo.ts\nconst foo = process.env.FOO;\n```\n\n### Valid:\n\n```typescript\n// foo.ts\nimport process from \"node:process\";\n\nconst foo = process.env.FOO;\n```\n",
     "tags": [
       "recommended"


### PR DESCRIPTION
# PR Summary
The PR updates the code of the  [`no-process-global`](https://github.com/denoland/deno_lint/blob/main/src/rules/no_process_global.rs) rule to be `no-process-global` instead of `no-process-globals` in order to be consistent as other rules (code and name are the same). Other than confusion, it solves issues like accessing the rule source code in the [website](https://lint.deno.land/rules/no-process-globals) which currently leads to broken page (press on the [Rule source](https://github.com/denoland/deno_lint/blob/main/src/rules/no_process_globals.rs) button in the rule [page](https://lint.deno.land/rules/no-process-globals)).