### PR TITLE
feat: add jsx-no-comment-text-nodes rule

### DIFF
--- a/docs/rules/jsx_no_comment_text_nodes.md
+++ b/docs/rules/jsx_no_comment_text_nodes.md
@@ -1,0 +1,14 @@
+Prevent comment strings being accidentally passed as text in JSX.
+
+### Invalid:
+
+```tsx
+const foo = <div>// comment</div>;
+const foo = <div>/* comment */</div>;
+```
+
+### Valid:
+
+```tsx
+const foo = <div>{/* comment */}</div>;
+```

--- a/schemas/rules.v1.json
+++ b/schemas/rules.v1.json
@@ -24,6 +24,7 @@
     "jsx-curly-braces",
     "jsx-key",
     "jsx-no-children-prop",
+    "jsx-no-comment-text-nodes",
     "jsx-no-danger-with-children",
     "jsx-no-duplicate-props",
     "jsx-no-useless-fragment",

--- a/src/rules.rs
+++ b/src/rules.rs
@@ -31,6 +31,7 @@ pub mod jsx_boolean_value;
 pub mod jsx_curly_braces;
 pub mod jsx_key;
 pub mod jsx_no_children_prop;
+pub mod jsx_no_comment_text_nodes;
 pub mod jsx_no_danger_with_children;
 pub mod jsx_no_duplicate_props;
 pub mod jsx_no_useless_fragment;
@@ -274,6 +275,7 @@ fn get_all_rules_raw() -> Vec<Box<dyn LintRule>> {
     Box::new(jsx_curly_braces::JSXCurlyBraces),
     Box::new(jsx_key::JSXKey),
     Box::new(jsx_no_children_prop::JSXNoChildrenProp),
+    Box::new(jsx_no_comment_text_nodes::JSXNoCommentTextNodes),
     Box::new(jsx_no_danger_with_children::JSXNoDangerWithChildren),
     Box::new(jsx_no_duplicate_props::JSXNoDuplicateProps),
     Box::new(jsx_no_useless_fragment::JSXNoUselessFragment),

--- a/src/rules/jsx_no_comment_text_nodes.rs
+++ b/src/rules/jsx_no_comment_text_nodes.rs
@@ -1,0 +1,88 @@
+// Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
+
+use super::{Context, LintRule};
+use crate::handler::{Handler, Traverse};
+use crate::tags::Tags;
+use crate::{tags, Program};
+use deno_ast::view::JSXText;
+use deno_ast::SourceRanged;
+
+#[derive(Debug)]
+pub struct JSXNoCommentTextNodes;
+
+const CODE: &str = "jsx-no-comment-text-nodes";
+
+impl LintRule for JSXNoCommentTextNodes {
+  fn tags(&self) -> Tags {
+    &[tags::RECOMMENDED, tags::REACT, tags::JSX, tags::FRESH]
+  }
+
+  fn code(&self) -> &'static str {
+    CODE
+  }
+
+  fn lint_program_with_ast_view(
+    &self,
+    context: &mut Context,
+    program: Program,
+  ) {
+    JSXNoCommentTextNodesHandler.traverse(program, context);
+  }
+
+  #[cfg(feature = "docs")]
+  fn docs(&self) -> &'static str {
+    include_str!("../../docs/rules/jsx_no_comment_text_nodes.md")
+  }
+}
+
+const MESSAGE: &str =
+  "Comments inside children should be placed inside curly braces";
+
+struct JSXNoCommentTextNodesHandler;
+
+impl Handler for JSXNoCommentTextNodesHandler {
+  fn jsx_text(&mut self, node: &JSXText, ctx: &mut Context) {
+    //
+    let value = &node.inner.value;
+    if value.starts_with("//") || value.starts_with("/*") {
+      ctx.add_diagnostic(node.range(), CODE, MESSAGE);
+    }
+  }
+}
+
+// most tests are taken from ESlint, commenting those
+// requiring code path support
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn jsx_no_comment_text_nodes_valid() {
+    assert_lint_ok! {
+      JSXNoCommentTextNodes,
+      filename: "file:///foo.jsx",
+      // non derived classes.
+      r#"<div>{/* comment */}</div>"#,
+    };
+  }
+
+  #[test]
+  fn jsx_no_comment_text_nodes_invalid() {
+    assert_lint_err! {
+      JSXNoCommentTextNodes,
+      filename: "file:///foo.jsx",
+      "<div>// comment</div>": [
+        {
+          col: 5,
+          message: MESSAGE,
+        }
+      ],
+      r#"<div>/* comment */</div>"#: [
+        {
+          col: 5,
+          message: MESSAGE,
+        }
+      ],
+    };
+  }
+}

--- a/src/rules/jsx_no_comment_text_nodes.rs
+++ b/src/rules/jsx_no_comment_text_nodes.rs
@@ -42,7 +42,6 @@ struct JSXNoCommentTextNodesHandler;
 
 impl Handler for JSXNoCommentTextNodesHandler {
   fn jsx_text(&mut self, node: &JSXText, ctx: &mut Context) {
-    //
     let value = &node.inner.value;
     if value.starts_with("//") || value.starts_with("/*") {
       ctx.add_diagnostic(node.range(), CODE, MESSAGE);

--- a/www/static/docs.json
+++ b/www/static/docs.json
@@ -159,6 +159,16 @@
     ]
   },
   {
+    "code": "jsx-no-comment-text-nodes",
+    "docs": "Prevent comment strings being accidentally passed as text in JSX.\n\n### Invalid:\n\n```tsx\nconst foo = <div>// comment</div>;\nconst foo = <div>/* comment */</div>;\n```\n\n### Valid:\n\n```tsx\nconst foo = <div>{/* comment */}</div>;\n```\n",
+    "tags": [
+      "recommended",
+      "react",
+      "jsx",
+      "fresh"
+    ]
+  },
+  {
     "code": "jsx-no-danger-with-children",
     "docs": "Using JSX children together with `dangerouslySetInnerHTML` is invalid as they\nwill be ignored.\n\n### Invalid:\n\n```tsx\n<div dangerouslySetInnerHTML={{ __html: \"<h1>hello</h1>\" }}>\n  <h1>this will never be rendered</h1>\n</div>;\n```\n\n### Valid:\n\n```tsx\n<div dangerouslySetInnerHTML={{ __html: \"<h1>hello</h1>\" }} />;\n```\n",
     "tags": [

--- a/www/static/docs.json
+++ b/www/static/docs.json
@@ -184,7 +184,8 @@
     "tags": [
       "recommended",
       "react",
-      "jsx"
+      "jsx",
+      "fresh"
     ]
   },
   {

--- a/www/static/docs.json
+++ b/www/static/docs.json
@@ -184,8 +184,7 @@
     "tags": [
       "recommended",
       "react",
-      "jsx",
-      "fresh"
+      "jsx"
     ]
   },
   {


### PR DESCRIPTION
Passing code comments as JSX text nodes is a common mistake. This Lint rule checks if a code comment was accidentally passed as JSX text by checking if it starts with `//` or `/*`.