### PR TITLE
feat: add jsx-no-duplicate-props rule

### DIFF
--- a/docs/rules/jsx_no_duplicate_props.md
+++ b/docs/rules/jsx_no_duplicate_props.md
@@ -1,0 +1,19 @@
+Disallow duplicated JSX props. Later props will always overwrite earlier props
+often leading to unexpected results.
+
+### Invalid:
+
+```tsx
+<div id="1" id="2" />;
+<App a a />;
+<App a {...b} a />;
+```
+
+### Valid:
+
+```tsx
+<div id="1" />
+<App a />
+<App a {...b} />
+<App {...b} b />
+```

--- a/schemas/rules.v1.json
+++ b/schemas/rules.v1.json
@@ -19,6 +19,7 @@
     "fresh-server-event-handlers",
     "getter-return",
     "guard-for-in",
+    "jsx-no-duplicate-props",
     "jsx-props-no-spread-multi",
     "no-array-constructor",
     "no-async-promise-executor",

--- a/src/rules.rs
+++ b/src/rules.rs
@@ -24,6 +24,7 @@ pub mod fresh_handler_export;
 pub mod fresh_server_event_handlers;
 pub mod getter_return;
 pub mod guard_for_in;
+pub mod jsx_no_duplicate_props;
 pub mod jsx_props_no_spread_multi;
 pub mod no_array_constructor;
 pub mod no_async_promise_executor;
@@ -257,6 +258,7 @@ fn get_all_rules_raw() -> Vec<Box<dyn LintRule>> {
     Box::new(fresh_server_event_handlers::FreshServerEventHandlers),
     Box::new(getter_return::GetterReturn),
     Box::new(guard_for_in::GuardForIn),
+    Box::new(jsx_no_duplicate_props::JSXNoDuplicateProps),
     Box::new(jsx_props_no_spread_multi::JSXPropsNoSpreadMulti),
     Box::new(no_array_constructor::NoArrayConstructor),
     Box::new(no_async_promise_executor::NoAsyncPromiseExecutor),

--- a/src/rules/jsx_no_duplicate_props.rs
+++ b/src/rules/jsx_no_duplicate_props.rs
@@ -15,7 +15,7 @@ const CODE: &str = "jsx-no-duplicate-props";
 
 impl LintRule for JSXNoDuplicateProps {
   fn tags(&self) -> &'static [&'static str] {
-    &["react", "jsx"]
+    &["recommended", "react", "jsx"]
   }
 
   fn code(&self) -> &'static str {

--- a/src/rules/jsx_no_duplicate_props.rs
+++ b/src/rules/jsx_no_duplicate_props.rs
@@ -1,0 +1,117 @@
+// Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
+
+use std::collections::HashSet;
+
+use super::{Context, LintRule};
+use crate::handler::{Handler, Traverse};
+use crate::Program;
+use deno_ast::view::{JSXAttrName, JSXAttrOrSpread, JSXOpeningElement};
+use deno_ast::SourceRanged;
+
+#[derive(Debug)]
+pub struct JSXNoDuplicateProps;
+
+const CODE: &str = "jsx-no-duplicate-props";
+
+impl LintRule for JSXNoDuplicateProps {
+  fn tags(&self) -> &'static [&'static str] {
+    &["react", "jsx"]
+  }
+
+  fn code(&self) -> &'static str {
+    CODE
+  }
+
+  fn lint_program_with_ast_view(
+    &self,
+    context: &mut Context,
+    program: Program,
+  ) {
+    JSXNoDuplicatedPropsHandler.traverse(program, context);
+  }
+
+  #[cfg(feature = "docs")]
+  fn docs(&self) -> &'static str {
+    include_str!("../../docs/rules/jsx_no_duplicate_props.md")
+  }
+}
+
+const MESSAGE: &str = "Duplicate JSX attribute found.";
+const HINT: &str = "Remove the duplicated attribute.";
+
+struct JSXNoDuplicatedPropsHandler;
+
+impl Handler for JSXNoDuplicatedPropsHandler {
+  fn jsx_opening_element(
+    &mut self,
+    node: &JSXOpeningElement,
+    ctx: &mut Context,
+  ) {
+    let mut seen: HashSet<&'_ str> = HashSet::new();
+    for attr in node.attrs {
+      if let JSXAttrOrSpread::JSXAttr(attr_name) = attr {
+        if let JSXAttrName::Ident(id) = attr_name.name {
+          let name = id.sym().as_str();
+          if seen.contains(name) {
+            ctx.add_diagnostic_with_hint(id.range(), CODE, MESSAGE, HINT);
+          }
+
+          seen.insert(name);
+        }
+      }
+    }
+  }
+}
+
+// most tests are taken from ESlint, commenting those
+// requiring code path support
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn jsx_no_duplicate_props_valid() {
+    assert_lint_ok! {
+      JSXNoDuplicateProps,
+      filename: "file:///foo.jsx",
+      "<App a b />",
+      "<div a b />",
+    };
+  }
+
+  #[test]
+  fn jsx_no_duplicate_props_invalid() {
+    assert_lint_err! {
+      JSXNoDuplicateProps,
+      filename: "file:///foo.jsx",
+      "<div a a />": [
+        {
+          col: 7,
+          message: MESSAGE,
+          hint: HINT,
+        }
+      ],
+      "<App a a />": [
+        {
+          col: 7,
+          message: MESSAGE,
+          hint: HINT,
+        }
+      ],
+      "<App a {...b} a />": [
+        {
+          col: 14,
+          message: MESSAGE,
+          hint: HINT,
+        }
+      ],
+      "<div a {...b} a />": [
+        {
+          col: 14,
+          message: MESSAGE,
+          hint: HINT,
+        }
+      ]
+    };
+  }
+}

--- a/www/static/docs.json
+++ b/www/static/docs.json
@@ -115,6 +115,7 @@
     "code": "jsx-no-duplicate-props",
     "docs": "Disallow duplicated JSX props. Later props will always overwrite earlier props\noften leading to unexpected results.\n\n### Invalid:\n\n```tsx\n<div id=\"1\" id=\"2\" />;\n<App a a />;\n<App a {...b} a />;\n```\n\n### Valid:\n\n```tsx\n<div id=\"1\" />\n<App a />\n<App a {...b} />\n<App {...b} b />\n```\n",
     "tags": [
+      "recommended",
       "react",
       "jsx"
     ]

--- a/www/static/docs.json
+++ b/www/static/docs.json
@@ -112,6 +112,14 @@
     "tags": []
   },
   {
+    "code": "jsx-no-duplicate-props",
+    "docs": "Disallow duplicated JSX props. Later props will always overwrite earlier props\noften leading to unexpected results.\n\n### Invalid:\n\n```tsx\n<div id=\"1\" id=\"2\" />;\n<App a a />;\n<App a {...b} a />;\n```\n\n### Valid:\n\n```tsx\n<div id=\"1\" />\n<App a />\n<App a {...b} />\n<App {...b} b />\n```\n",
+    "tags": [
+      "react",
+      "jsx"
+    ]
+  },
+  {
     "code": "jsx-props-no-spread-multi",
     "docs": "Spreading the same expression twice is typically a mistake and causes\nunnecessary computations.\n\n### Invalid:\n\n```tsx\n<div {...foo} {...foo} />\n<div {...foo} a {...foo} />\n<Foo {...foo.bar} {...foo.bar} />\n```\n\n### Valid:\n\n```tsx\n<div {...foo} />\n<div {...foo.bar} a />\n<Foo {...foo.bar} />\n```\n",
     "tags": [


### PR DESCRIPTION
Ensure that the same prop is not passed twice to a JSX node. This is typically a mistake.