### PR TITLE
feat: add jsx-no-useless-fragment rule

### DIFF
--- a/docs/rules/jsx_no_useless_fragment.md
+++ b/docs/rules/jsx_no_useless_fragment.md
@@ -1,0 +1,20 @@
+Fragments are only necessary at the top of a JSX "block" and only when there are
+multiple children. Fragments are not needed in other scenarios.
+
+### Invalid:
+
+```tsx
+<></>
+<><div /></>
+<><App /></>
+<p>foo <>bar</></p>
+```
+
+### Valid:
+
+```tsx
+<>{foo}</>
+<><div /><div /></>
+<>foo <div /></>
+<p>foo bar</p>
+```

--- a/src/rules.rs
+++ b/src/rules.rs
@@ -24,6 +24,7 @@ pub mod fresh_handler_export;
 pub mod fresh_server_event_handlers;
 pub mod getter_return;
 pub mod guard_for_in;
+pub mod jsx_no_useless_fragment;
 pub mod no_array_constructor;
 pub mod no_async_promise_executor;
 pub mod no_await_in_loop;
@@ -255,6 +256,7 @@ fn get_all_rules_raw() -> Vec<Box<dyn LintRule>> {
     Box::new(fresh_server_event_handlers::FreshServerEventHandlers),
     Box::new(getter_return::GetterReturn),
     Box::new(guard_for_in::GuardForIn),
+    Box::new(jsx_no_useless_fragment::JSXNoUselessFragment),
     Box::new(no_array_constructor::NoArrayConstructor),
     Box::new(no_async_promise_executor::NoAsyncPromiseExecutor),
     Box::new(no_await_in_loop::NoAwaitInLoop),

--- a/src/rules/jsx_no_useless_fragment.rs
+++ b/src/rules/jsx_no_useless_fragment.rs
@@ -1,0 +1,121 @@
+// Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
+
+use super::{Context, LintRule};
+use crate::handler::{Handler, Traverse};
+use crate::Program;
+use deno_ast::view::{JSXElement, JSXElementChild, JSXFragment};
+use deno_ast::SourceRanged;
+
+#[derive(Debug)]
+pub struct JSXNoUselessFragment;
+
+const CODE: &str = "jsx-no-useless-fragment";
+
+impl LintRule for JSXNoUselessFragment {
+  fn tags(&self) -> &'static [&'static str] {
+    &["react", "jsx", "fresh"]
+  }
+
+  fn code(&self) -> &'static str {
+    CODE
+  }
+
+  fn lint_program_with_ast_view(
+    &self,
+    context: &mut Context,
+    program: Program,
+  ) {
+    JSXNoUselessFragmentHandler.traverse(program, context);
+  }
+
+  #[cfg(feature = "docs")]
+  fn docs(&self) -> &'static str {
+    include_str!("../../docs/rules/jsx_no_useless_fragment.md")
+  }
+}
+
+const MESSAGE: &str = "Unnecessary Fragment detected";
+const HINT: &str = "Remove this Fragment";
+
+struct JSXNoUselessFragmentHandler;
+
+impl Handler for JSXNoUselessFragmentHandler {
+  // Check root fragments
+  fn jsx_fragment(&mut self, node: &JSXFragment, ctx: &mut Context) {
+    if node.children.is_empty() {
+      ctx.add_diagnostic_with_hint(node.range(), CODE, MESSAGE, HINT);
+    } else if node.children.len() == 1 {
+      if let Some(first) = &node.children.first() {
+        match first {
+          JSXElementChild::JSXElement(_) | JSXElementChild::JSXFragment(_) => {
+            ctx.add_diagnostic_with_hint(node.range(), CODE, MESSAGE, HINT);
+          }
+          _ => {}
+        }
+      }
+    }
+  }
+
+  fn jsx_element(&mut self, node: &JSXElement, ctx: &mut Context) {
+    for child in node.children {
+      if let JSXElementChild::JSXFragment(frag) = child {
+        ctx.add_diagnostic_with_hint(frag.range(), CODE, MESSAGE, HINT);
+      }
+    }
+  }
+}
+
+// most tests are taken from ESlint, commenting those
+// requiring code path support
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn jsx_no_useless_fragment_valid() {
+    assert_lint_ok! {
+      JSXNoUselessFragment,
+      filename: "file:///foo.jsx",
+      r#"<><div /><div /></>"#,
+      r#"<>foo<div /></>"#,
+      r#"<>{foo}</>"#,
+      r#"<>{foo}bar</>"#,
+    };
+  }
+
+  #[test]
+  fn jsx_no_useless_fragment_invalid() {
+    assert_lint_err! {
+      JSXNoUselessFragment,
+      filename: "file:///foo.jsx",
+      r#"<></>"#: [
+        {
+          col: 0,
+          message: MESSAGE,
+          hint: HINT,
+        }
+      ],
+      r#"<><div /></>"#: [
+        {
+          col: 0,
+          message: MESSAGE,
+          hint: HINT,
+        }
+      ],
+      r#"<p>foo <>bar</></p>"#: [
+        {
+          col: 7,
+          message: MESSAGE,
+          hint: HINT,
+        }
+      ],
+      r#"<p>foo <><div /><div /></></p>"#: [
+        {
+          col: 7,
+          message: MESSAGE,
+          hint: HINT,
+        }
+      ],
+    };
+  }
+}

--- a/www/static/docs.json
+++ b/www/static/docs.json
@@ -112,6 +112,15 @@
     "tags": []
   },
   {
+    "code": "jsx-no-useless-fragment",
+    "docs": "Fragments are only necessary at the top of a JSX \"block\" and only when there are\nmultiple children. Fragments are not needed in other scenarios.\n\n### Invalid:\n\n```tsx\n<></>\n<><div /></>\n<><App /></>\n<p>foo <>bar</></p>\n```\n\n### Valid:\n\n```tsx\n<>{foo}</>\n<><div /><div /></>\n<>foo <div /></>\n<p>foo bar</p>\n```\n",
+    "tags": [
+      "react",
+      "jsx",
+      "fresh"
+    ]
+  },
+  {
     "code": "no-array-constructor",
     "docs": "Enforce conventional usage of array construction\n\nArray construction is conventionally done via literal notation such as `[]` or\n`[1, 2, 3]`. Using the `new Array()` is discouraged as is `new Array(1, 2, 3)`.\nThere are two reasons for this. The first is that a single supplied argument\ndefines the array length, while multiple arguments instead populate the array of\nno fixed size. This confusion is avoided when pre-populated arrays are only\ncreated using literal notation. The second argument to avoiding the `Array`\nconstructor is that the `Array` global may be redefined.\n\nThe one exception to this rule is when creating a new array of fixed size, e.g.\n`new Array(6)`. This is the conventional way to create arrays of fixed length.\n\n### Invalid:\n\n```typescript\n// This is 4 elements, not a size 100 array of 3 elements\nconst a = new Array(100, 1, 2, 3);\n\nconst b = new Array(); // use [] instead\n```\n\n### Valid:\n\n```typescript\nconst a = new Array(100);\nconst b = [];\nconst c = [1, 2, 3];\n```\n",
     "tags": [


### PR DESCRIPTION
Fragments were introduced to allow multiple top level children on a JSX block. They're useless when used with a single child.