### PR TITLE
chore: update readme for new rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,3 +201,4 @@ Before submitting, please make sure the following is done:
    1. Run `cargo build --example dlint --all-features`
    2. Update docs by running the generated binary with these arguments
       `./target/debug/examples/dlint rules --json > www/static/docs.json`
+   3. Update schema via `deno task update-schemas`


### PR DESCRIPTION
Update readme to hint at running `deno task update-schemas` when adding a new rule