### PR TITLE
fix: rules-of-hooks not detecting hooks in hooks

### DIFF
--- a/src/rules/rules_of_hooks.rs
+++ b/src/rules/rules_of_hooks.rs
@@ -190,18 +190,8 @@ impl Handler for RulesOfHooksHandler {
       for item in self.parent_kind.iter().rev() {
         match item {
           ParentKind::Unknown => break,
-          ParentKind::Var(name) => {
-            if !is_hook_or_component_name(name) {
-              ctx.add_diagnostic_with_hint(
-                node.range(),
-                CODE,
-                DiagnosticKind::OutsideComponent.message(),
-                DiagnosticKind::OutsideComponent.hint(),
-              );
-            }
+          ParentKind::Var(_) => continue,
 
-            break;
-          }
           ParentKind::Fn((name, cond_count)) => {
             if *cond_count > 0 {
               ctx.add_diagnostic_with_hint(
@@ -211,6 +201,7 @@ impl Handler for RulesOfHooksHandler {
                 DiagnosticKind::Conditionally.hint(),
               );
             } else if !is_hook_or_component_name(name) {
+              eprintln!("====");
               ctx.add_diagnostic_with_hint(
                 node.range(),
                 CODE,
@@ -289,8 +280,11 @@ mod tests {
       r#"export const Foo = () => { useState(0) }"#,
       r#"export function Foo() { useState(0) }"#,
       r#"const Foo = () => { useState(0) }"#,
+      r#"const useFoo = () => { useState(0) }"#,
       r#"function foo() { return function Foo() { useState(0) }}"#,
       r#"function foo() { return () => { useState(0) }}"#,
+      r#"function useFoo() { useState(0) }"#,
+      r#"function useFoo() { const foo = useState(0); }"#
     };
   }
 
@@ -367,6 +361,13 @@ mod tests {
           col: 23,
           message: DiagnosticKind::TryCatch.message(),
           hint: DiagnosticKind::TryCatch.hint(),
+        }
+      ],
+      r#"function foo() { const foo = useState(0); }"#: [
+        {
+          col: 29,
+          message: DiagnosticKind::OutsideComponent.message(),
+          hint: DiagnosticKind::OutsideComponent.hint(),
         }
       ],
     };


### PR DESCRIPTION
This fixes an error in the `rules-of-hooks` linting rule that didn't detect when a hook is inside another hook as part of a variable declaration.

```ts
// Valid, but would print a lint error
function useFoo() {
  const foo = useState(0);
}
```

Upon looking at the code further it turns out that the variable declaration handling is less involved.