### PR TITLE
fix(jsx-no-danger-with-children): account for ignored JSXText nodes

### DIFF
--- a/src/rules/jsx_no_danger_with_children.rs
+++ b/src/rules/jsx_no_danger_with_children.rs
@@ -38,7 +38,7 @@ const MESSAGE: &str =
 const HINT: &str = "Remove the JSX children";
 
 static IGNORE_TEXT: Lazy<regex::Regex> =
-  Lazy::new(|| regex::Regex::new(r#"\n\s+"#).unwrap());
+  Lazy::new(|| regex::Regex::new(r#"^\n\s+$"#).unwrap());
 
 struct JSXNoDangerWithChildrenHandler;
 


### PR DESCRIPTION
Technically, JSX children aren't empty in cases like this:

```jsx
<div>
</div>
```

Under the hood there is still a single child that contains only whitespace and is typically dropped during rendering.

```jsx
JSXText {
  text: "\n   "
}
```

I forgot about that when writing this rule.

Fixes https://github.com/denoland/deno_lint/issues/1398