### PR TITLE
feat: add no-empty-case

### DIFF
--- a/src/rules.rs
+++ b/src/rules.rs
@@ -59,6 +59,7 @@ pub mod no_dupe_else_if;
 pub mod no_dupe_keys;
 pub mod no_duplicate_case;
 pub mod no_empty;
+pub mod no_empty_case;
 pub mod no_empty_character_class;
 pub mod no_empty_enum;
 pub mod no_empty_interface;
@@ -300,6 +301,7 @@ fn get_all_rules_raw() -> Vec<Box<dyn LintRule>> {
     Box::new(no_dupe_keys::NoDupeKeys),
     Box::new(no_duplicate_case::NoDuplicateCase),
     Box::new(no_empty::NoEmpty),
+    Box::new(no_empty_case::NoEmptyCase),
     Box::new(no_empty_character_class::NoEmptyCharacterClass),
     Box::new(no_empty_enum::NoEmptyEnum),
     Box::new(no_empty_interface::NoEmptyInterface),

--- a/src/rules/no_empty_case.rs
+++ b/src/rules/no_empty_case.rs
@@ -1,0 +1,108 @@
+// Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
+
+use super::{Context, LintRule};
+use crate::diagnostic::{LintFix, LintFixChange};
+use crate::handler::{Handler, Traverse};
+use crate::tags::{self, Tags};
+use crate::Program;
+use deno_ast::view::NodeTrait;
+use deno_ast::SourceRanged;
+
+#[derive(Debug)]
+pub struct NoEmptyCase;
+
+const CODE: &str = "no-empty-case";
+const MESSAGE: &str = "An empty switch-case statement should be removed.";
+const HINT: &str = "Remove empty switch-case";
+
+impl LintRule for NoEmptyCase {
+  fn tags(&self) -> Tags {
+    &[tags::RECOMMENDED]
+  }
+
+  fn code(&self) -> &'static str {
+    CODE
+  }
+
+  fn lint_program_with_ast_view(
+    &self,
+    context: &mut Context,
+    program: Program<'_>,
+  ) {
+    NoEmptyCaseHandler.traverse(program, context);
+  }
+}
+
+struct NoEmptyCaseHandler;
+
+impl Handler for NoEmptyCaseHandler {
+  fn switch_case(
+    &mut self,
+    switch_case: &deno_ast::view::SwitchCase<'_>,
+    context: &mut Context,
+  ) {
+    if let [stmt] = switch_case.cons.iter().as_slice() {
+      let text = stmt.text();
+      if text[1..text.len() - 1].trim().is_empty() {
+        let range = stmt.range();
+        let change = LintFixChange {
+          new_text: "".into(),
+          range,
+        };
+        context.add_diagnostic_with_fixes(
+          range,
+          CODE,
+          MESSAGE,
+          Some(HINT.into()),
+          vec![LintFix {
+            description: HINT.into(),
+            changes: vec![change],
+          }],
+        );
+      }
+    }
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn valid() {
+    assert_lint_ok! {
+      NoEmptyCase,
+      "switch (n) {case 0:case 1:{// todo \n}}",
+      "switch (n) {case 0:case 1:default:}",
+    };
+  }
+
+  #[test]
+  fn invalid() {
+    assert_lint_err! {
+      NoEmptyCase,
+      "switch (n) {case 0:case 1:{}}": [{
+          col: 26,
+          line: 1,
+          message: MESSAGE,
+          hint: HINT,
+          fix: (
+            HINT,
+            "switch (n) {case 0:case 1:}"
+          ),
+        }
+      ],
+      "switch (n) {case 0:case 1:default:{}}": [{
+        col: 34,
+        line: 1,
+        message: MESSAGE,
+        hint: HINT,
+        fix: (
+          HINT,
+          "switch (n) {case 0:case 1:default:}"
+        ),
+      }
+    ],
+    }
+  }
+}

--- a/src/rules/no_empty_case.rs
+++ b/src/rules/no_empty_case.rs
@@ -42,7 +42,17 @@ impl Handler for NoEmptyCaseHandler {
     context: &mut Context,
   ) {
     if let [stmt] = switch_case.cons.iter().as_slice() {
+      // Only treat the case as empty when its single statement is an empty
+      // block (e.g. `case 0: {}`). Guarding on `Stmt::Block` avoids panicking
+      // on statements shorter than two characters (e.g. `case 0:;`) and avoids
+      // false positives on real statements (e.g. `case 0: a;`).
+      if !matches!(stmt, deno_ast::view::Stmt::Block(_)) {
+        return;
+      }
       let text = stmt.text();
+      // The block text between the surrounding braces must be whitespace-only.
+      // Slicing off the braces keeps comment-only blocks (e.g. `{ /* todo */ }`)
+      // from being reported as empty.
       if text[1..text.len() - 1].trim().is_empty() {
         let range = stmt.range();
         let change = LintFixChange {
@@ -74,6 +84,8 @@ mod tests {
       NoEmptyCase,
       "switch (n) {case 0:case 1:{// todo \n}}",
       "switch (n) {case 0:case 1:default:}",
+      "switch (n) { case 0:; }",
+      "switch (n) { case 0: a; }",
     };
   }
 


### PR DESCRIPTION
Remove empty switch-case statements

```js
switch (n) {
  case 0: { }
  case 1: { }
  default: {
    // TODO
  }
}
```
```js
switch (n) {
  case 0: 
  case 1: 
  default: {
    // TODO
  }
}
```


