### PR TITLE
dlint: add --fix

### DIFF
--- a/examples/dlint/diagnostics.rs
+++ b/examples/dlint/diagnostics.rs
@@ -1,8 +1,8 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
-use std::collections::HashSet;
 use deno_ast::{diagnostics::Diagnostic, SourceTextInfo};
 use deno_lint::diagnostic::LintDiagnostic;
+use std::collections::HashSet;
 
 pub fn display_diagnostics(
   diagnostics: &[LintDiagnostic],

--- a/examples/dlint/diagnostics.rs
+++ b/examples/dlint/diagnostics.rs
@@ -1,6 +1,7 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
-use deno_ast::diagnostics::Diagnostic;
+use std::collections::HashSet;
+use deno_ast::{diagnostics::Diagnostic, SourceTextInfo};
 use deno_lint::diagnostic::LintDiagnostic;
 
 pub fn display_diagnostics(
@@ -12,6 +13,53 @@ pub fn display_diagnostics(
     Some("pretty") => print_pretty(diagnostics),
     _ => unreachable!("Invalid output format specified"),
   }
+}
+
+pub(crate) fn apply_lint_fixes(
+  text_info: &SourceTextInfo,
+  diagnostics: &[LintDiagnostic],
+) -> Option<String> {
+  if diagnostics.is_empty() {
+    return None;
+  }
+
+  let file_start = text_info.range().start;
+  let mut quick_fixes = diagnostics
+    .iter()
+    // use the first quick fix
+    .filter_map(|d| d.details.fixes.first())
+    .flat_map(|fix| fix.changes.iter())
+    .map(|change| deno_ast::TextChange {
+      range: change.range.as_byte_range(file_start),
+      new_text: change.new_text.to_string(),
+    })
+    .collect::<Vec<_>>();
+  if quick_fixes.is_empty() {
+    return None;
+  }
+
+  let mut import_fixes = HashSet::new();
+  // remove any overlapping text changes, we'll circle
+  // back for another pass to fix the remaining
+  quick_fixes.sort_by_key(|change| change.range.start);
+  for i in (1..quick_fixes.len()).rev() {
+    let cur = &quick_fixes[i];
+    let previous = &quick_fixes[i - 1];
+    // hack: deduplicate import fixes to avoid creating errors
+    if previous.new_text.trim_start().starts_with("import ") {
+      import_fixes.insert(previous.new_text.trim().to_string());
+    }
+    let is_overlapping = cur.range.start <= previous.range.end;
+    if is_overlapping
+      || (cur.new_text.trim_start().starts_with("import ")
+        && import_fixes.contains(cur.new_text.trim()))
+    {
+      quick_fixes.remove(i);
+    }
+  }
+  let new_text =
+    deno_ast::apply_text_changes(text_info.text_str(), quick_fixes);
+  Some(new_text)
 }
 
 fn print_compact(diagnostics: &[LintDiagnostic]) {

--- a/examples/dlint/main.rs
+++ b/examples/dlint/main.rs
@@ -166,8 +166,8 @@ fn run_linter(
     diagnostics::display_diagnostics(d, format);
     if fix {
       let info = SourceTextInfo::new(source_code.clone().into());
-      let code = apply_lint_fixes(&info, d).expect("failed to apply_lint_fixes");
-      std::fs::write(file_path, code)?;
+      let s = apply_lint_fixes(&info, d).expect("failed to apply_lint_fixes");
+      std::fs::write(file_path, s)?;
     }
   }
 

--- a/examples/dlint/main.rs
+++ b/examples/dlint/main.rs
@@ -166,8 +166,9 @@ fn run_linter(
     diagnostics::display_diagnostics(d, format);
     if fix {
       let info = SourceTextInfo::new(source_code.clone().into());
-      let s = apply_lint_fixes(&info, d).expect("failed to apply_lint_fixes");
-      std::fs::write(file_path, s)?;
+      if let Some(s) = apply_lint_fixes(&info, d) {
+        std::fs::write(file_path, s)?;
+      }
     }
   }
 


### PR DESCRIPTION
Add `--fix` option to dlint, same as `deno lint --fix` command. This can be used with git to easily observe how a new change affects the code

apply_lint_fixes seems to be reusable? I simply copied from deno code