### PR TITLE
fix(rule-of-hooks): handle var decl with destructuring

### DIFF
--- a/src/rules/react_rules_of_hooks.rs
+++ b/src/rules/react_rules_of_hooks.rs
@@ -72,7 +72,7 @@ enum ParentKind {
   Loop,
   TryCatch,
   Var(String), // var decl with identifier
-  VarOther, // var decl with other pattern (e.g. array, object)
+  VarOther,    // var decl with other pattern (e.g. array, object)
   Unknown,
 }
 


### PR DESCRIPTION
This PR fixes a case of rule-of-hooks. Currently the example below doesn't produce lint diagnostics because of the handling of var declaration:

```js
function Foo() {
  if (cond) {
    const [state, setState] = useState(0);
  }
}
```

This PR fixes the above case.