### PR TITLE
fix(jsx-curly-braces): ignore values that require escaping

### DIFF
--- a/src/rules/jsx_curly_braces.rs
+++ b/src/rules/jsx_curly_braces.rs
@@ -18,7 +18,7 @@ pub struct JSXCurlyBraces;
 
 const CODE: &str = "jsx-curly-braces";
 
-const IGNORE_CHARS: Lazy<Regex> = Lazy::new(|| Regex::new(r"[{}<>]").unwrap());
+static IGNORE_CHARS: Lazy<Regex> = Lazy::new(|| Regex::new(r"[{}<>]").unwrap());
 
 impl LintRule for JSXCurlyBraces {
   fn tags(&self) -> Tags {

--- a/src/rules/jsx_curly_braces.rs
+++ b/src/rules/jsx_curly_braces.rs
@@ -81,6 +81,13 @@ impl Handler for JSXCurlyBracesHandler {
 
       if let JSXElementChild::JSXExprContainer(child_expr) = child {
         if let JSXExpr::Expr(Expr::Lit(Lit::Str(lit_str))) = child_expr.expr {
+          // Ignore entities which would require escaping.
+          if lit_str.inner.value.contains('>')
+            || lit_str.inner.value.contains('}')
+          {
+            continue;
+          }
+
           // Allowed if this node is at the end of a line
           // <div>{" "}
           // </div>
@@ -174,6 +181,8 @@ mod tests {
         foo{" "}
         <span />
       </div>"#,
+      r#"<div>foo{">"}</div>"#,
+      r#"<div>foo{"}"}</div>"#,
     };
   }
 

--- a/src/rules/jsx_curly_braces.rs
+++ b/src/rules/jsx_curly_braces.rs
@@ -10,11 +10,15 @@ use deno_ast::view::{
   NodeTrait,
 };
 use deno_ast::SourceRanged;
+use once_cell::sync::Lazy;
+use regex::Regex;
 
 #[derive(Debug)]
 pub struct JSXCurlyBraces;
 
 const CODE: &str = "jsx-curly-braces";
+
+const IGNORE_CHARS: Lazy<Regex> = Lazy::new(|| Regex::new(r"[{}>]").unwrap());
 
 impl LintRule for JSXCurlyBraces {
   fn tags(&self) -> Tags {
@@ -82,9 +86,7 @@ impl Handler for JSXCurlyBracesHandler {
       if let JSXElementChild::JSXExprContainer(child_expr) = child {
         if let JSXExpr::Expr(Expr::Lit(Lit::Str(lit_str))) = child_expr.expr {
           // Ignore entities which would require escaping.
-          if lit_str.inner.value.contains('>')
-            || lit_str.inner.value.contains('}')
-          {
+          if IGNORE_CHARS.is_match(lit_str.inner.value.as_str()) {
             continue;
           }
 
@@ -183,6 +185,7 @@ mod tests {
       </div>"#,
       r#"<div>foo{">"}</div>"#,
       r#"<div>foo{"}"}</div>"#,
+      r#"<div>foo{"{"}</div>"#,
     };
   }
 

--- a/src/rules/jsx_curly_braces.rs
+++ b/src/rules/jsx_curly_braces.rs
@@ -18,7 +18,7 @@ pub struct JSXCurlyBraces;
 
 const CODE: &str = "jsx-curly-braces";
 
-const IGNORE_CHARS: Lazy<Regex> = Lazy::new(|| Regex::new(r"[{}>]").unwrap());
+const IGNORE_CHARS: Lazy<Regex> = Lazy::new(|| Regex::new(r"[{}<>]").unwrap());
 
 impl LintRule for JSXCurlyBraces {
   fn tags(&self) -> Tags {
@@ -183,9 +183,14 @@ mod tests {
         foo{" "}
         <span />
       </div>"#,
+      r#"<div>foo{"<"}</div>"#,
       r#"<div>foo{">"}</div>"#,
       r#"<div>foo{"}"}</div>"#,
       r#"<div>foo{"{"}</div>"#,
+      r#"<div>foo{"foo <"}</div>"#,
+      r#"<div>foo{"foo >"}</div>"#,
+      r#"<div>foo{"foo }"}</div>"#,
+      r#"<div>foo{"foo {"}</div>"#,
     };
   }
 


### PR DESCRIPTION
Don't turn expression into a string when the JSX child would require escaping or it would clash with `jsx-no-unescaped-entities` rule.

Fixes https://github.com/denoland/deno/issues/28225