### PR TITLE
fix: nullish coalescing operator conditional detection

### DIFF
--- a/src/rules/react_rules_of_hooks.rs
+++ b/src/rules/react_rules_of_hooks.rs
@@ -342,6 +342,18 @@ function doAThing() {
         useCustomHook(val ?? 0);
         useState(0);
       }"#,
+      r#"function Foo() {
+        useCustomHook(val && 0);
+        useState(0);
+      }"#,
+      r#"function Foo() {
+        useCustomHook(val || 0);
+        useState(0);
+      }"#,
+      r#"function Foo() {
+        useCustomHook(val > 0);
+        useState(0);
+      }"#,
     };
   }
 

--- a/src/rules/react_rules_of_hooks.rs
+++ b/src/rules/react_rules_of_hooks.rs
@@ -185,9 +185,13 @@ impl Handler for RulesOfHooksHandler {
           }
         }
       }
+      Node::BinExpr(_) => {
+        if let Some(ParentKind::Bin) = self.parent_kind.pop() {
+          self.maybe_decrease_cond_counter();
+        }
+      }
       Node::FnDecl(_)
       | Node::ArrowExpr(_)
-      | Node::BinExpr(_)
       | Node::CondExpr(_)
       | Node::VarDeclarator(_)
       | Node::ForInStmt(_)
@@ -334,6 +338,10 @@ function doAThing() {
   }
   const [foo, setFoo] = useState(false);
 }"#,
+      r#"function Foo() {
+        useCustomHook(val ?? 0);
+        useState(0);
+      }"#,
     };
   }
 


### PR DESCRIPTION
Need to pop conditional on binary expression exits.

Fixes #1426 