### PR TITLE
chore: fix rust version on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,8 @@ For more concrete implementation visit
 
 ## Developing
 
-Make sure to have latest stable version of Rust installed (see [rust-toolchain.toml](./rust-toolchain.toml)).
+Make sure to have latest stable version of Rust installed, see
+[rust-toolchain.toml](./rust-toolchain.toml).
 
 ```shell
 // check version

--- a/README.md
+++ b/README.md
@@ -141,12 +141,11 @@ For more concrete implementation visit
 
 ## Developing
 
-Make sure to have latest stable version of Rust installed (1.56.0).
+Make sure to have latest stable version of Rust installed (see [rust-toolchain.toml](./rust-toolchain.toml)).
 
 ```shell
 // check version
 $ rustc --version
-rustc 1.56.0 (09c42c458 2021-10-18)
 
 // build all targets
 $ cargo build --all-targets


### PR DESCRIPTION
minor fix: the Rust version in the README was outdated, so this pr updates it.