### PR TITLE
fix: nested switch empty fallthrough

### DIFF
--- a/src/rules/no_fallthrough.rs
+++ b/src/rules/no_fallthrough.rs
@@ -191,6 +191,23 @@ switch(someValue) {
     console.log(42);
 }
       "#,
+      r#"
+switch(foo) {
+  case true:
+    switch (bar) {
+      case true:
+      default:
+        return true;
+    }
+  default:
+    switch (bar) {
+      case true:
+        return true;
+      default:
+        return false;
+    }
+}
+      "#
     };
   }
 


### PR DESCRIPTION
Close #1444 

This PR fixes empty fallthrough case `End` merge logic by tracking `End::Continue` state of each case.

Also add a test case of boolean and operation using nested switch.