### PR TITLE
fix: explicit-function-return-type now also works on arrow functions

### DIFF
--- a/src/rules/explicit_function_return_type.rs
+++ b/src/rules/explicit_function_return_type.rs
@@ -62,6 +62,17 @@ impl Handler for ExplicitFunctionReturnTypeHandler {
       );
     }
   }
+
+  fn arrow_expr(&mut self, arrow: &ast_view::ArrowExpr, context: &mut Context) {
+    if arrow.return_type.is_none() {
+      context.add_diagnostic_with_hint(
+        arrow.range(),
+        CODE,
+        ExplicitFunctionReturnTypeMessage::MissingRetType,
+        ExplicitFunctionReturnTypeHint::AddRetType,
+      );
+    }
+  }
 }
 
 #[cfg(test)]
@@ -73,10 +84,12 @@ mod tests {
     assert_lint_ok! {
       ExplicitFunctionReturnType,
       "function fooTyped(): void { }",
-      "const bar = (a: string) => { }",
       "const barTyped = (a: string): Promise<void> => { }",
       "class Test { set test(value: string) {} }",
       "const obj = { set test(value: string) {} };",
+      "const arrow = (a: string): void => { }",
+      "const arrow = (): number => 0",
+      "const arrow = async (): Promise<void> => {}",
     };
 
     assert_lint_ok! {
@@ -124,7 +137,25 @@ function a() {
         message: ExplicitFunctionReturnTypeMessage::MissingRetType,
         hint: ExplicitFunctionReturnTypeHint::AddRetType,
       },
-      ]
+      ],
+      r#"const arrow = (a: string) => { }"#: [
+      {
+        col: 14,
+        message: ExplicitFunctionReturnTypeMessage::MissingRetType,
+        hint: ExplicitFunctionReturnTypeHint::AddRetType,
+      }],
+      r#"const arrow = () => 0"#: [
+      {
+        col: 14,
+        message: ExplicitFunctionReturnTypeMessage::MissingRetType,
+        hint: ExplicitFunctionReturnTypeHint::AddRetType,
+      }],
+      r#"const arrow = async () => { }"#: [
+      {
+        col: 14,
+        message: ExplicitFunctionReturnTypeMessage::MissingRetType,
+        hint: ExplicitFunctionReturnTypeHint::AddRetType,
+      }]
     }
   }
 }


### PR DESCRIPTION
This is a fix for https://github.com/denoland/deno_lint/issues/1334

The `explicit-function-return-type` rule was not implemented for arrow functions, so I added it.

~~This fix aligns the deno_lint implementation of this rule with the default [typescript-eslint behaviour](https://typescript-eslint.io/rules/explicit-function-return-type/).~~

This fix gets deno_lint closer to the default [typescript-eslint behaviour](https://typescript-eslint.io/rules/explicit-function-return-type/), but also makes deno_lint somewhat stricter - as default typescript-eslint allows skipping the return type on arrow functions in a few cases.

Happy to extend this PR to include those cases - though I suppose it's up to a maintainer to decide how strict this should be.