### PR TITLE
feat: remove no-node-globals and no-process-global from recommended rules

### DIFF
--- a/src/rules/no_node_globals.rs
+++ b/src/rules/no_node_globals.rs
@@ -6,7 +6,6 @@ use crate::diagnostic::LintFix;
 use crate::diagnostic::LintFixChange;
 use crate::handler::Handler;
 use crate::handler::Traverse;
-use crate::tags;
 use crate::tags::Tags;
 use crate::Program;
 use std::borrow::Cow;
@@ -47,7 +46,7 @@ impl LintRule for NoNodeGlobals {
   }
 
   fn tags(&self) -> Tags {
-    &[tags::RECOMMENDED]
+    &[]
   }
 }
 

--- a/src/rules/no_process_global.rs
+++ b/src/rules/no_process_global.rs
@@ -6,7 +6,6 @@ use crate::diagnostic::LintFix;
 use crate::diagnostic::LintFixChange;
 use crate::handler::Handler;
 use crate::handler::Traverse;
-use crate::tags;
 use crate::tags::Tags;
 use crate::Program;
 
@@ -39,7 +38,7 @@ impl LintRule for NoProcessGlobal {
   }
 
   fn tags(&self) -> Tags {
-    &[tags::RECOMMENDED]
+    &[]
   }
 }
 


### PR DESCRIPTION
## Summary
- Remove the `recommended` tag from `no-node-globals` and `no-process-global` lint rules
- These rules should no longer be enabled by default when users run `deno lint`

## Test plan
- [x] `cargo test --lib` passes (368 tests)
- [x] `cargo check` compiles cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)