### PR TITLE
fix(no-implicit-declare-namespace-export): skip module augmentations

### DIFF
--- a/src/rules/no_implicit_declare_namespace_export.rs
+++ b/src/rules/no_implicit_declare_namespace_export.rs
@@ -41,6 +41,14 @@ impl Handler for NoImplicitDeclareNamespaceExportHandler {
     module_decl: &ast_view::TsModuleDecl,
     ctx: &mut Context,
   ) {
+    // `declare global { ... }` is a module-augmentation form: TypeScript
+    // explicitly disallows `export {}` inside it ("Exports and export
+    // assignments are not permitted in module augmentations"), so emitting
+    // the implicit-export hint here would suggest a fix that doesn't
+    // compile. See denoland/deno#33268.
+    if module_decl.inner.global {
+      return;
+    }
     if module_decl.inner.declare {
       if let Some(ast_view::TsNamespaceBody::TsModuleBlock(block)) =
         module_decl.body
@@ -135,6 +143,19 @@ declare namespace bar {
       "#,
       r#"
 declare namespace empty {}
+      "#,
+      // `declare global` cannot use `export {}` inside it, so the rule
+      // must not flag implicit-export usage in that block.
+      // See denoland/deno#33268.
+      r#"
+declare global {
+  const asdf = 1;
+}
+      "#,
+      r#"
+declare global {
+  interface Window { foo: string }
+}
       "#,
     };
   }

--- a/src/rules/no_implicit_declare_namespace_export.rs
+++ b/src/rules/no_implicit_declare_namespace_export.rs
@@ -33,6 +33,18 @@ impl LintRule for NoImplicitDeclareNamespaceExport {
   }
 }
 
+/// A file is an ES module when it has at least one top-level `import`/`export`
+/// statement (every `ModuleDecl` is such a statement).
+fn file_is_module(program: ast_view::Program) -> bool {
+  match program {
+    ast_view::Program::Module(module) => module
+      .body
+      .iter()
+      .any(|item| matches!(item, ast_view::ModuleItem::ModuleDecl(_))),
+    ast_view::Program::Script(_) => false,
+  }
+}
+
 struct NoImplicitDeclareNamespaceExportHandler;
 
 impl Handler for NoImplicitDeclareNamespaceExportHandler {
@@ -47,6 +59,17 @@ impl Handler for NoImplicitDeclareNamespaceExportHandler {
     // the implicit-export hint here would suggest a fix that doesn't
     // compile. See denoland/deno#33268.
     if module_decl.inner.global {
+      return;
+    }
+    // `declare module "foo" { ... }` is also a module augmentation — and so
+    // likewise rejects `export {}` (TS2669) — but only when the surrounding
+    // file is itself a module (has a top-level import/export). In a plain
+    // ambient script it is a real ambient module declaration where members are
+    // implicitly exported and `export {}` is valid, so the rule still fires.
+    if module_decl.inner.declare
+      && matches!(&module_decl.id, ast_view::TsModuleName::Str(_))
+      && file_is_module(ctx.program())
+    {
       return;
     }
     if module_decl.inner.declare {
@@ -157,6 +180,15 @@ declare global {
   interface Window { foo: string }
 }
       "#,
+      // `declare module "foo" { ... }` in a *module* file (note the top-level
+      // `export {}`) is a module augmentation, so `export {};` inside it is
+      // likewise rejected by TypeScript and the rule must not fire.
+      r#"
+export {};
+declare module "foo" {
+  const x: number;
+}
+      "#,
     };
   }
 
@@ -183,6 +215,16 @@ declare global {
     assert_lint_err! {
       NoImplicitDeclareNamespaceExport,
       r#"declare namespace foo { interface X {} }"#: [
+        { col: 0,  message: MESSAGE, hint: HINT }
+      ],
+    };
+
+    // `declare module "foo"` in a *script* file (no top-level import/export) is
+    // an ambient module declaration, not an augmentation, so members are
+    // implicitly exported and the rule should still fire.
+    assert_lint_err! {
+      NoImplicitDeclareNamespaceExport,
+      r#"declare module "foo" { type X = 1; }"#: [
         { col: 0,  message: MESSAGE, hint: HINT }
       ],
     };


### PR DESCRIPTION
Per denoland/deno#33268, the `no-implicit-declare-namespace-export` rule
fires on ambient blocks that are *module augmentations* and tells users to add
`export {}` to suppress it. TypeScript rejects `export {}` /
`export { ... }` inside an augmentation (TS2669 "Exports and export assignments
are not permitted in module augmentations"), so the suggested fix does not
compile — the rule effectively makes those blocks unlintable without an ignore
pragma.

This skips a `declare` module declaration when it is an augmentation:

- `declare global { ... }` is unconditionally a global-scope augmentation, so
  it is always skipped.
- `declare module "foo" { ... }` is an augmentation only when the surrounding
  file is itself a module (has a top-level `import`/`export`); those are
  skipped too. In a plain ambient script, `declare module "foo"` is a real
  ambient module declaration where members are implicitly exported and
  `export {}` is valid, so the rule still fires there.

## Repro (before this PR)

```ts
// error: Implicit exports in ambient namespaces are discouraged to use
//   Try adding an `export {};` to the top of the namespace to disable this behavior
declare global {
  const asdf: number;
}

// Following the hint just creates a TypeScript error:
declare global {
  export {};   // TS2669: Exports and export assignments are not permitted in module augmentations.
  const asdf: number;
}
```

## Tests

- Valid: `declare global { ... }` blocks, and a `declare module "foo" { ... }`
  augmentation in a module file (top-level `export {}`).
- Invalid: `declare module "foo" { ... }` in a script file still fires, since
  there it is an ambient module declaration rather than an augmentation.

Closes denoland/deno#33268