### PR TITLE
fix(no-implicit-declare-namespace-export): skip `declare global`

### DIFF
--- a/src/rules/no_implicit_declare_namespace_export.rs
+++ b/src/rules/no_implicit_declare_namespace_export.rs
@@ -41,7 +41,10 @@ impl Handler for NoImplicitDeclareNamespaceExportHandler {
     module_decl: &ast_view::TsModuleDecl,
     ctx: &mut Context,
   ) {
-    if module_decl.inner.declare {
+    // `declare global { ... }` is a module augmentation and cannot contain
+    // `export { ... }` or `export {}`, so the hint this rule emits would only
+    // swap one error for another. Skip it.
+    if module_decl.inner.declare && !module_decl.inner.global {
       if let Some(ast_view::TsNamespaceBody::TsModuleBlock(block)) =
         module_decl.body
       {
@@ -108,6 +111,20 @@ declare namespace bar {
       "#,
       r#"
 declare namespace empty {}
+      "#,
+      // `declare global { ... }` is a module augmentation; `export {};` is a
+      // syntax error inside it, so the rule must not fire here.
+      // See https://github.com/denoland/deno/issues/33268.
+      r#"
+declare global {
+  const asdf: number;
+}
+      "#,
+      r#"
+declare global {
+  interface X {}
+  const FOO: string;
+}
       "#,
     };
 


### PR DESCRIPTION
## Summary

- `declare global { ... }` is a module augmentation, and TypeScript rejects both `export {}` and `export { ... }` inside one (`TS2669 / "Exports and export assignments are not permitted in module augmentations"`).
- The current `no-implicit-declare-namespace-export` rule fires on a `declare global` block and suggests `export {};`, but following that hint swaps the warning for a real TypeScript compile error — so the rule just makes `declare global` augmentations unlintable without an ignore pragma.
- Skip `TsModuleDecl` nodes where `module_decl.inner.global` is true (SWC's flag for `declare global`).

Refs denoland/deno#33268.

## Repro (before this PR)

```ts
// error: Implicit exports in ambient namespaces are discouraged to use
//   Try adding an `export {};` to the top of the namespace to disable this behavior
declare global {
  const asdf: number;
}

// Following the hint just creates a TypeScript error:
declare global {
  export {};   // TS2669: Exports and export assignments are not permitted in module augmentations.
  const asdf: number;
}
```

## Test plan

- [x] Extended `use_explicit_namespace_export_valid` with two `declare global { ... }` fixtures (one with a `const`, one with `interface` + `const`). Verified they fail the previous assertion and pass with this change.
- [x] `cargo test no_implicit_declare_namespace_export` clean.
- [x] `cargo test` full suite clean.
- [x] `deno run --allow-run ./tools/format.ts --check` clean.