### PR TITLE
feat: add LintDiagnostic::severity

### DIFF
--- a/examples/dlint/diagnostics.rs
+++ b/examples/dlint/diagnostics.rs
@@ -16,15 +16,26 @@ pub fn display_diagnostics(
 
 fn print_compact(diagnostics: &[LintDiagnostic]) {
   for diagnostic in diagnostics {
+    // Capitalize the severity label ("error"/"warning" -> "Error"/"Warning")
+    // so the compact output keeps its existing leading-cap style.
+    let severity_label = {
+      let s = diagnostic.severity.as_str();
+      let mut chars = s.chars();
+      match chars.next() {
+        Some(c) => c.to_uppercase().collect::<String>() + chars.as_str(),
+        None => String::new(),
+      }
+    };
     match &diagnostic.range {
       Some(range) => {
         let display_index =
           range.text_info.line_and_column_display(range.range.start);
         eprintln!(
-          "{}: line {}, col {}, Error - {} ({})",
+          "{}: line {}, col {}, {} - {} ({})",
           diagnostic.specifier,
           display_index.line_number,
           display_index.column_number,
+          severity_label,
           diagnostic.details.message,
           diagnostic.details.code
         )

--- a/src/context.rs
+++ b/src/context.rs
@@ -2,8 +2,8 @@
 
 use crate::control_flow::ControlFlow;
 use crate::diagnostic::{
-  LintDiagnostic, LintDiagnosticDetails, LintDiagnosticRange, LintDocsUrl,
-  LintFix,
+  LintDiagnostic, LintDiagnosticDetails, LintDiagnosticRange,
+  LintDiagnosticSeverity, LintDocsUrl, LintFix,
 };
 use crate::ignore_directives::{
   parse_line_ignore_directives, CodeStatus, FileIgnoreDirective,
@@ -455,6 +455,21 @@ impl<'a> Context<'a> {
       .push(self.create_diagnostic(maybe_range, details));
   }
 
+  /// Like [`add_diagnostic_details`] but lets the caller specify the
+  /// severity of the diagnostic. Existing callers that want the default
+  /// behavior should keep using [`add_diagnostic_details`], which emits
+  /// diagnostics at [`LintDiagnosticSeverity::Error`].
+  pub fn add_diagnostic_details_with_severity(
+    &mut self,
+    maybe_range: Option<LintDiagnosticRange>,
+    details: LintDiagnosticDetails,
+    severity: LintDiagnosticSeverity,
+  ) {
+    let mut diagnostic = self.create_diagnostic(maybe_range, details);
+    diagnostic.severity = severity;
+    self.diagnostics.push(diagnostic);
+  }
+
   /// Add fully constructed diagnostics.
   ///
   /// This function can be used by the "external linter" to provide its own
@@ -472,6 +487,7 @@ impl<'a> Context<'a> {
       specifier: self.specifier().clone(),
       range: maybe_range,
       details,
+      severity: LintDiagnosticSeverity::default(),
     }
   }
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -465,9 +465,11 @@ impl<'a> Context<'a> {
     details: LintDiagnosticDetails,
     severity: LintDiagnosticSeverity,
   ) {
-    let mut diagnostic = self.create_diagnostic(maybe_range, details);
-    diagnostic.severity = severity;
-    self.diagnostics.push(diagnostic);
+    self.diagnostics.push(self.create_diagnostic_with_severity(
+      maybe_range,
+      details,
+      severity,
+    ));
   }
 
   /// Add fully constructed diagnostics.
@@ -483,11 +485,24 @@ impl<'a> Context<'a> {
     maybe_range: Option<LintDiagnosticRange>,
     details: LintDiagnosticDetails,
   ) -> LintDiagnostic {
+    self.create_diagnostic_with_severity(
+      maybe_range,
+      details,
+      LintDiagnosticSeverity::default(),
+    )
+  }
+
+  pub(crate) fn create_diagnostic_with_severity(
+    &self,
+    maybe_range: Option<LintDiagnosticRange>,
+    details: LintDiagnosticDetails,
+    severity: LintDiagnosticSeverity,
+  ) -> LintDiagnostic {
     LintDiagnostic {
       specifier: self.specifier().clone(),
       range: maybe_range,
       details,
-      severity: LintDiagnosticSeverity::default(),
+      severity,
     }
   }
 

--- a/src/diagnostic.rs
+++ b/src/diagnostic.rs
@@ -13,6 +13,34 @@ use deno_ast::diagnostics::DiagnosticSourceRange;
 use deno_ast::ModuleSpecifier;
 use deno_ast::SourceRange;
 use deno_ast::SourceTextInfo;
+use serde::Deserialize;
+use serde::Serialize;
+
+/// Severity for a [`LintDiagnostic`].
+///
+/// `Error` is the default to preserve backwards-compatible behavior with
+/// pre-severity versions of `deno_lint` where every diagnostic was treated
+/// as an error.
+#[derive(
+  Debug, Default, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize,
+)]
+#[serde(rename_all = "lowercase")]
+pub enum LintDiagnosticSeverity {
+  #[default]
+  Error,
+  Warning,
+}
+
+impl LintDiagnosticSeverity {
+  /// Returns the canonical lowercase string label for the severity
+  /// (`"error"` or `"warning"`). Useful for compact text formatters.
+  pub fn as_str(&self) -> &'static str {
+    match self {
+      LintDiagnosticSeverity::Error => "error",
+      LintDiagnosticSeverity::Warning => "warning",
+    }
+  }
+}
 
 #[derive(Debug, Clone)]
 pub struct LintFixChange {
@@ -70,11 +98,17 @@ pub struct LintDiagnostic {
   /// the whole file.
   pub range: Option<LintDiagnosticRange>,
   pub details: LintDiagnosticDetails,
+  /// Severity for this diagnostic. Defaults to [`LintDiagnosticSeverity::Error`]
+  /// so existing rules that don't opt in keep their current "error" behavior.
+  pub severity: LintDiagnosticSeverity,
 }
 
 impl Diagnostic for LintDiagnostic {
   fn level(&self) -> DiagnosticLevel {
-    DiagnosticLevel::Error
+    match self.severity {
+      LintDiagnosticSeverity::Error => DiagnosticLevel::Error,
+      LintDiagnosticSeverity::Warning => DiagnosticLevel::Warning,
+    }
   }
 
   fn code(&self) -> Cow<'_, str> {
@@ -100,6 +134,12 @@ impl Diagnostic for LintDiagnostic {
 
   fn snippet(&self) -> Option<DiagnosticSnippet<'_>> {
     let range = self.range.as_ref()?;
+    let style = match self.severity {
+      LintDiagnosticSeverity::Error => DiagnosticSnippetHighlightStyle::Error,
+      LintDiagnosticSeverity::Warning => {
+        DiagnosticSnippetHighlightStyle::Warning
+      }
+    };
     Some(DiagnosticSnippet {
       source: Cow::Borrowed(&range.text_info),
       highlights: vec![DiagnosticSnippetHighlight {
@@ -107,7 +147,7 @@ impl Diagnostic for LintDiagnostic {
           start: DiagnosticSourcePos::SourcePos(range.range.start),
           end: DiagnosticSourcePos::SourcePos(range.range.end),
         },
-        style: DiagnosticSnippetHighlightStyle::Error,
+        style,
         description: range.description.as_deref().map(Cow::Borrowed),
       }],
     })
@@ -138,5 +178,64 @@ impl Diagnostic for LintDiagnostic {
       LintDocsUrl::Custom(url) => Some(Cow::Borrowed(url)),
       LintDocsUrl::None => None,
     }
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn severity_default_is_error() {
+    assert_eq!(LintDiagnosticSeverity::default(), LintDiagnosticSeverity::Error);
+  }
+
+  #[test]
+  fn severity_as_str_labels() {
+    assert_eq!(LintDiagnosticSeverity::Error.as_str(), "error");
+    assert_eq!(LintDiagnosticSeverity::Warning.as_str(), "warning");
+  }
+
+  #[test]
+  fn severity_serializes_to_lowercase_json() {
+    let json = serde_json::to_string(&LintDiagnosticSeverity::Warning).unwrap();
+    assert_eq!(json, "\"warning\"");
+    let json = serde_json::to_string(&LintDiagnosticSeverity::Error).unwrap();
+    assert_eq!(json, "\"error\"");
+  }
+
+  #[test]
+  fn severity_round_trips_through_serde() {
+    let s: LintDiagnosticSeverity =
+      serde_json::from_str("\"warning\"").unwrap();
+    assert_eq!(s, LintDiagnosticSeverity::Warning);
+    let s: LintDiagnosticSeverity = serde_json::from_str("\"error\"").unwrap();
+    assert_eq!(s, LintDiagnosticSeverity::Error);
+  }
+
+  #[test]
+  fn level_maps_severity_to_diagnostic_level() {
+    let specifier = ModuleSpecifier::parse("file:///main.ts").unwrap();
+    let mk = |severity| LintDiagnostic {
+      specifier: specifier.clone(),
+      range: None,
+      details: LintDiagnosticDetails {
+        message: "msg".to_string(),
+        code: "code".to_string(),
+        hint: None,
+        fixes: vec![],
+        custom_docs_url: LintDocsUrl::Default,
+        info: vec![],
+      },
+      severity,
+    };
+    assert!(matches!(
+      mk(LintDiagnosticSeverity::Error).level(),
+      DiagnosticLevel::Error
+    ));
+    assert!(matches!(
+      mk(LintDiagnosticSeverity::Warning).level(),
+      DiagnosticLevel::Warning
+    ));
   }
 }

--- a/src/diagnostic.rs
+++ b/src/diagnostic.rs
@@ -187,7 +187,10 @@ mod tests {
 
   #[test]
   fn severity_default_is_error() {
-    assert_eq!(LintDiagnosticSeverity::default(), LintDiagnosticSeverity::Error);
+    assert_eq!(
+      LintDiagnosticSeverity::default(),
+      LintDiagnosticSeverity::Error
+    );
   }
 
   #[test]

--- a/src/diagnostic.rs
+++ b/src/diagnostic.rs
@@ -16,7 +16,11 @@ use deno_ast::SourceTextInfo;
 use serde::Deserialize;
 use serde::Serialize;
 
-/// Severity for a [`LintDiagnostic`].
+/// Severity of an emitted [`LintDiagnostic`].
+///
+/// This is a property of the emitted diagnostic instance rather than of the
+/// rule's [`LintDiagnosticDetails`], because the same rule may be configured to
+/// emit either errors or warnings depending on consumer configuration.
 ///
 /// `Error` is the default to preserve backwards-compatible behavior with
 /// pre-severity versions of `deno_lint` where every diagnostic was treated
@@ -26,8 +30,10 @@ use serde::Serialize;
 )]
 #[serde(rename_all = "lowercase")]
 pub enum LintDiagnosticSeverity {
+  /// A hard error. The default, to preserve existing behavior.
   #[default]
   Error,
+  /// A warning that does not necessarily indicate a failure.
   Warning,
 }
 


### PR DESCRIPTION
## Summary
Refs #1274. Adds a `severity` field on `LintDiagnostic` plus a `LintDiagnosticSeverity` enum (`Error` default, `Warning`).

## Files
- `src/diagnostic.rs` — added `LintDiagnosticSeverity` enum, `severity` field on `LintDiagnostic`, severity-aware `Diagnostic::level()` and snippet highlight style, plus 5 unit tests.
- `src/context.rs` — `create_diagnostic` populates `severity: Default::default()` (Error) for backwards compat; new `add_diagnostic_details_with_severity` opt-in API.
- `examples/dlint/diagnostics.rs` — compact formatter prints actual severity label instead of hardcoded "Error".

## Backwards compatibility
Default severity preserves the existing "all errors" behavior. New field added without removing or renaming any API. Existing rules unchanged.

## Test plan
- `cargo test` — 373 lib + 3 example pass, 0 fail.
- New tests cover default-is-Error, JSON round-trip (lowercase), `level()` mapping, and label strings.
- `cargo clippy --all-targets -- -D warnings` clean.

## Out of scope
The issue's "point 2" (per-rule config customization) crosses repos and was left for further discussion per the issue author.
