### PR TITLE
chore: bump deno_ast to 0.53.2 and deno_semver to 0.10.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -279,9 +279,9 @@ checksum = "be1e0bca6c3637f992fc1cc7cbc52a78c1ef6db076dbf1059c4323d6a2048376"
 
 [[package]]
 name = "deno_ast"
-version = "0.53.0"
+version = "0.53.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ac5df28715465cff3f03294564f38c9cd3c24c4cfb965a32fd1327efa111b02"
+checksum = "05792fb2b77938767ffeb0853289e86501fddc84b1cdba9e5dc860c52baa2ff7"
 dependencies = [
  "capacity_builder",
  "deno_error",
@@ -372,9 +372,9 @@ dependencies = [
 
 [[package]]
 name = "deno_semver"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2625b7107cc3f61a462886d5fa77c23e063c1fd15b90e3d5ee2646e9f6178d55"
+checksum = "147261611819fb4dfe339b53e3b45d6704c7e32c86ce33a88511d5bcebebaaa3"
 dependencies = [
  "capacity_builder",
  "deno_error",
@@ -823,9 +823,9 @@ checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
 
 [[package]]
 name = "monch"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b52c1b33ff98142aecea13138bd399b68aa7ab5d9546c300988c345004001eea"
+checksum = "6bcc6ad3b93f756f2532d29f7c7291b8d246a2c460a99a3611327bb726830014"
 
 [[package]]
 name = "new_debug_unreachable"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ test = true
 default = []
 
 [dependencies]
-deno_ast = { version = "0.53.0", features = ["scopes", "transforms", "utils", "visit", "view", "react"] }
+deno_ast = { version = "0.53.2", features = ["scopes", "transforms", "utils", "visit", "view", "react"] }
 log = "0.4.20"
 serde = { version = "1.0.195", features = ["derive"] }
 serde_json = "1.0.111"
@@ -33,7 +33,7 @@ derive_more = { version = "0.99.17", features = ["display"] }
 anyhow = "1.0.79"
 if_chain = "1.0.2"
 phf = { version = "0.11.2", features = ["macros"] }
-deno_semver = "0.9.0"
+deno_semver = "0.10.0"
 
 [dev-dependencies]
 ansi_term = "0.12.1"


### PR DESCRIPTION
Bump deno_ast to 0.53.2 and deno_semver to 0.10.0 (monch 0.6.0 perf improvements).