### PR TITLE
fix: accept both 'handler' and 'handlers' exports in Fresh routes

### DIFF
--- a/src/rules/fresh_handler_export.rs
+++ b/src/rules/fresh_handler_export.rs
@@ -4,16 +4,12 @@ use super::{Context, LintRule};
 use crate::handler::{Handler, Traverse};
 use crate::tags::{self, Tags};
 
-use deno_ast::view::{Decl, Pat, Program};
-use deno_ast::SourceRanged;
+use deno_ast::view::Program;
 
 #[derive(Debug)]
 pub struct FreshHandlerExport;
 
 const CODE: &str = "fresh-handler-export";
-const MESSAGE: &str =
-  "Fresh middlewares must be exported as \"handler\" but got \"handlers\" instead.";
-const HINT: &str = "Did you mean \"handler\"?";
 
 impl LintRule for FreshHandlerExport {
   fn tags(&self) -> Tags {
@@ -38,33 +34,9 @@ struct Visitor;
 impl Handler for Visitor {
   fn export_decl(
     &mut self,
-    export_decl: &deno_ast::view::ExportDecl,
-    ctx: &mut Context,
+    _export_decl: &deno_ast::view::ExportDecl,
+    _ctx: &mut Context,
   ) {
-    // Fresh only considers components in the routes/ folder to be
-    // server components.
-    let Some(mut path_segments) = ctx.specifier().path_segments() else {
-      return;
-    };
-    if !path_segments.any(|part| part == "routes") {
-      return;
-    }
-
-    let id = match export_decl.decl {
-      Decl::Var(var_decl) => {
-        if let Some(first) = var_decl.decls.first() {
-          let Pat::Ident(name_ident) = first.name else {
-            return;
-          };
-          name_ident.id
-        } else {
-          return;
-        }
-      }
-      Decl::Fn(fn_decl) => fn_decl.ident,
-      _ => return,
-    };
-
     // Fresh accepts both "handler" and "handlers" exports
     // No diagnostic needed - both are valid
   }

--- a/src/rules/fresh_handler_export.rs
+++ b/src/rules/fresh_handler_export.rs
@@ -65,10 +65,8 @@ impl Handler for Visitor {
       _ => return,
     };
 
-    // Fresh middleware handler must be exported as "handler" not "handlers"
-    if id.sym().eq("handlers") {
-      ctx.add_diagnostic_with_hint(id.range(), CODE, MESSAGE, HINT);
-    }
+    // Fresh accepts both "handler" and "handlers" exports
+    // No diagnostic needed - both are valid
   }
 }
 
@@ -120,23 +118,20 @@ mod tests {
       "export async function handler() {}",
     );
 
-    assert_lint_err!(FreshHandlerExport, filename: "file:///routes/index.tsx",  r#"export const handlers = {}"#: [
-    {
-      col: 13,
-      message: MESSAGE,
-      hint: HINT,
-    }]);
-    assert_lint_err!(FreshHandlerExport, filename: "file:///routes/index.tsx",  r#"export function handlers() {}"#: [
-    {
-      col: 16,
-      message: MESSAGE,
-      hint: HINT,
-    }]);
-    assert_lint_err!(FreshHandlerExport, filename: "file:///routes/index.tsx",  r#"export async function handlers() {}"#: [
-    {
-      col: 22,
-      message: MESSAGE,
-      hint: HINT,
-    }]);
+    assert_lint_ok!(
+      FreshHandlerExport,
+      filename: "file:///routes/index.tsx",
+      "export const handlers = {}",
+    );
+    assert_lint_ok!(
+      FreshHandlerExport,
+      filename: "file:///routes/index.tsx",
+      "export function handlers() {}",
+    );
+    assert_lint_ok!(
+      FreshHandlerExport,
+      filename: "file:///routes/index.tsx",
+      "export async function handlers() {}",
+    );
   }
 }


### PR DESCRIPTION
## Problem

The `fresh-handler-export` linter rule incorrectly flags `handlers` (plural) as an error in Fresh route files. However, Fresh framework actually supports both `handler` and `handlers` exports.

## Evidence

From Fresh source code ([fs_routes.ts](https://github.com/denoland/fresh/blob/main/packages/fresh/src/fs_routes.ts)):

```
Route files must export a default component, a "handler" or "handlers" export, or a "config" export.
```

## Fix

This PR removes the check that flags `handlers` as invalid, allowing both conventions as Fresh intended.

## Changes

- `src/rules/fresh_handler_export.rs`: Remove the diagnostic for `handlers` export
- Update tests to show both `handler` and `handlers` are valid in `routes/`

## Testing

The existing tests have been updated to reflect that both exports are valid.