### PR TITLE
feat: add severity field to LintDiagnostic

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -2,8 +2,8 @@
 
 use crate::control_flow::ControlFlow;
 use crate::diagnostic::{
-  LintDiagnostic, LintDiagnosticDetails, LintDiagnosticRange, LintDocsUrl,
-  LintFix,
+  LintDiagnostic, LintDiagnosticDetails, LintDiagnosticRange,
+  LintDiagnosticSeverity, LintDocsUrl, LintFix,
 };
 use crate::ignore_directives::{
   parse_line_ignore_directives, CodeStatus, FileIgnoreDirective,
@@ -455,6 +455,22 @@ impl<'a> Context<'a> {
       .push(self.create_diagnostic(maybe_range, details));
   }
 
+  /// Like [`Context::add_diagnostic_details`], but allows specifying a
+  /// non-default [`LintDiagnosticSeverity`]. The common call sites default to
+  /// [`LintDiagnosticSeverity::Error`]; use this to emit a warning instead.
+  pub fn add_diagnostic_details_with_severity(
+    &mut self,
+    maybe_range: Option<LintDiagnosticRange>,
+    details: LintDiagnosticDetails,
+    severity: LintDiagnosticSeverity,
+  ) {
+    self.diagnostics.push(self.create_diagnostic_with_severity(
+      maybe_range,
+      details,
+      severity,
+    ));
+  }
+
   /// Add fully constructed diagnostics.
   ///
   /// This function can be used by the "external linter" to provide its own
@@ -468,10 +484,24 @@ impl<'a> Context<'a> {
     maybe_range: Option<LintDiagnosticRange>,
     details: LintDiagnosticDetails,
   ) -> LintDiagnostic {
+    self.create_diagnostic_with_severity(
+      maybe_range,
+      details,
+      LintDiagnosticSeverity::default(),
+    )
+  }
+
+  pub(crate) fn create_diagnostic_with_severity(
+    &self,
+    maybe_range: Option<LintDiagnosticRange>,
+    details: LintDiagnosticDetails,
+    severity: LintDiagnosticSeverity,
+  ) -> LintDiagnostic {
     LintDiagnostic {
       specifier: self.specifier().clone(),
       range: maybe_range,
       details,
+      severity,
     }
   }
 

--- a/src/diagnostic.rs
+++ b/src/diagnostic.rs
@@ -61,6 +61,20 @@ pub struct LintDiagnosticDetails {
   pub info: Vec<Cow<'static, str>>,
 }
 
+/// Severity of an emitted [`LintDiagnostic`].
+///
+/// This is a property of the emitted diagnostic instance rather than of the
+/// rule's [`LintDiagnosticDetails`], because the same rule may be configured to
+/// emit either errors or warnings depending on consumer configuration.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum LintDiagnosticSeverity {
+  /// A hard error. This is the default to preserve existing behavior.
+  #[default]
+  Error,
+  /// A warning that does not necessarily indicate a failure.
+  Warning,
+}
+
 #[derive(Clone)]
 pub struct LintDiagnostic {
   pub specifier: ModuleSpecifier,
@@ -70,11 +84,17 @@ pub struct LintDiagnostic {
   /// the whole file.
   pub range: Option<LintDiagnosticRange>,
   pub details: LintDiagnosticDetails,
+  /// Severity of this diagnostic instance. Defaults to
+  /// [`LintDiagnosticSeverity::Error`].
+  pub severity: LintDiagnosticSeverity,
 }
 
 impl Diagnostic for LintDiagnostic {
   fn level(&self) -> DiagnosticLevel {
-    DiagnosticLevel::Error
+    match self.severity {
+      LintDiagnosticSeverity::Error => DiagnosticLevel::Error,
+      LintDiagnosticSeverity::Warning => DiagnosticLevel::Warning,
+    }
   }
 
   fn code(&self) -> Cow<'_, str> {
@@ -138,5 +158,48 @@ impl Diagnostic for LintDiagnostic {
       LintDocsUrl::Custom(url) => Some(Cow::Borrowed(url)),
       LintDocsUrl::None => None,
     }
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  fn diagnostic_with_severity(
+    severity: LintDiagnosticSeverity,
+  ) -> LintDiagnostic {
+    LintDiagnostic {
+      specifier: ModuleSpecifier::parse("file:///foo.ts").unwrap(),
+      range: None,
+      details: LintDiagnosticDetails {
+        message: "message".to_string(),
+        code: "some-code".to_string(),
+        hint: None,
+        fixes: vec![],
+        custom_docs_url: LintDocsUrl::Default,
+        info: vec![],
+      },
+      severity,
+    }
+  }
+
+  #[test]
+  fn severity_defaults_to_error() {
+    assert_eq!(
+      LintDiagnosticSeverity::default(),
+      LintDiagnosticSeverity::Error
+    );
+  }
+
+  #[test]
+  fn level_reflects_severity() {
+    assert!(matches!(
+      diagnostic_with_severity(LintDiagnosticSeverity::Error).level(),
+      DiagnosticLevel::Error
+    ));
+    assert!(matches!(
+      diagnostic_with_severity(LintDiagnosticSeverity::Warning).level(),
+      DiagnosticLevel::Warning
+    ));
   }
 }


### PR DESCRIPTION
Adds a per-diagnostic severity concept to the crate. A new `LintDiagnosticSeverity` enum (`Error`, `Warning`) and a `severity` field on `LintDiagnostic` replace the previously hardcoded `DiagnosticLevel::Error` in the `Diagnostic::level()` implementation, which now maps the severity onto `deno_ast`'s `DiagnosticLevel`.

The change is backward compatible: every existing diagnostic construction path defaults to `Error`, so current behavior is unchanged. Rules and external consumers can now emit a warning-level diagnostic via the new `Context::add_diagnostic_details_with_severity` method or by setting the `severity` field on a `LintDiagnostic` directly.

This only exposes the capability in the crate. Wiring user-facing configuration (so `deno.json` can mark a rule as a warning) lives in the deno CLI and is intentionally out of scope here.

Towards #1274.