### PR TITLE
fix: reduce no-fallthrough and no-unreachable false positives

### DIFF
--- a/src/control_flow/analyze_test.rs
+++ b/src/control_flow/analyze_test.rs
@@ -936,6 +936,121 @@ switch (foo) {
   });
 }
 
+// https://github.com/denoland/deno_lint/issues/1042
+#[test]
+fn issue_1042() {
+  let src = r#"
+switch (foo) {
+  case 1:
+    Deno.exit(1);
+  default:
+    break;
+}
+"#;
+  analyze_flow(src, |flow| {
+    assert_flow!(flow, 1, false, Some(End::Continue)); // switch stmt
+    assert_flow!(flow, 18, false, Some(End::forced_return())); // `case 1`
+    assert_flow!(flow, 30, false, Some(End::forced_return())); // `Deno.exit(1);`
+    assert_flow!(flow, 46, false, Some(End::Break)); // `default`
+  });
+}
+
+// https://github.com/denoland/deno_lint/issues/1156
+#[test]
+fn issue_1156() {
+  let src = r#"
+switch (foo) {
+  case 1:
+    while (true) {
+      bar();
+    }
+  default:
+    baz();
+}
+"#;
+  analyze_flow(src, |flow| {
+    // `case 1` stops execution because the infinite loop never breaks.
+    assert_flow!(flow, 18, false, Some(End::forced_infinite_loop()));
+    // The `while` statement itself is exposed as a finisher.
+    assert_flow!(flow, 30, false, Some(End::forced_infinite_loop()));
+  });
+}
+
+// https://github.com/denoland/deno_lint/issues/1331
+#[test]
+fn issue_1331() {
+  let src = r#"
+for (let i = 0; i < 10; i++) {
+  switch (i) {
+    case 0:
+      switch (i) {
+        case 0:
+          continue;
+        default:
+          return 0;
+      }
+    case 1:
+      return 1;
+  }
+}
+"#;
+  analyze_flow(src, |flow| {
+    // The inner switch stops execution (every path either continues the loop or
+    // returns), so the outer `case 0` does not fall through to `case 1`.
+    assert!(flow
+      .meta(StartSourcePos::START_SOURCE_POS + 51)
+      .unwrap()
+      .stops_execution()); // outer `case 0`
+  });
+}
+
+// https://github.com/denoland/deno_lint/issues/1444
+#[test]
+fn issue_1444() {
+  let src = r#"
+switch (b1) {
+  case true:
+    switch (b2) {
+      case true:
+      default:
+        return true;
+    }
+  case false:
+    return false;
+}
+"#;
+  analyze_flow(src, |flow| {
+    // The inner switch always returns (the empty `case true` falls through to
+    // the `default`), so the outer `case true` stops execution.
+    assert!(flow
+      .meta(StartSourcePos::START_SOURCE_POS + 17)
+      .unwrap()
+      .stops_execution()); // outer `case true`
+  });
+}
+
+// https://github.com/denoland/deno_lint/issues/1303
+#[test]
+fn issue_1303() {
+  let src = r#"
+function f() {
+  const fooError = new Error("foo");
+  try {
+    throw fooError;
+  } catch (cause) {
+    bar();
+    throw new Error("bar", { cause });
+  }
+}
+"#;
+  analyze_flow(src, |flow| {
+    // `throw fooError` re-throws an existing identifier; the catch block must
+    // still be considered reachable.
+    let bar = flow.meta(StartSourcePos::START_SOURCE_POS + 105).unwrap();
+    assert!(!bar.unreachable); // `bar();`
+  });
+}
+
 // https://github.com/denoland/deno_lint/issues/644
 #[test]
 fn issue_644() {

--- a/src/control_flow/mod.rs
+++ b/src/control_flow/mod.rs
@@ -575,10 +575,8 @@ impl Visit for Analyzer<'_> {
 
       let any_plain_break =
         case_ends.iter().any(|e| matches!(e, Some(End::Break)));
-      let last_falls_through = matches!(
-        case_ends.last(),
-        Some(None) | Some(Some(End::Continue))
-      );
+      let last_falls_through =
+        matches!(case_ends.last(), Some(None) | Some(Some(End::Continue)));
 
       if any_plain_break || last_falls_through {
         End::Continue

--- a/src/control_flow/mod.rs
+++ b/src/control_flow/mod.rs
@@ -121,6 +121,11 @@ struct Scope<'a> {
   /// - Some(None): Stopped at a break statement without label
   /// - Some(Somd(id)): Stopped at a break statement with label id
   found_break: Option<Option<Id>>,
+  /// Whether an unlabeled `break` statement targeting the nearest enclosing loop
+  /// or switch was found. This is tracked separately from `found_break` because
+  /// `found_break` can only store a single break and a labeled break (targeting
+  /// an outer construct) would otherwise mask an unlabeled one.
+  found_unlabeled_break: bool,
   found_continue: bool,
 }
 
@@ -187,6 +192,18 @@ impl End {
     }
   }
 
+  /// A forced stop that isn't a plain `return`/`throw`/infinite-loop, such as a
+  /// `continue` or labeled `break` that exits a construct enclosing a switch.
+  /// It still stops execution (so it prevents fallthrough), but carries no
+  /// specific reason.
+  fn forced_stop() -> Self {
+    End::Forced {
+      ret: false,
+      throw: false,
+      infinite_loop: false,
+    }
+  }
+
   fn merge_forced(self, other: Self) -> Option<Self> {
     match (self, other) {
       (
@@ -223,9 +240,28 @@ impl<'a> Scope<'a> {
       end: None,
       may_throw: false,
       found_break: None,
+      found_unlabeled_break: false,
       found_continue: false,
     }
   }
+}
+
+/// Returns `true` if the given call expression is a call to `Deno.exit` or
+/// `process.exit`, which terminate the process and thus stop execution.
+fn is_forced_exit_call(n: &CallExpr) -> bool {
+  let Callee::Expr(callee) = &n.callee else {
+    return false;
+  };
+  let Expr::Member(member) = &**callee else {
+    return false;
+  };
+  let Expr::Ident(obj) = &*member.obj else {
+    return false;
+  };
+  let MemberProp::Ident(prop) = &member.prop else {
+    return false;
+  };
+  matches!(&*obj.sym, "Deno" | "process") && &*prop.sym == "exit"
 }
 
 impl Analyzer<'_> {
@@ -239,7 +275,15 @@ impl Analyzer<'_> {
     F: for<'any> FnOnce(&mut Analyzer<'any>),
   {
     let prev_end = self.scope.end;
-    let (info, end, hoist, found_break, found_continue, may_throw) = {
+    let (
+      info,
+      end,
+      hoist,
+      found_break,
+      found_unlabeled_break,
+      found_continue,
+      may_throw,
+    ) = {
       let mut child = Analyzer {
         info: take(&mut self.info),
         scope: Scope::new(Some(&self.scope), kind.clone()),
@@ -262,6 +306,7 @@ impl Analyzer<'_> {
         child.scope.end,
         child.scope.used_hoistable_ids,
         child.scope.found_break,
+        child.scope.found_unlabeled_break,
         child.scope.found_continue,
         child.scope.may_throw,
       )
@@ -273,7 +318,23 @@ impl Analyzer<'_> {
     // Preserve information about visited ast nodes.
     self.scope.may_throw |= may_throw;
 
-    self.scope.found_continue |= found_continue;
+    // A loop consumes unlabeled `continue` statements that target it; they
+    // shouldn't be attributed to an enclosing construct. A function obviously
+    // contains its own continues.
+    match kind {
+      BlockKind::Loop | BlockKind::Function => {}
+      _ => {
+        self.scope.found_continue |= found_continue;
+      }
+    };
+
+    // A loop or switch consumes unlabeled `break` statements that target it.
+    match kind {
+      BlockKind::Loop | BlockKind::Case | BlockKind::Function => {}
+      _ => {
+        self.scope.found_unlabeled_break |= found_unlabeled_break;
+      }
+    };
 
     match kind {
       BlockKind::Case => {}
@@ -377,7 +438,23 @@ impl Visit for Analyzer<'_> {
 
   fn visit_throw_stmt(&mut self, n: &ThrowStmt) {
     n.visit_children_with(self);
+    // A `throw` statement can always be caught by an enclosing `try`/`catch`,
+    // regardless of what is being thrown (e.g. `throw someVariable`). Mark the
+    // scope as possibly throwing so that the corresponding `catch` block is not
+    // treated as unreachable.
+    self.scope.may_throw = true;
     self.mark_as_end(n.start(), End::forced_throw());
+  }
+
+  fn visit_call_expr(&mut self, n: &CallExpr) {
+    n.visit_children_with(self);
+
+    // Treat `Deno.exit(...)` and `process.exit(...)` as statements that stop
+    // execution. There's no type information available here, so this is a
+    // targeted syntactic heuristic.
+    if is_forced_exit_call(n) {
+      self.mark_as_end(n.start(), End::forced_return());
+    }
   }
 
   fn visit_break_stmt(&mut self, n: &BreakStmt) {
@@ -386,6 +463,7 @@ impl Visit for Analyzer<'_> {
       self.scope.found_break = Some(Some(label));
     } else {
       self.scope.found_break = Some(None);
+      self.scope.found_unlabeled_break = true;
     }
   }
 
@@ -472,24 +550,45 @@ impl Visit for Analyzer<'_> {
     let prev_end = self.scope.end;
     n.visit_children_with(self);
 
-    let end = {
-      let has_default = n.cases.iter().any(|case| case.test.is_none());
-      let forced_end = n
+    let has_default = n.cases.iter().any(|case| case.test.is_none());
+
+    // The code following a switch is reachable (i.e. the switch does not stop
+    // execution) if any of the following holds:
+    //
+    //  - there's no `default` case (a value might match nothing), or
+    //  - some case exits via a plain `break` (which jumps to right after the
+    //    switch), or
+    //  - the last case completes normally and "falls off" the end of the
+    //    switch.
+    //
+    // Otherwise every path either returns/throws, loops forever, or escapes an
+    // enclosing construct (via `continue`/labeled `break`), so the switch stops
+    // execution.
+    let end = if !has_default {
+      End::Continue
+    } else {
+      let case_ends: Vec<Option<End>> = n
         .cases
         .iter()
-        .filter_map(|case| self.get_end_reason(case.start()))
-        .try_fold(
-          End::Forced {
-            ret: false,
-            throw: false,
-            infinite_loop: false,
-          },
-          |acc, cur| acc.merge_forced(cur),
-        );
+        .map(|case| self.get_end_reason(case.start()))
+        .collect();
 
-      match forced_end {
-        Some(e) if has_default => e,
-        _ => End::Continue,
+      let any_plain_break =
+        case_ends.iter().any(|e| matches!(e, Some(End::Break)));
+      let last_falls_through = matches!(
+        case_ends.last(),
+        Some(None) | Some(Some(End::Continue))
+      );
+
+      if any_plain_break || last_falls_through {
+        End::Continue
+      } else {
+        case_ends
+          .into_iter()
+          .flatten()
+          .filter(|e| e.is_forced())
+          .reduce(|acc, cur| acc.merge_forced(cur).unwrap_or(acc))
+          .unwrap_or_else(End::forced_stop)
       }
     };
 
@@ -507,8 +606,15 @@ impl Visit for Analyzer<'_> {
     self.with_child_scope(BlockKind::Case, n.start(), |a| {
       n.cons.visit_with(a);
 
-      if a.scope.found_break.is_some() {
+      if a.scope.found_unlabeled_break {
+        // A plain `break` exits the switch: execution reaches the code right
+        // after the switch, so this case does not fall through to the next one.
         case_end = Some(End::Break);
+      } else if a.scope.found_break.is_some() || a.scope.found_continue {
+        // A labeled `break` or a `continue` escapes an enclosing construct (a
+        // loop or labeled statement). This case stops execution (so it doesn't
+        // fall through) but doesn't reach the code after the switch either.
+        case_end = Some(End::forced_stop());
       } else if matches!(a.scope.end, Some(End::Forced { .. })) {
         case_end = a.scope.end;
       }
@@ -611,7 +717,7 @@ impl Visit for Analyzer<'_> {
     self.with_child_scope(BlockKind::Loop, n.body.start(), |a| {
       n.body.visit_with(a);
 
-      let has_break = matches!(a.scope.found_break, Some(None));
+      let has_break = a.scope.found_unlabeled_break;
 
       if !has_break {
         let end = match a.get_end_reason(n.body.start()) {
@@ -680,7 +786,7 @@ impl Visit for Analyzer<'_> {
         matches!(n.test.cast_to_bool(expr_ctxt), (_, Value::Known(true)));
       let end_reason = a.get_end_reason(body_lo);
       let return_or_throw = end_reason.is_some_and(|e| e.is_forced());
-      let has_break = matches!(a.scope.found_break, Some(None));
+      let has_break = a.scope.found_unlabeled_break;
 
       if unconditionally_enter && return_or_throw && !has_break {
         // This `unwrap` is safe;
@@ -697,6 +803,15 @@ impl Visit for Analyzer<'_> {
       }
     });
 
+    // Expose the loop statement itself (not just its body) as a finisher when
+    // it unconditionally stops execution, so that consumers reading the
+    // metadata at the statement's start (e.g. `no-fallthrough`) see it.
+    if let Some(end) = self.get_end_reason(body_lo) {
+      if end.is_forced() {
+        self.mark_as_end(n.start(), end);
+      }
+    }
+
     n.test.visit_with(self);
   }
 
@@ -712,9 +827,13 @@ impl Visit for Analyzer<'_> {
       let infinite_loop =
         matches!(n.test.cast_to_bool(expr_ctxt), (_, Value::Known(true)))
           && a.scope.found_break.is_none();
-      let has_break = matches!(a.scope.found_break, Some(None));
+      let has_break = a.scope.found_unlabeled_break;
+      // A `continue` jumps to the loop's condition check. If the body contains a
+      // (reachable) `continue`, then it doesn't *unconditionally* return/throw,
+      // so a non-infinite do-while loop may still exit normally.
+      let has_continue = a.scope.found_continue;
 
-      if return_or_throw && !has_break {
+      if return_or_throw && !has_break && !has_continue {
         // This `unwrap` is safe;
         // if `return_or_throw` is true, `end_reason` is surely wrapped in `Some`.
         a.mark_as_end(body_lo, end_reason.unwrap());

--- a/src/control_flow/mod.rs
+++ b/src/control_flow/mod.rs
@@ -446,14 +446,18 @@ impl Visit for Analyzer<'_> {
     self.mark_as_end(n.start(), End::forced_throw());
   }
 
-  fn visit_call_expr(&mut self, n: &CallExpr) {
+  fn visit_expr_stmt(&mut self, n: &ExprStmt) {
     n.visit_children_with(self);
 
-    // Treat `Deno.exit(...)` and `process.exit(...)` as statements that stop
-    // execution. There's no type information available here, so this is a
-    // targeted syntactic heuristic.
-    if is_forced_exit_call(n) {
-      self.mark_as_end(n.start(), End::forced_return());
+    // Treat a `Deno.exit(...)` / `process.exit(...)` *expression statement* as
+    // stopping execution. There's no type information available here, so this
+    // is a targeted syntactic heuristic. It is intentionally limited to
+    // statement position: a call in expression position (e.g.
+    // `cond ?? Deno.exit(1)`) must not poison the surrounding scope.
+    if let Expr::Call(call) = &*n.expr {
+      if is_forced_exit_call(call) {
+        self.mark_as_end(n.start(), End::forced_return());
+      }
     }
   }
 

--- a/src/rules/no_fallthrough.rs
+++ b/src/rules/no_fallthrough.rs
@@ -95,8 +95,23 @@ impl Visit for NoFallthroughVisitor<'_, '_> {
         }
 
         if last {
-          let comments = self.context.trailing_comments_at(stmt.end());
-          if allow_fall_through(comments) {
+          let mut allow =
+            allow_fall_through(self.context.trailing_comments_at(stmt.end()));
+
+          // The fallthrough comment may also be placed on the last line inside
+          // a block, e.g. `case 0: { foo(); /* falls through */ }`.
+          // See https://github.com/denoland/deno_lint/issues/1041
+          if !allow {
+            if let Stmt::Block(block) = stmt {
+              if let Some(inner_last) = block.stmts.last() {
+                allow = allow_fall_through(
+                  self.context.trailing_comments_at(inner_last.end()),
+                );
+              }
+            }
+          }
+
+          if allow {
             should_emit_err = false;
             // User comment beats everything
             prev_range = Some(case.range());
@@ -189,6 +204,112 @@ switch(someValue) {
   } break;
   default:
     console.log(42);
+}
+      "#,
+
+      // https://github.com/denoland/deno_lint/issues/1042
+      r#"
+switch (input) {
+  case "x":
+    Deno.exit();
+  default:
+    break;
+}
+      "#,
+      r#"
+switch (input) {
+  case "x":
+    process.exit(1);
+  default:
+    break;
+}
+      "#,
+
+      // https://github.com/denoland/deno_lint/issues/1156
+      r#"
+function* sequence(type) {
+  let num = 0;
+  switch (type) {
+    case "even":
+      while (true) {
+        if (isEven(num)) yield num;
+        num += 1;
+      }
+    case "odd":
+      yield 1;
+  }
+}
+      "#,
+
+      // https://github.com/denoland/deno_lint/issues/1331
+      r#"
+export function repro(...nums) {
+  for (let i = 0; i < nums.length; i++) {
+    switch (nums[i]) {
+      case 0:
+        switch (i) {
+          case 0:
+            continue;
+          default:
+            return 0;
+        }
+      case 1:
+        return 1;
+    }
+  }
+}
+      "#,
+      // https://github.com/denoland/deno_lint/issues/1379
+      r#"
+function foo(i, type, flags) {
+  maybeFlag: if (isFlagProp(i)) {
+    switch (i) {
+      case AST_PROP_OPERATOR:
+        switch (type) {
+          case 1:
+            return getAssignOperator(flags);
+          default:
+            break maybeFlag;
+        }
+      case AST_PROP_PREFIX:
+        return true;
+    }
+  }
+}
+      "#,
+
+      // https://github.com/denoland/deno_lint/issues/1444
+      r#"
+function booleanAnd(b1, b2) {
+  switch (b1) {
+    case true:
+      switch (b2) {
+        case true:
+        default:
+          return true;
+      }
+    case false:
+      switch (b2) {
+        case true:
+          return true;
+        case false:
+          return false;
+      }
+  }
+}
+      "#,
+
+      // https://github.com/denoland/deno_lint/issues/1041
+      r#"
+function handler(req) {
+  switch (path) {
+    case "/data": {
+      if (req.method === 'GET') return getData()
+      // fallthrough
+    }
+    default:
+      return new Response("not found", { status: 404 });
+  }
 }
       "#,
     };

--- a/src/rules/no_unreachable.rs
+++ b/src/rules/no_unreachable.rs
@@ -438,6 +438,54 @@ function foo(trueOrFalse: boolean) {
   }
 }
       "#,
+
+      // https://github.com/denoland/deno_lint/issues/1468
+      r#"
+function test(): boolean {
+  let tryCount = 0;
+  do {
+    const httpCode = genRandomNumber(200, 700);
+    if (isRetryableError(httpCode)) {
+      continue;
+    }
+    return randomlyErrorOut();
+  } while (tryCount++ < retryCount);
+  throw new Error("Exceeded maximum retry attempts");
+}
+      "#,
+
+      // https://github.com/denoland/deno_lint/issues/1341
+      r#"
+let one: number | undefined;
+mainLoop: for (;;) {
+  let two: number | undefined;
+  for (;;) {
+    if (one === 10) {
+      break mainLoop;
+    }
+    if (two === 10) {
+      break;
+    }
+    two = (two ?? 0) + 1;
+  }
+  one = (one ?? 0) + 1;
+  console.log(one);
+}
+console.log("finished!");
+      "#,
+
+      // https://github.com/denoland/deno_lint/issues/1303
+      r#"
+function f() {
+  const fooError = new Error("foo");
+  try {
+    throw fooError;
+  } catch (cause) {
+    assert(cause instanceof Error && cause.message === "foo");
+    throw new Error("bar", { cause });
+  }
+}
+      "#,
     };
   }
 

--- a/src/rules/no_unreachable.rs
+++ b/src/rules/no_unreachable.rs
@@ -486,6 +486,17 @@ function f() {
   }
 }
       "#,
+
+      // `Deno.exit()` / `process.exit()` in *expression* position must not mark
+      // the following statements as unreachable.
+      r#"
+function h() {
+  const port = Deno.env.get("PORT") ?? Deno.exit(1);
+  startServer(port);
+}
+      "#,
+      "function g(cond) { const result = cond || Deno.exit(1); return result; }",
+      "function p(cond) { const x = cond ? 1 : process.exit(); console.log(x); }",
     };
   }
 


### PR DESCRIPTION
Improves the shared control-flow analysis in `src/control_flow` so that `no-fallthrough` and `no-unreachable` stop firing on code that cannot actually fall through or that is in fact reachable. Fixing the analysis at the root means both rules benefit from the same changes.

The following false positives are addressed, each reproduced as a failing test first and then fixed:

- `Deno.exit()` / `process.exit()` in a switch case is recognized as forced termination (#1042)
- an infinite loop (`while (true) {}`) in a case precludes fallthrough (#1156)
- `continue` inside a nested switch or loop is no longer treated as a fallthrough (#1331)
- a labeled `break` inside a nested switch counts as stopping execution (#1379)
- empty fallthrough in a nested switch is handled correctly (#1444)
- a `/* falls through */` comment is accepted as the last line of a case block (#1041)
- a `do…while` with a `continue` is no longer deemed to unconditionally return (#1468)
- an unlabeled `break` is no longer masked by a coexisting labeled `break` (#1341)
- `throw <identifier>` keeps the following `catch` reachable (#1303)

General detection of functions that return `never` (#782) is not included, as it requires type information that is not available to deno_lint.

No existing test expectations were modified; only new tests were added.

Closes #1042, #1156, #1331, #1379, #1444, #1041, #1468, #1341, #1303.