### PR TITLE
feat: add jsx-a11y accessibility lint rules (content/attribute cluster)

### DIFF
--- a/src/rules.rs
+++ b/src/rules.rs
@@ -26,6 +26,10 @@ pub mod fresh_handler_export;
 pub mod fresh_server_event_handlers;
 pub mod getter_return;
 pub mod guard_for_in;
+pub mod jsx_a11y_anchor_has_content;
+pub mod jsx_a11y_heading_has_content;
+pub mod jsx_a11y_html_has_lang;
+pub mod jsx_a11y_iframe_has_title;
 pub mod jsx_boolean_value;
 pub mod jsx_button_has_type;
 pub mod jsx_curly_braces;
@@ -269,6 +273,10 @@ fn get_all_rules_raw() -> Vec<Box<dyn LintRule>> {
     Box::new(fresh_server_event_handlers::FreshServerEventHandlers),
     Box::new(getter_return::GetterReturn),
     Box::new(guard_for_in::GuardForIn),
+    Box::new(jsx_a11y_anchor_has_content::JSXA11yAnchorHasContent),
+    Box::new(jsx_a11y_heading_has_content::JSXA11yHeadingHasContent),
+    Box::new(jsx_a11y_html_has_lang::JSXA11yHtmlHasLang),
+    Box::new(jsx_a11y_iframe_has_title::JSXA11yIframeHasTitle),
     Box::new(jsx_boolean_value::JSXBooleanValue),
     Box::new(jsx_button_has_type::JSXButtonHasType),
     Box::new(jsx_curly_braces::JSXCurlyBraces),

--- a/src/rules/jsx_a11y_anchor_has_content.rs
+++ b/src/rules/jsx_a11y_anchor_has_content.rs
@@ -1,0 +1,242 @@
+// Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
+
+use super::{Context, LintRule};
+use crate::handler::{Handler, Traverse};
+use crate::tags::{self, Tags};
+use crate::Program;
+use deno_ast::view::{
+  Expr, JSXAttr, JSXAttrName, JSXAttrOrSpread, JSXAttrValue, JSXElement,
+  JSXElementChild, JSXElementName, JSXExpr, JSXOpeningElement, Lit,
+};
+use deno_ast::SourceRanged;
+
+#[derive(Debug)]
+pub struct JSXA11yAnchorHasContent;
+
+const CODE: &str = "jsx-a11y-anchor-has-content";
+
+// TODO(deno_lint): The reference rule supports a `components` setting to map
+// custom component names to `a`. Option support is deferred until deno_lint's
+// JS-plugin option handling is ready, so only the built-in `a` element is
+// checked. The reference rule's autofix (removing `aria-hidden`/`hidden`
+// attributes) is also not ported.
+impl LintRule for JSXA11yAnchorHasContent {
+  fn tags(&self) -> Tags {
+    &[tags::A11Y, tags::JSX, tags::REACT, tags::FRESH]
+  }
+
+  fn code(&self) -> &'static str {
+    CODE
+  }
+
+  fn lint_program_with_ast_view(
+    &self,
+    context: &mut Context,
+    program: Program,
+  ) {
+    JSXA11yAnchorHasContentHandler.traverse(program, context);
+  }
+}
+
+const MESSAGE: &str = "Missing accessible content when using `a` elements.";
+const HINT: &str =
+  "Provide screen reader accessible content when using `a` elements.";
+
+struct JSXA11yAnchorHasContentHandler;
+
+impl Handler for JSXA11yAnchorHasContentHandler {
+  fn jsx_element(&mut self, node: &JSXElement, ctx: &mut Context) {
+    let JSXElementName::Ident(name) = node.opening.name else {
+      return;
+    };
+
+    if name.sym() != "a" {
+      return;
+    }
+
+    if is_hidden_from_screen_reader(node.opening) {
+      return;
+    }
+
+    if object_has_accessible_child(node.children, node.opening) {
+      return;
+    }
+
+    for attr in ["title", "aria-label"] {
+      if get_attr_ignore_case(node.opening, attr).is_some() {
+        return;
+      }
+    }
+
+    ctx.add_diagnostic_with_hint(node.range(), CODE, MESSAGE, HINT);
+  }
+}
+
+fn get_attr_ignore_case<'a>(
+  opening: &'a JSXOpeningElement<'a>,
+  target: &str,
+) -> Option<&'a JSXAttr<'a>> {
+  opening.attrs.iter().find_map(|attr| {
+    let JSXAttrOrSpread::JSXAttr(attr) = attr else {
+      return None;
+    };
+    let JSXAttrName::Ident(name) = attr.name else {
+      return None;
+    };
+    if name.sym().eq_ignore_ascii_case(target) {
+      Some(*attr)
+    } else {
+      None
+    }
+  })
+}
+
+fn is_hidden_from_screen_reader<'a>(
+  opening: &'a JSXOpeningElement<'a>,
+) -> bool {
+  let JSXElementName::Ident(name) = opening.name else {
+    return false;
+  };
+
+  if name.sym().eq_ignore_ascii_case("input") {
+    if let Some(attr) = get_attr_ignore_case(opening, "type") {
+      if let Some(JSXAttrValue::Str(s)) = attr.value {
+        if s.value().to_string_lossy().eq_ignore_ascii_case("hidden") {
+          return true;
+        }
+      }
+    }
+  }
+
+  match get_attr_ignore_case(opening, "aria-hidden") {
+    None => false,
+    Some(attr) => match attr.value {
+      None => true,
+      Some(JSXAttrValue::Str(s)) => s.value().to_string_lossy() == "true",
+      Some(JSXAttrValue::JSXExprContainer(container)) => {
+        expr_to_boolean(&container.expr)
+      }
+      _ => false,
+    },
+  }
+}
+
+fn expr_to_boolean(expr: &JSXExpr) -> bool {
+  let JSXExpr::Expr(expr) = expr else {
+    return false;
+  };
+  match expr {
+    Expr::Lit(Lit::Bool(b)) => b.value(),
+    Expr::Lit(Lit::Num(n)) => n.value() != 0.0,
+    Expr::Lit(Lit::Str(s)) => !s.value().to_string_lossy().is_empty(),
+    _ => false,
+  }
+}
+
+fn object_has_accessible_child<'a>(
+  children: &'a [JSXElementChild<'a>],
+  opening: &'a JSXOpeningElement<'a>,
+) -> bool {
+  let has_child = children.iter().any(|child| match child {
+    JSXElementChild::JSXText(text) => !text.value().is_empty(),
+    JSXElementChild::JSXElement(child) => {
+      !is_hidden_from_screen_reader(child.opening)
+    }
+    JSXElementChild::JSXExprContainer(container) => match container.expr {
+      JSXExpr::Expr(Expr::Lit(Lit::Null(_))) => false,
+      JSXExpr::Expr(Expr::Ident(id)) => id.sym() != "undefined",
+      JSXExpr::JSXEmptyExpr(_) => false,
+      _ => true,
+    },
+    _ => false,
+  });
+
+  has_child
+    || get_attr_ignore_case(opening, "dangerouslySetInnerHTML").is_some()
+    || get_attr_ignore_case(opening, "children").is_some()
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn anchor_has_content_valid() {
+    assert_lint_ok! {
+      JSXA11yAnchorHasContent,
+      filename: "file:///foo.jsx",
+      r#"<div />;"#,
+      r#"<a>Foo</a>"#,
+      r#"<a><Bar /></a>"#,
+      r#"<a>{foo}</a>"#,
+      r#"<a>{foo.bar}</a>"#,
+      r#"<a dangerouslySetInnerHTML={{ __html: "foo" }} />"#,
+      r#"<a children={children} />"#,
+      r#"<Link />"#,
+      r#"<a title={title} />"#,
+      r#"<a aria-label={ariaLabel} />"#,
+      r#"<a title={title} aria-label={ariaLabel} />"#,
+      r#"<a><Bar aria-hidden="false" /></a>"#,
+      r#"<a aria-hidden>Foo</a>"#,
+      r#"<a aria-hidden="true">Foo</a>"#,
+      r#"<a hidden>Foo</a>"#,
+      r#"<a aria-hidden><span aria-hidden>Foo</span></a>"#,
+      r#"<a hidden="true">Foo</a>"#,
+      r#"<a hidden="">Foo</a>"#,
+      r#"<a><div hidden /></a>"#,
+      r#"<a><Bar hidden /></a>"#,
+      r#"<a><Bar hidden="" /></a>"#,
+      r#"<a><Bar hidden="until-hidden" /></a>"#,
+    };
+  }
+
+  #[test]
+  fn anchor_has_content_invalid() {
+    assert_lint_err! {
+      JSXA11yAnchorHasContent,
+      filename: "file:///foo.jsx",
+      r#"<a />"#: [
+        {
+          col: 0,
+          message: MESSAGE,
+          hint: HINT,
+        }
+      ],
+      r#"<a><Bar aria-hidden /></a>"#: [
+        {
+          col: 0,
+          message: MESSAGE,
+          hint: HINT,
+        }
+      ],
+      r#"<a><Bar aria-hidden="true" /></a>"#: [
+        {
+          col: 0,
+          message: MESSAGE,
+          hint: HINT,
+        }
+      ],
+      r#"<a><input type="hidden" /></a>"#: [
+        {
+          col: 0,
+          message: MESSAGE,
+          hint: HINT,
+        }
+      ],
+      r#"<a>{undefined}</a>"#: [
+        {
+          col: 0,
+          message: MESSAGE,
+          hint: HINT,
+        }
+      ],
+      r#"<a>{null}</a>"#: [
+        {
+          col: 0,
+          message: MESSAGE,
+          hint: HINT,
+        }
+      ]
+    };
+  }
+}

--- a/src/rules/jsx_a11y_heading_has_content.rs
+++ b/src/rules/jsx_a11y_heading_has_content.rs
@@ -1,0 +1,225 @@
+// Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
+
+use super::{Context, LintRule};
+use crate::handler::{Handler, Traverse};
+use crate::tags::{self, Tags};
+use crate::Program;
+use deno_ast::view::{
+  Expr, JSXAttr, JSXAttrName, JSXAttrOrSpread, JSXAttrValue, JSXElement,
+  JSXElementChild, JSXElementName, JSXExpr, JSXOpeningElement, Lit,
+};
+use deno_ast::SourceRanged;
+
+#[derive(Debug)]
+pub struct JSXA11yHeadingHasContent;
+
+const CODE: &str = "jsx-a11y-heading-has-content";
+
+// TODO(deno_lint): The reference rule supports a `components` option (and a
+// `components` setting) to treat custom component names as headings. Option
+// support is deferred until deno_lint's JS-plugin option handling is ready, so
+// only the built-in `h1`-`h6` elements are checked.
+impl LintRule for JSXA11yHeadingHasContent {
+  fn tags(&self) -> Tags {
+    &[tags::A11Y, tags::JSX, tags::REACT, tags::FRESH]
+  }
+
+  fn code(&self) -> &'static str {
+    CODE
+  }
+
+  fn lint_program_with_ast_view(
+    &self,
+    context: &mut Context,
+    program: Program,
+  ) {
+    JSXA11yHeadingHasContentHandler.traverse(program, context);
+  }
+}
+
+const MESSAGE: &str =
+  "Headings must have content and the content must be accessible by a screen reader.";
+const HINT: &str =
+  "Provide screen reader accessible content when using heading elements.";
+
+struct JSXA11yHeadingHasContentHandler;
+
+impl Handler for JSXA11yHeadingHasContentHandler {
+  fn jsx_element(&mut self, node: &JSXElement, ctx: &mut Context) {
+    let JSXElementName::Ident(name) = node.opening.name else {
+      return;
+    };
+
+    if !is_heading(name.sym()) {
+      return;
+    }
+
+    if object_has_accessible_child(node.children, node.opening) {
+      return;
+    }
+
+    if is_hidden_from_screen_reader(node.opening) {
+      return;
+    }
+
+    ctx.add_diagnostic_with_hint(node.range(), CODE, MESSAGE, HINT);
+  }
+}
+
+fn is_heading(name: &str) -> bool {
+  matches!(name, "h1" | "h2" | "h3" | "h4" | "h5" | "h6")
+}
+
+fn get_attr_ignore_case<'a>(
+  opening: &'a JSXOpeningElement<'a>,
+  target: &str,
+) -> Option<&'a JSXAttr<'a>> {
+  opening.attrs.iter().find_map(|attr| {
+    let JSXAttrOrSpread::JSXAttr(attr) = attr else {
+      return None;
+    };
+    let JSXAttrName::Ident(name) = attr.name else {
+      return None;
+    };
+    if name.sym().eq_ignore_ascii_case(target) {
+      Some(*attr)
+    } else {
+      None
+    }
+  })
+}
+
+fn is_hidden_from_screen_reader<'a>(
+  opening: &'a JSXOpeningElement<'a>,
+) -> bool {
+  let JSXElementName::Ident(name) = opening.name else {
+    return false;
+  };
+
+  if name.sym().eq_ignore_ascii_case("input") {
+    if let Some(attr) = get_attr_ignore_case(opening, "type") {
+      if let Some(JSXAttrValue::Str(s)) = attr.value {
+        if s.value().to_string_lossy().eq_ignore_ascii_case("hidden") {
+          return true;
+        }
+      }
+    }
+  }
+
+  match get_attr_ignore_case(opening, "aria-hidden") {
+    None => false,
+    Some(attr) => match attr.value {
+      None => true,
+      Some(JSXAttrValue::Str(s)) => s.value().to_string_lossy() == "true",
+      Some(JSXAttrValue::JSXExprContainer(container)) => {
+        expr_to_boolean(&container.expr)
+      }
+      _ => false,
+    },
+  }
+}
+
+fn expr_to_boolean(expr: &JSXExpr) -> bool {
+  let JSXExpr::Expr(expr) = expr else {
+    return false;
+  };
+  match expr {
+    Expr::Lit(Lit::Bool(b)) => b.value(),
+    Expr::Lit(Lit::Num(n)) => n.value() != 0.0,
+    Expr::Lit(Lit::Str(s)) => !s.value().to_string_lossy().is_empty(),
+    _ => false,
+  }
+}
+
+fn object_has_accessible_child<'a>(
+  children: &'a [JSXElementChild<'a>],
+  opening: &'a JSXOpeningElement<'a>,
+) -> bool {
+  let has_child = children.iter().any(|child| match child {
+    JSXElementChild::JSXText(text) => !text.value().is_empty(),
+    JSXElementChild::JSXElement(child) => {
+      !is_hidden_from_screen_reader(child.opening)
+    }
+    JSXElementChild::JSXExprContainer(container) => match container.expr {
+      JSXExpr::Expr(Expr::Lit(Lit::Null(_))) => false,
+      JSXExpr::Expr(Expr::Ident(id)) => id.sym() != "undefined",
+      JSXExpr::JSXEmptyExpr(_) => false,
+      _ => true,
+    },
+    _ => false,
+  });
+
+  has_child
+    || get_attr_ignore_case(opening, "dangerouslySetInnerHTML").is_some()
+    || get_attr_ignore_case(opening, "children").is_some()
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn heading_has_content_valid() {
+    assert_lint_ok! {
+      JSXA11yHeadingHasContent,
+      filename: "file:///foo.jsx",
+      r#"<h1>Foo</h1>"#,
+      r#"<h2>Foo</h2>"#,
+      r#"<h3>Foo</h3>"#,
+      r#"<h4>Foo</h4>"#,
+      r#"<h5>Foo</h5>"#,
+      r#"<h6>Foo</h6>"#,
+      r#"<h6>123</h6>"#,
+      r#"<h1><Bar /></h1>"#,
+      r#"<h1>{foo}</h1>"#,
+      r#"<h1>{foo.bar}</h1>"#,
+      r#"<h1 dangerouslySetInnerHTML={{ __html: "foo" }} />"#,
+      r#"<h1 children={children} />"#,
+      r#"<h1 aria-hidden />"#,
+      r#"<h1><CustomInput type="hidden" /></h1>"#,
+    };
+  }
+
+  #[test]
+  fn heading_has_content_invalid() {
+    assert_lint_err! {
+      JSXA11yHeadingHasContent,
+      filename: "file:///foo.jsx",
+      r#"<h1 />"#: [
+        {
+          col: 0,
+          message: MESSAGE,
+          hint: HINT,
+        }
+      ],
+      r#"<h1><Bar aria-hidden /></h1>"#: [
+        {
+          col: 0,
+          message: MESSAGE,
+          hint: HINT,
+        }
+      ],
+      r#"<h1>{undefined}</h1>"#: [
+        {
+          col: 0,
+          message: MESSAGE,
+          hint: HINT,
+        }
+      ],
+      r#"<h1><></></h1>"#: [
+        {
+          col: 0,
+          message: MESSAGE,
+          hint: HINT,
+        }
+      ],
+      r#"<h1><input type="hidden" /></h1>"#: [
+        {
+          col: 0,
+          message: MESSAGE,
+          hint: HINT,
+        }
+      ]
+    };
+  }
+}

--- a/src/rules/jsx_a11y_html_has_lang.rs
+++ b/src/rules/jsx_a11y_html_has_lang.rs
@@ -1,0 +1,213 @@
+// Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
+
+use super::{Context, LintRule};
+use crate::handler::{Handler, Traverse};
+use crate::tags::{self, Tags};
+use crate::Program;
+use deno_ast::view::{
+  Expr, JSXAttrName, JSXAttrOrSpread, JSXAttrValue, JSXElementName, JSXExpr,
+  Lit,
+};
+use deno_ast::{view as ast_view, SourceRanged};
+
+#[derive(Debug)]
+pub struct JSXA11yHtmlHasLang;
+
+const CODE: &str = "jsx-a11y-html-has-lang";
+
+// TODO(deno_lint): The reference rule supports a `components` setting to map
+// custom component names to `html`. Option support is deferred until
+// deno_lint's JS-plugin option handling is ready, so only the built-in
+// `html` element is checked.
+impl LintRule for JSXA11yHtmlHasLang {
+  fn tags(&self) -> Tags {
+    &[tags::A11Y, tags::JSX, tags::REACT, tags::FRESH]
+  }
+
+  fn code(&self) -> &'static str {
+    CODE
+  }
+
+  fn lint_program_with_ast_view(
+    &self,
+    context: &mut Context,
+    program: Program,
+  ) {
+    JSXA11yHtmlHasLangHandler.traverse(program, context);
+  }
+}
+
+const MISSING_PROP_MESSAGE: &str = "Missing `lang` attribute.";
+const MISSING_PROP_HINT: &str = "Add a `lang` attribute to the `html` element whose value represents the primary language of document.";
+const MISSING_VALUE_MESSAGE: &str = "Missing value for `lang` attribute.";
+const MISSING_VALUE_HINT: &str =
+  "Provide a meaningful value for the `lang` attribute.";
+
+struct JSXA11yHtmlHasLangHandler;
+
+impl Handler for JSXA11yHtmlHasLangHandler {
+  fn jsx_opening_element(
+    &mut self,
+    node: &ast_view::JSXOpeningElement,
+    ctx: &mut Context,
+  ) {
+    let JSXElementName::Ident(name) = node.name else {
+      return;
+    };
+    if name.sym() != "html" {
+      return;
+    }
+
+    let mut lang_attr = None;
+    for attr in node.attrs {
+      let JSXAttrOrSpread::JSXAttr(attr) = attr else {
+        continue;
+      };
+      let JSXAttrName::Ident(attr_name) = attr.name else {
+        continue;
+      };
+      if attr_name.sym().eq_ignore_ascii_case("lang") {
+        lang_attr = Some(attr);
+        break;
+      }
+    }
+
+    let Some(attr) = lang_attr else {
+      ctx.add_diagnostic_with_hint(
+        node.name.range(),
+        CODE,
+        MISSING_PROP_MESSAGE,
+        MISSING_PROP_HINT,
+      );
+      return;
+    };
+
+    if !is_valid_lang_value(attr.value) {
+      ctx.add_diagnostic_with_hint(
+        node.range(),
+        CODE,
+        MISSING_VALUE_MESSAGE,
+        MISSING_VALUE_HINT,
+      );
+    }
+  }
+}
+
+fn is_valid_lang_value(value: Option<JSXAttrValue>) -> bool {
+  match value {
+    // `<html lang />` is considered valid by the reference implementation.
+    None => true,
+    Some(JSXAttrValue::Str(s)) => !s.value().to_string_lossy().is_empty(),
+    Some(JSXAttrValue::JSXExprContainer(container)) => {
+      let JSXExpr::Expr(expr) = container.expr else {
+        return false;
+      };
+      match expr {
+        Expr::Lit(Lit::Null(_))
+        | Expr::Lit(Lit::Bool(_))
+        | Expr::Lit(Lit::Num(_)) => false,
+        Expr::Ident(id) => id.sym() != "undefined",
+        Expr::Lit(Lit::Str(s)) => !s.value().to_string_lossy().is_empty(),
+        Expr::Tpl(tpl) => {
+          !tpl.exprs.is_empty()
+            || tpl.quasis.iter().any(|q| !q.inner.raw.as_str().is_empty())
+        }
+        _ => true,
+      }
+    }
+    _ => true,
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn html_has_lang_valid() {
+    assert_lint_ok! {
+      JSXA11yHtmlHasLang,
+      filename: "file:///foo.jsx",
+      r#"<div />;"#,
+      r#"<html lang="en" />"#,
+      r#"<html lang="en-US" />"#,
+      r#"<html lang={"en-US"} />"#,
+      r#"<html lang={`en-US`} />"#,
+      r#"<html lang={`${foo}`} />"#,
+      r#"<html lang={foo} />;"#,
+      r#"<html lang />;"#,
+      r#"<HTML />;"#,
+    };
+  }
+
+  #[test]
+  fn html_has_lang_invalid() {
+    assert_lint_err! {
+      JSXA11yHtmlHasLang,
+      filename: "file:///foo.jsx",
+      r#"<html />;"#: [
+        {
+          col: 1,
+          message: MISSING_PROP_MESSAGE,
+          hint: MISSING_PROP_HINT,
+        }
+      ],
+      r#"<html {...props} />;"#: [
+        {
+          col: 1,
+          message: MISSING_PROP_MESSAGE,
+          hint: MISSING_PROP_HINT,
+        }
+      ],
+      r#"<html lang={undefined} />;"#: [
+        {
+          col: 0,
+          message: MISSING_VALUE_MESSAGE,
+          hint: MISSING_VALUE_HINT,
+        }
+      ],
+      r#"<html lang={null} />;"#: [
+        {
+          col: 0,
+          message: MISSING_VALUE_MESSAGE,
+          hint: MISSING_VALUE_HINT,
+        }
+      ],
+      r#"<html lang={false} />;"#: [
+        {
+          col: 0,
+          message: MISSING_VALUE_MESSAGE,
+          hint: MISSING_VALUE_HINT,
+        }
+      ],
+      r#"<html lang={1} />;"#: [
+        {
+          col: 0,
+          message: MISSING_VALUE_MESSAGE,
+          hint: MISSING_VALUE_HINT,
+        }
+      ],
+      r#"<html lang={''} />;"#: [
+        {
+          col: 0,
+          message: MISSING_VALUE_MESSAGE,
+          hint: MISSING_VALUE_HINT,
+        }
+      ],
+      r#"<html lang={``} />;"#: [
+        {
+          col: 0,
+          message: MISSING_VALUE_MESSAGE,
+          hint: MISSING_VALUE_HINT,
+        }
+      ],
+      r#"<html lang="" />;"#: [
+        {
+          col: 0,
+          message: MISSING_VALUE_MESSAGE,
+          hint: MISSING_VALUE_HINT,
+        }
+      ]
+    };
+  }
+}

--- a/src/rules/jsx_a11y_iframe_has_title.rs
+++ b/src/rules/jsx_a11y_iframe_has_title.rs
@@ -1,0 +1,214 @@
+// Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
+
+use super::{Context, LintRule};
+use crate::handler::{Handler, Traverse};
+use crate::tags::{self, Tags};
+use crate::Program;
+use deno_ast::view::{
+  BinaryOp, Expr, JSXAttrName, JSXAttrOrSpread, JSXAttrValue, JSXElementName,
+  JSXExpr, Lit,
+};
+use deno_ast::{view as ast_view, SourceRanged};
+
+#[derive(Debug)]
+pub struct JSXA11yIframeHasTitle;
+
+const CODE: &str = "jsx-a11y-iframe-has-title";
+
+// TODO(deno_lint): The reference rule supports a `components` setting to map
+// custom component names to `iframe`. Option support is deferred until
+// deno_lint's JS-plugin option handling is ready, so only the built-in
+// `iframe` element is checked.
+impl LintRule for JSXA11yIframeHasTitle {
+  fn tags(&self) -> Tags {
+    &[tags::A11Y, tags::JSX, tags::REACT, tags::FRESH]
+  }
+
+  fn code(&self) -> &'static str {
+    CODE
+  }
+
+  fn lint_program_with_ast_view(
+    &self,
+    context: &mut Context,
+    program: Program,
+  ) {
+    JSXA11yIframeHasTitleHandler.traverse(program, context);
+  }
+}
+
+const MESSAGE: &str = "Missing `title` attribute for the `iframe` element.";
+const HINT: &str = "Provide a `title` property for the `iframe` element.";
+
+struct JSXA11yIframeHasTitleHandler;
+
+impl Handler for JSXA11yIframeHasTitleHandler {
+  fn jsx_opening_element(
+    &mut self,
+    node: &ast_view::JSXOpeningElement,
+    ctx: &mut Context,
+  ) {
+    let JSXElementName::Ident(name) = node.name else {
+      return;
+    };
+    if name.sym() != "iframe" {
+      return;
+    }
+
+    let mut title_attr = None;
+    for attr in node.attrs {
+      let JSXAttrOrSpread::JSXAttr(attr) = attr else {
+        continue;
+      };
+      let JSXAttrName::Ident(attr_name) = attr.name else {
+        continue;
+      };
+      if attr_name.sym().eq_ignore_ascii_case("title") {
+        title_attr = Some(attr);
+        break;
+      }
+    }
+
+    let Some(attr) = title_attr else {
+      ctx.add_diagnostic_with_hint(node.name.range(), CODE, MESSAGE, HINT);
+      return;
+    };
+
+    if !is_valid_title_value(attr.value) {
+      ctx.add_diagnostic_with_hint(node.name.range(), CODE, MESSAGE, HINT);
+    }
+  }
+}
+
+fn is_valid_title_value(value: Option<JSXAttrValue>) -> bool {
+  match value {
+    Some(JSXAttrValue::Str(s)) => !s.value().to_string_lossy().is_empty(),
+    Some(JSXAttrValue::JSXExprContainer(container)) => {
+      let JSXExpr::Expr(expr) = container.expr else {
+        return false;
+      };
+      match expr {
+        Expr::Lit(Lit::Str(s)) => !s.value().to_string_lossy().is_empty(),
+        Expr::Tpl(tpl) => {
+          !tpl.exprs.is_empty()
+            || tpl.quasis.iter().any(|q| !q.inner.raw.as_str().is_empty())
+        }
+        Expr::Ident(id) => id.sym() != "undefined",
+        // These expressions are considered valid because their value cannot
+        // be statically determined to be empty.
+        Expr::Call(_)
+        | Expr::Member(_)
+        | Expr::Cond(_)
+        | Expr::TaggedTpl(_)
+        | Expr::New(_) => true,
+        Expr::Bin(bin) => matches!(
+          bin.op(),
+          BinaryOp::LogicalAnd
+            | BinaryOp::LogicalOr
+            | BinaryOp::NullishCoalescing
+        ),
+        _ => false,
+      }
+    }
+    _ => false,
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn iframe_has_title_valid() {
+    assert_lint_ok! {
+      JSXA11yIframeHasTitle,
+      filename: "file:///foo.jsx",
+      r#"<div />;"#,
+      r#"<iframe title='Unique title' />"#,
+      r#"<iframe title={foo} />"#,
+      r#"<iframe title={`Title`} />"#,
+      r#"<iframe title={`${title}`} />"#,
+      r#"<FooComponent />"#,
+      r#"<iframe title={titleGenerator('hello')} />"#,
+      r#"<iframe title={file.name} />"#,
+      r#"<iframe title={obj.prop.name} />"#,
+      r#"<iframe title={obj['prop']} />"#,
+      r#"<iframe title={a ?? b} />"#,
+      r#"<iframe title={a && b} />"#,
+      r#"<iframe title={a ? b : c} />"#,
+      r#"<iframe title={i18n`title`} />"#,
+      r#"<iframe title={new Title()} />"#,
+    };
+  }
+
+  #[test]
+  fn iframe_has_title_invalid() {
+    assert_lint_err! {
+      JSXA11yIframeHasTitle,
+      filename: "file:///foo.jsx",
+      r#"<iframe />"#: [
+        {
+          col: 1,
+          message: MESSAGE,
+          hint: HINT,
+        }
+      ],
+      r#"<iframe {...props} />"#: [
+        {
+          col: 1,
+          message: MESSAGE,
+          hint: HINT,
+        }
+      ],
+      r#"<iframe title={undefined} />"#: [
+        {
+          col: 1,
+          message: MESSAGE,
+          hint: HINT,
+        }
+      ],
+      r#"<iframe title='' />"#: [
+        {
+          col: 1,
+          message: MESSAGE,
+          hint: HINT,
+        }
+      ],
+      r#"<iframe title={false} />"#: [
+        {
+          col: 1,
+          message: MESSAGE,
+          hint: HINT,
+        }
+      ],
+      r#"<iframe title={true} />"#: [
+        {
+          col: 1,
+          message: MESSAGE,
+          hint: HINT,
+        }
+      ],
+      r#"<iframe title={''} />"#: [
+        {
+          col: 1,
+          message: MESSAGE,
+          hint: HINT,
+        }
+      ],
+      r#"<iframe title={``} />"#: [
+        {
+          col: 1,
+          message: MESSAGE,
+          hint: HINT,
+        }
+      ],
+      r#"<iframe title={42} />"#: [
+        {
+          col: 1,
+          message: MESSAGE,
+          hint: HINT,
+        }
+      ]
+    };
+  }
+}

--- a/src/tags.rs
+++ b/src/tags.rs
@@ -25,5 +25,7 @@ pub const JSR: Tag = Tag("jsr");
 pub const REACT: Tag = Tag("react");
 pub const JSX: Tag = Tag("jsx");
 pub const WORKSPACE: Tag = Tag("workspace");
+pub const A11Y: Tag = Tag("a11y");
 
-pub const ALL_TAGS: Tags = &[RECOMMENDED, FRESH, JSR, REACT, JSX, WORKSPACE];
+pub const ALL_TAGS: Tags =
+  &[RECOMMENDED, FRESH, JSR, REACT, JSX, WORKSPACE, A11Y];


### PR DESCRIPTION
First cluster of accessibility rules ported from oxlint / eslint-plugin-jsx-a11y, implemented in Rust against `deno_ast::view` using the existing `Handler`/`Traverse` pattern.

Four rules are added:

- `jsx-a11y-anchor-has-content` — an `<a>` anchor must have content accessible to screen readers (text, a non-hidden child, or `dangerouslySetInnerHTML` / `title` / `aria-label`).
- `jsx-a11y-heading-has-content` — heading elements `<h1>`–`<h6>` must have content.
- `jsx-a11y-html-has-lang` — the `<html>` element must have a non-empty `lang` attribute.
- `jsx-a11y-iframe-has-title` — `<iframe>` must have a non-empty `title` attribute.

A new `a11y` tag is introduced. These rules are **opt-in**: they are tagged `a11y`, `jsx`, `react`, `fresh` but intentionally **not** `recommended`, so they only run when a user enables them. Individual rules can be promoted to `recommended` later.

The configurable `components` option (custom-component name mapping) and the autofixers from the reference implementations are intentionally deferred for now; only built-in DOM element names are handled. Test fixtures are ported from the oxlint reference (pass cases → `assert_lint_ok!`, fail cases → `assert_lint_err!`).

This is the start of the jsx-a11y porting track (35 rules total); see the project notes for the full plan.