### PR TITLE
fix(jsx-curly-braces): allow significant whitespace and comment-like literals

### DIFF
--- a/src/rules/jsx_curly_braces.rs
+++ b/src/rules/jsx_curly_braces.rs
@@ -85,8 +85,27 @@ impl Handler for JSXCurlyBracesHandler {
 
       if let JSXElementChild::JSXExprContainer(child_expr) = child {
         if let JSXExpr::Expr(Expr::Lit(Lit::Str(lit_str))) = child_expr.expr {
+          let value = lit_str.inner.value.to_string_lossy();
+
           // Ignore entities which would require escaping.
-          if IGNORE_CHARS.is_match(&lit_str.inner.value.to_string_lossy()) {
+          if IGNORE_CHARS.is_match(&value) {
+            continue;
+          }
+
+          // Leading or trailing whitespace (including whitespace-only
+          // strings) is significant: JSX trims and collapses whitespace
+          // around text nodes, so removing the curly braces would change
+          // the rendered output. This makes `{" "}` separators valid.
+          // See https://github.com/denoland/deno_lint/issues/1422
+          if value.trim() != value {
+            continue;
+          }
+
+          // Comment-like text (`//` or `/*`) must stay wrapped in curly
+          // braces, otherwise it becomes a comment text node which
+          // `jsx-no-comment-text-nodes` forbids.
+          // See https://github.com/denoland/deno_lint/issues/1440
+          if value.starts_with("//") || value.starts_with("/*") {
             continue;
           }
 
@@ -195,6 +214,18 @@ mod tests {
       r#"<div>foo{"foo >"}</div>"#,
       r#"<div>foo{"foo }"}</div>"#,
       r#"<div>foo{"foo {"}</div>"#,
+      // Whitespace-only separators are significant (#1422)
+      r#"<div>foo{" "}bar</div>"#,
+      r#"<div>foo{"  "}bar</div>"#,
+      r#"<div><foo />{" "}<bar /></div>"#,
+      // Leading/trailing whitespace is significant (#1422)
+      r#"<div>foo{" :"}bar</div>"#,
+      r#"<div>foo{" ("}bar</div>"#,
+      r#"<div>foo{") "}bar</div>"#,
+      // Comment-like text must stay wrapped (#1440)
+      r#"<div>foo{"//"}</div>"#,
+      r#"<div>foo{"/*"}</div>"#,
+      r#"<div>{"// not a comment"}</div>"#,
     };
   }
 


### PR DESCRIPTION
Removing curly braces around a JSX child string literal can change the
rendered output or contradict another lint rule. This relaxes
`jsx-curly-braces` so it no longer flags two such cases.

Whitespace around JSX text nodes is trimmed and collapsed, so a literal
that is whitespace-only or has leading/trailing whitespace is
meaningful. `{" "}` separators (common when a long line is broken across
multiple lines, where the surrounding newlines would otherwise strip the
space) are now left alone. This also resolves the conflict with
`deno fmt` noted in #1422.

Comment-like literals (`//` or `/*`) must stay wrapped: removing the
braces turns them into a comment text node, which `jsx-no-comment-text-nodes`
forbids. Previously the two rules contradicted each other — wrapping the
text to satisfy one tripped the other. See #1440.

Closes #1422.
Closes #1440.