### PR TITLE
fix(no-control-regex): zero-pad code point in diagnostic message

### DIFF
--- a/src/rules/no_control_regex.rs
+++ b/src/rules/no_control_regex.rs
@@ -19,7 +19,7 @@ const CODE: &str = "no-control-regex";
 #[derive(Display)]
 enum NoControlRegexMessage {
   #[display(
-    fmt = "Unexpected control character(s) in regular expression: \\x{:x}.",
+    fmt = "Unexpected control character(s) in regular expression: \\x{:02x}.",
     _0
   )]
   Unexpected(u64),
@@ -186,6 +186,20 @@ mod tests {
   }
 
   #[test]
+  fn message_zero_pads_to_two_hex_digits() {
+    // Regression for #1143: the code point must be zero-padded so a null
+    // character renders as `\x00`, not `\x0`.
+    assert_eq!(
+      NoControlRegexMessage::Unexpected(0x00).to_string(),
+      r"Unexpected control character(s) in regular expression: \x00.",
+    );
+    assert_eq!(
+      NoControlRegexMessage::Unexpected(0x1f).to_string(),
+      r"Unexpected control character(s) in regular expression: \x1f.",
+    );
+  }
+
+  #[test]
   fn no_control_regex_valid() {
     assert_lint_ok! {
       NoControlRegex,
@@ -209,6 +223,13 @@ mod tests {
   fn no_control_regex_invalid() {
     assert_lint_err! {
       NoControlRegex,
+      r"/\x00/": [
+        {
+          col: 0,
+          message: NoControlRegexMessage::Unexpected(0x00),
+          hint: NoControlRegexHint::DisableOrRework,
+        }
+      ],
       r"/\x1f/": [
         {
           col: 0,


### PR DESCRIPTION
Refs #1143.

The `no-control-regex` diagnostic formatted the offending code point with
`{:x}`, which drops leading zeros. A null character (`\x00`) was therefore
reported as:

> Unexpected control character(s) in regular expression: \x0.

i.e. `\x0` instead of `\x00`. The rule only ever flags code points
`<= 0x1f`, so formatting with `{:02x}` always yields the correct two-digit
escape (`\x00` .. `\x1f`) and never truncates.

Includes a unit test pinning the rendered message string for `0x00` and
`0x1f`, plus a `/\x00/` case in the invalid set.

Scope note: this PR intentionally addresses only the message bug. The issue
also raises two separate, more opinionated points — whether `\x7f` (DEL)
should be flagged (it currently isn't, which matches ESLint's `no-control-regex`,
that only considers `\x00`-`\x1f`), and whether the rule should be removed
from the recommended set. Those are policy decisions left for the issue
discussion.