### PR TITLE
fix(constructor-super): unwrap sequence expressions when finding super()

### DIFF
--- a/src/rules/constructor_super.rs
+++ b/src/rules/constructor_super.rs
@@ -68,42 +68,43 @@ fn inherits_from_non_constructor(class: &ast_view::Class) -> bool {
 }
 
 fn super_call_ranges(constructor: &ast_view::Constructor) -> Vec<SourceRange> {
+  let mut ranges = Vec::new();
   if let Some(block_stmt) = &constructor.body {
-    block_stmt
-      .stmts
-      .iter()
-      .filter_map(extract_super_range)
-      .collect()
-  } else {
-    vec![]
+    for stmt in block_stmt.stmts {
+      collect_super_ranges_in_stmt(stmt, &mut ranges);
+    }
   }
+  ranges
 }
 
-fn extract_super_range(stmt: &ast_view::Stmt) -> Option<SourceRange> {
+fn collect_super_ranges_in_stmt(
+  stmt: &ast_view::Stmt,
+  ranges: &mut Vec<SourceRange>,
+) {
   if let ast_view::Stmt::Expr(expr) = stmt {
-    super_range_in_expr(expr.expr)
-  } else {
-    None
+    collect_super_ranges(expr.expr, ranges);
   }
 }
 
-/// Returns the range of a `super()` call in `expr`, if any.
+/// Collects the range of every `super()` call in `expr`.
 ///
 /// `super()` may not be the whole expression: it can appear inside a
 /// comma/sequence expression, e.g. `super(), 0;` or `0, super();`. In those
-/// cases it is still called unconditionally, so the sequence is unwrapped.
-fn super_range_in_expr(expr: ast_view::Expr) -> Option<SourceRange> {
+/// cases it is still called unconditionally, so the sequence is unwrapped, and
+/// each branch is inspected so `super(), super()` reports both calls.
+fn collect_super_ranges(expr: ast_view::Expr, ranges: &mut Vec<SourceRange>) {
   match expr {
     ast_view::Expr::Call(call)
       if matches!(&call.callee, ast_view::Callee::Super(_)) =>
     {
-      Some(call.range())
+      ranges.push(call.range());
     }
-    ast_view::Expr::Seq(seq) => seq
-      .exprs
-      .iter()
-      .find_map(|inner| super_range_in_expr(*inner)),
-    _ => None,
+    ast_view::Expr::Seq(seq) => {
+      for inner in seq.exprs {
+        collect_super_ranges(*inner, ranges);
+      }
+    }
+    _ => {}
   }
 }
 
@@ -112,7 +113,9 @@ fn return_before_super<'a, 'view>(
 ) -> Option<&'a ast_view::ReturnStmt<'view>> {
   if let Some(block_stmt) = &constructor.body {
     for stmt in block_stmt.stmts {
-      if extract_super_range(stmt).is_some() {
+      let mut ranges = Vec::new();
+      collect_super_ranges_in_stmt(stmt, &mut ranges);
+      if !ranges.is_empty() {
         return None;
       }
 
@@ -379,6 +382,15 @@ mod tests {
         }
       ],
       "class A extends B { constructor() { super(); super(); } }": [
+        {
+          col: 45,
+          message: too_many_super_message,
+          hint: too_many_super_hint,
+        }
+      ],
+      // Two `super()` calls within a single sequence expression are both
+      // counted, so the second is still reported as too many.
+      "class A extends B { constructor() { super(), super(); } }": [
         {
           col: 45,
           message: too_many_super_message,

--- a/src/rules/constructor_super.rs
+++ b/src/rules/constructor_super.rs
@@ -5,7 +5,6 @@ use crate::handler::{Handler, Traverse};
 use crate::tags::{self, Tags};
 use crate::Program;
 use deno_ast::{view as ast_view, SourceRange, SourceRanged};
-use if_chain::if_chain;
 
 #[derive(Debug)]
 pub struct ConstructorSuper;
@@ -81,15 +80,30 @@ fn super_call_ranges(constructor: &ast_view::Constructor) -> Vec<SourceRange> {
 }
 
 fn extract_super_range(stmt: &ast_view::Stmt) -> Option<SourceRange> {
-  if_chain! {
-    if let ast_view::Stmt::Expr(expr) = stmt;
-    if let ast_view::Expr::Call(call) = expr.expr;
-    if matches!(&call.callee, ast_view::Callee::Super(_));
-    then {
+  if let ast_view::Stmt::Expr(expr) = stmt {
+    super_range_in_expr(expr.expr)
+  } else {
+    None
+  }
+}
+
+/// Returns the range of a `super()` call in `expr`, if any.
+///
+/// `super()` may not be the whole expression: it can appear inside a
+/// comma/sequence expression, e.g. `super(), 0;` or `0, super();`. In those
+/// cases it is still called unconditionally, so the sequence is unwrapped.
+fn super_range_in_expr(expr: ast_view::Expr) -> Option<SourceRange> {
+  match expr {
+    ast_view::Expr::Call(call)
+      if matches!(&call.callee, ast_view::Callee::Super(_)) =>
+    {
       Some(call.range())
-    } else {
-      None
     }
+    ast_view::Expr::Seq(seq) => seq
+      .exprs
+      .iter()
+      .find_map(|inner| super_range_in_expr(*inner)),
+    _ => None,
   }
 }
 
@@ -223,6 +237,11 @@ mod tests {
       // "class A extends B { constructor() { try {} finally { super(); } } }",
       // "class A extends B { constructor() { if (a) throw Error(); super(); } }",
 
+      // https://github.com/denoland/deno_lint/issues/1490
+      // `super()` inside a comma/sequence expression is still called.
+      "class A extends B { constructor() { super(), 0; } }",
+      "class A extends B { constructor() { 0, super(); } }",
+
       // derived classes.
       "class A extends (class B {}) { constructor() { super(); } }",
       "class A extends (B = C) { constructor() { super(); } }",
@@ -267,6 +286,15 @@ mod tests {
     assert_lint_err! {
       ConstructorSuper,
       "class A { constructor() { super(); } }": [
+        {
+          col: 26,
+          message: unnecessary_super_message,
+          hint: unnecessary_super_hint,
+        }
+      ],
+      // https://github.com/denoland/deno_lint/issues/1490
+      // `super()` in a sequence expression is unwrapped for all checks.
+      "class A { constructor() { super(), 0; } }": [
         {
           col: 26,
           message: unnecessary_super_message,


### PR DESCRIPTION
Fixes #1490.

`constructor-super` only recognized a `super()` call when it was the *entire*
expression statement. When `super()` appeared inside a comma/sequence
expression it was missed, and the constructor was wrongly reported as missing a
`super()` call:

```ts
class A {}
export class C extends A {
  constructor() {
    super(), 0; // false "must call super()"
  }
}
export class D extends A {
  constructor() {
    0, super(); // false "must call super()"
  }
}
```

`super()` is called unconditionally in both cases.

Fix: factor the call detection into `super_range_in_expr`, which unwraps
`SeqExpr` and returns the range of a `super()` call found in any sub-expression.
Because it reuses the same helper, the fix applies uniformly to every check the
rule performs — missing `super()`, unnecessary `super()` in a non-derived
class, and the return-before-super substitute.

Adds valid tests for `super(), 0;` and `0, super();` in a derived class, and an
invalid test confirming `super()` in a sequence is still flagged as unnecessary
in a non-derived class.