### PR TITLE
fix(no-console): flag console imported from node:console

### DIFF
--- a/src/rules/no_console.rs
+++ b/src/rules/no_console.rs
@@ -3,9 +3,10 @@ use crate::handler::{Handler, Traverse};
 use crate::tags::Tags;
 use crate::Program;
 
+use deno_ast::swc::ast::Id;
 use deno_ast::view as ast_view;
 use deno_ast::SourceRanged;
-use if_chain::if_chain;
+use std::collections::HashSet;
 
 #[derive(Debug)]
 pub struct NoConsole;
@@ -27,45 +28,62 @@ impl LintRule for NoConsole {
     context: &mut Context,
     program: Program,
   ) {
-    NoConsoleHandler.traverse(program, context);
+    NoConsoleHandler {
+      imported_console: HashSet::new(),
+    }
+    .traverse(program, context);
   }
 }
 
-struct NoConsoleHandler;
+struct NoConsoleHandler {
+  /// Bindings imported as the default export of `node:console`, e.g.
+  /// `import console from "node:console";`. These refer to the same `console`
+  /// object as the global, so usages should be flagged too.
+  imported_console: HashSet<Id>,
+}
+
+impl NoConsoleHandler {
+  fn is_console(&self, ident: &ast_view::Ident, ctx: &mut Context) -> bool {
+    let id = ident.inner.to_id();
+    // `console` imported from `node:console` (any local name).
+    if self.imported_console.contains(&id) {
+      return true;
+    }
+    // The global `console`.
+    ident.sym() == "console" && ctx.scope().is_global(&id)
+  }
+}
 
 impl Handler for NoConsoleHandler {
+  fn import_decl(&mut self, import: &ast_view::ImportDecl, _ctx: &mut Context) {
+    if import.src.value().to_string_lossy() != "node:console" {
+      return;
+    }
+    for specifier in import.specifiers {
+      if let ast_view::ImportSpecifier::Default(default) = specifier {
+        self.imported_console.insert(default.local.to_id());
+      }
+    }
+  }
+
   fn member_expr(&mut self, expr: &ast_view::MemberExpr, ctx: &mut Context) {
     if expr.parent().is::<ast_view::MemberExpr>() {
       return;
     }
 
     use deno_ast::view::Expr;
-    if_chain! {
-      if let Expr::Ident(ident) = &expr.obj;
-      if ident.sym() == "console";
-      if ctx.scope().is_global(&ident.inner.to_id());
-      then {
-        ctx.add_diagnostic(
-          ident.range(),
-          CODE,
-          MESSAGE,
-        );
+    if let Expr::Ident(ident) = &expr.obj {
+      if self.is_console(ident, ctx) {
+        ctx.add_diagnostic(ident.range(), CODE, MESSAGE);
       }
     }
   }
 
   fn expr_stmt(&mut self, expr: &ast_view::ExprStmt, ctx: &mut Context) {
     use deno_ast::view::Expr;
-    if_chain! {
-      if let Expr::Ident(ident) = &expr.expr;
-      if ident.sym() == "console";
-      if ctx.scope().is_global(&ident.inner.to_id());
-      then {
-        ctx.add_diagnostic(
-          ident.range(),
-          CODE,
-          MESSAGE,
-        );
+    if let Expr::Ident(ident) = &expr.expr {
+      if self.is_console(ident, ctx) {
+        ctx.add_diagnostic(ident.range(), CODE, MESSAGE);
       }
     }
   }
@@ -85,6 +103,10 @@ mod tests {
       r"const console = { log() {} } console.log('Error message');",
       // https://github.com/denoland/deno_lint/issues/1232
       "const x: { console: any } = { console: 21 }; x.console",
+      // a `console` imported from somewhere other than `node:console`
+      "import console from './my-console.ts';\nconsole.log('hi');",
+      // a non-default import from `node:console` (e.g. the `Console` class)
+      "import { Console } from 'node:console';\nconst c = new Console(process.stdout);",
     );
   }
 
@@ -114,6 +136,25 @@ mod tests {
             message: MESSAGE,
         }],
         r#"console.warn("test");"#: [{
+            col: 0,
+            message: MESSAGE,
+        }],
+        // https://github.com/denoland/deno_lint/issues/1316
+        // `console` imported from `node:console`.
+        "import console from \"node:console\";\nconsole.log(\"hi\");": [{
+            line: 2,
+            col: 0,
+            message: MESSAGE,
+        }],
+        // imported under a different local name.
+        "import myConsole from \"node:console\";\nmyConsole.log(\"hi\");": [{
+            line: 2,
+            col: 0,
+            message: MESSAGE,
+        }],
+        // bare reference to the imported binding.
+        "import console from \"node:console\";\nconsole;": [{
+            line: 2,
             col: 0,
             message: MESSAGE,
         }],


### PR DESCRIPTION
Fixes #1316.

`no-console` only flagged the *global* `console`, so this slipped through even
though it is the same console object:

```ts
import console from "node:console";

console.log("hi");
```

The rule now also collects default-import bindings whose source is
`node:console` and treats member access (or a bare reference) on them as
console usage, in addition to the existing global check. Detection is by
binding identity rather than name, so an aliased import
(`import myConsole from "node:console"`) is caught too.

Scope is deliberately narrow to avoid false positives:

- only the **default** import of `node:console` is tracked — `import { Console }`
  (the class) and other named imports are left alone;
- a `console` imported from any other module, or a local `const console`, is
  unaffected.

Adds invalid tests for the default import, an aliased default import, and a
bare reference, plus valid tests for a non-`node:console` import and the
`Console` named import.