### PR TITLE
fix(no-invalid-regexp): allow duplicate group names across alternatives

### DIFF
--- a/src/js_regex/mod.rs
+++ b/src/js_regex/mod.rs
@@ -1268,6 +1268,46 @@ mod tests {
   }
 
   #[test]
+  fn duplicate_named_capturing_group() {
+    // https://github.com/denoland/deno_lint/issues/1372
+    // Duplicate group names are valid when they live in different alternatives
+    // of a disjunction (ES2025), but invalid when they could both participate
+    // in a single match.
+    let mut validator = EcmaRegexValidator::new(EcmaVersion::Es2018);
+
+    // valid: declared in different alternatives.
+    assert_eq!(validator.validate_pattern("(?<a>x)|(?<a>y)", false), Ok(()));
+    assert_eq!(validator.validate_pattern("(?<a>x)|(?<a>y)", true), Ok(()));
+    assert_eq!(
+      validator.validate_pattern(
+        "(?<year>\\d{4})-\\d{2}|\\d{2}-(?<year>\\d{4})",
+        true
+      ),
+      Ok(())
+    );
+    assert_eq!(
+      validator.validate_pattern(
+        "(?<op>do)\\(\\)|(?<op>don't)\\(\\)|(?<op>mul)\\((?<a>\\d+),(?<b>\\d+)\\)",
+        false
+      ),
+      Ok(())
+    );
+    // valid: nested alternatives.
+    assert_eq!(
+      validator.validate_pattern("(?<a>x)|(?:(?<a>y)|(?<a>z))", true),
+      Ok(())
+    );
+
+    // invalid: same alternative.
+    assert_ne!(validator.validate_pattern("(?<a>x)(?<a>y)", true), Ok(()));
+    // invalid: one declaration always participates alongside the alternation.
+    assert_ne!(
+      validator.validate_pattern("((?<a>x)|(?<a>y))(?<a>z)", true),
+      Ok(())
+    );
+  }
+
+  #[test]
   fn unicode_group_names_invalid_2020() {
     // source: https://github.com/mysticatea/regexpp/blob/master/test/fixtures/parser/literal/unicode-group-names-invalid.json
     let mut validator = EcmaRegexValidator::new(EcmaVersion::Es2020);

--- a/src/js_regex/mod.rs
+++ b/src/js_regex/mod.rs
@@ -1297,6 +1297,12 @@ mod tests {
       validator.validate_pattern("(?<a>x)|(?:(?<a>y)|(?<a>z))", true),
       Ok(())
     );
+    // valid: a backreference still resolves when the name is duplicated across
+    // alternatives.
+    assert_eq!(
+      validator.validate_pattern("(?<a>x)\\k<a>|(?<a>y)\\k<a>", true),
+      Ok(())
+    );
 
     // invalid: same alternative.
     assert_ne!(validator.validate_pattern("(?<a>x)(?<a>y)", true), Ok(()));

--- a/src/js_regex/validator.rs
+++ b/src/js_regex/validator.rs
@@ -1,5 +1,6 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
+use std::collections::HashMap;
 use std::collections::HashSet;
 use std::ops::{Deref, DerefMut};
 
@@ -121,6 +122,15 @@ pub struct EcmaRegexValidator {
   last_assertion_is_quantifiable: bool,
   num_capturing_parens: u32,
   group_names: HashSet<String>,
+  /// For each capture-group name, the alternation paths at which it was
+  /// declared. A path is the stack of `(disjunction id, alternative index)`
+  /// pairs enclosing the declaration. Two same-named groups are only valid if
+  /// some common disjunction places them in different alternatives.
+  group_name_paths: HashMap<String, Vec<Vec<(u32, u32)>>>,
+  /// The alternation path of the position currently being parsed.
+  alt_path: Vec<(u32, u32)>,
+  /// Monotonic id handed out to each `Disjunction` as it is entered.
+  next_disjunction_id: u32,
   backreference_names: HashSet<String>,
 }
 
@@ -136,6 +146,21 @@ impl DerefMut for EcmaRegexValidator {
   fn deref_mut(&mut self) -> &mut Self::Target {
     &mut self.reader
   }
+}
+
+/// Returns `true` if two capture groups declared at the given alternation
+/// paths could both participate in a single match — in which case sharing a
+/// name is invalid. They cannot both participate when some common disjunction
+/// places them in different alternatives.
+fn paths_might_both_participate(a: &[(u32, u32)], b: &[(u32, u32)]) -> bool {
+  for &(a_disjunction, a_alt) in a {
+    for &(b_disjunction, b_alt) in b {
+      if a_disjunction == b_disjunction && a_alt != b_alt {
+        return false;
+      }
+    }
+  }
+  true
 }
 
 impl EcmaRegexValidator {
@@ -155,6 +180,9 @@ impl EcmaRegexValidator {
       last_assertion_is_quantifiable: false,
       num_capturing_parens: 0,
       group_names: HashSet::new(),
+      group_name_paths: HashMap::new(),
+      alt_path: Vec::new(),
+      next_disjunction_id: 0,
       backreference_names: HashSet::new(),
     }
   }
@@ -219,6 +247,9 @@ impl EcmaRegexValidator {
   fn consume_pattern(&mut self) -> Result<(), String> {
     self.num_capturing_parens = self.count_capturing_parens();
     self.group_names.clear();
+    self.group_name_paths.clear();
+    self.alt_path.clear();
+    self.next_disjunction_id = 0;
     self.backreference_names.clear();
 
     self.consume_disjunction()?;
@@ -251,10 +282,18 @@ impl EcmaRegexValidator {
   ///      Alternative[?U, ?N] `|` Disjunction[?U, ?N]
   /// ```
   fn consume_disjunction(&mut self) -> Result<(), String> {
+    let disjunction_id = self.next_disjunction_id;
+    self.next_disjunction_id += 1;
+    let mut alternative_index = 0;
+
+    self.alt_path.push((disjunction_id, alternative_index));
     self.consume_alternative()?;
     while self.eat('|') {
+      alternative_index += 1;
+      *self.alt_path.last_mut().unwrap() = (disjunction_id, alternative_index);
       self.consume_alternative()?;
     }
+    self.alt_path.pop();
 
     if self.consume_quantifier(true)? {
       Err("Nothing to repeat".to_string())
@@ -631,12 +670,24 @@ impl EcmaRegexValidator {
   fn consume_group_specifier(&mut self) -> Result<bool, String> {
     if self.eat('?') {
       if self.eat_group_name()? {
-        if !self.group_names.contains(&self.last_str_value) {
-          self.group_names.insert(self.last_str_value.clone());
-          Ok(true)
-        } else {
-          Err("Duplicate capture group name".to_string())
+        let name = self.last_str_value.clone();
+        let path = self.alt_path.clone();
+        // A duplicate name is allowed as long as no previous declaration of
+        // the same name could participate in the same match (i.e. there is a
+        // common enclosing disjunction that puts them in different
+        // alternatives). This is the ES2025 "duplicate named capturing
+        // groups" semantics.
+        let declarations =
+          self.group_name_paths.entry(name.clone()).or_default();
+        if declarations
+          .iter()
+          .any(|prev| paths_might_both_participate(prev, &path))
+        {
+          return Err("Duplicate capture group name".to_string());
         }
+        declarations.push(path);
+        self.group_names.insert(name);
+        Ok(true)
       } else {
         Err("Invalid group".to_string())
       }


### PR DESCRIPTION
Fixes #1372.

Named capture groups are allowed to share a name when they appear in different
alternatives of a disjunction — the ES2025 "duplicate named capturing groups"
feature, which current V8 (and therefore Deno) already supports. The regex
validator rejected any repeated name, producing false `Invalid RegExp literal`
diagnostics for valid patterns:

```js
/(?<year>\d{4})-\d{2}|\d{2}-(?<year>\d{4})/      // valid per MDN
/(?<op>do)\(\)|(?<op>don't)\(\)|(?<op>mul)\(...\)/  // the issue's pattern
```

Approach: track, for each declared name, the alternation path of its
declaration — the stack of `(disjunction id, alternative index)` pairs
enclosing it. A new declaration conflicts with a prior one only when the two
could both participate in a single match, i.e. there is no common disjunction
that places them in different alternatives. This keeps the genuine errors:

| pattern | result |
|---|---|
| `(?<a>x)\|(?<a>y)` | valid |
| `(?<a>x)\|(?:(?<a>y)\|(?<a>z))` | valid |
| `(?<a>x)(?<a>y)` | invalid (same alternative) |
| `((?<a>x)\|(?<a>y))(?<a>z)` | invalid (`z` always participates) |

Each case was cross-checked against V8 with `deno eval`. Adds a
`duplicate_named_capturing_group` test covering the valid and invalid shapes;
the existing same-alternative duplicate tests are unchanged.