### PR TITLE
fix(no-extra-non-null-assertion): don't flag assertions on optional-chain results

### DIFF
--- a/src/rules/no_extra_non_null_assertion.rs
+++ b/src/rules/no_extra_non_null_assertion.rs
@@ -94,6 +94,13 @@ impl Handler for NoExtraNonNullAssertionHandler {
     opt_chain_expr: &OptChainExpr,
     ctx: &mut Context,
   ) {
+    // A non-null assertion is only "extra" when the access applied to it is
+    // itself optional, e.g. `foo!?.bar`. When the link is not optional — as in
+    // `(a?.b)!.c` or `(a?.b)![c]`, where the `?.` belongs to an earlier link —
+    // the assertion applies to the optional-chain *result* and is meaningful.
+    if !opt_chain_expr.inner.optional {
+      return;
+    }
     let expr = match &opt_chain_expr.base {
       OptChainBase::Member(member_expr) => &member_expr.obj,
       OptChainBase::Call(call_expr) => &call_expr.callee,
@@ -114,6 +121,12 @@ mod tests {
       r#"function foo() { return "foo"; }"#,
       r#"function foo(bar: undefined | string) { return bar!; }"#,
       r#"function foo(bar?: { str: string }) { return bar?.str; }"#,
+      // A non-null assertion on an optional-chain result, followed by a
+      // non-optional access, is meaningful and must not be flagged.
+      // https://github.com/denoland/deno_lint/issues/1432
+      r#"function foo(bar?: { str: string }) { return bar?.str!.length; }"#,
+      // https://github.com/denoland/deno_lint/issues/1254
+      r#"function foo(bar?: { arr?: number[] }) { return bar?.arr![0]; }"#,
     };
   }
 
@@ -164,6 +177,15 @@ mod tests {
         }
       ],
       r#"function foo(bar?: { str: string }) { return (bar!)?.(); }"#: [
+        {
+          col: 45,
+          message: NoExtraNonNullAssertionMessage::Unexpected,
+          hint: NoExtraNonNullAssertionHint::Remove,
+        }
+      ],
+      // A non-null assertion immediately followed by another optional link
+      // (`!?.`) is still redundant, even on an optional-chain result.
+      r#"function foo(bar?: { str: string }) { return bar?.str!?.length; }"#: [
         {
           col: 45,
           message: NoExtraNonNullAssertionMessage::Unexpected,


### PR DESCRIPTION
Fixes #1432.
Fixes #1254.

`no-extra-non-null-assertion` flagged a non-null assertion whenever it was the
base of an optional-chain link — even when that link was a plain (non-optional)
access. That produced false positives on meaningful assertions:

```ts
document.children[0]?.textContent!.trim(); // #1432
info.streamInfo.state?.subjects!["key"];   // #1254
```

In both, the `?.` belongs to an earlier link and the `!` asserts the
optional-chain *result* before a normal `.`/`[]` access — removing it makes
TypeScript report `possibly undefined`.

The fix only runs the check when the optional-chain link applied to the
assertion is itself optional (`opt_chain_expr.optional`), so `foo!?.bar` and
`foo!?.()` are still flagged. This matches @typescript-eslint's
`no-extra-non-null-assertion`, which reports a non-null assertion only when its
parent member/call access is optional. A `!?.` that appears *after* an
optional-chain result (`a?.b!?.c`) is still redundant and remains flagged.

Adds valid tests for `a?.b!.c` / `a?.b![0]` and an invalid test for
`a?.b!?.c`; all existing cases are unchanged.

Note on #1144 (`x!?.cleanup()`): that case is left flagged on purpose — it is
exactly the `!?.` form ESLint reports, and distinguishing the
definite-assignment scenario described there would require type information.