### PR TITLE
fix(fresh-handler-export): whitelist handler and handlers instead of blacklisting handlers

### DIFF
--- a/src/rules/fresh_handler_export.rs
+++ b/src/rules/fresh_handler_export.rs
@@ -12,8 +12,8 @@ pub struct FreshHandlerExport;
 
 const CODE: &str = "fresh-handler-export";
 const MESSAGE: &str =
-  "Fresh middlewares must be exported as \"handler\" but got \"handlers\" instead.";
-const HINT: &str = "Did you mean \"handler\"?";
+  "Fresh route handlers must be exported as \"handler\" or \"handlers\".";
+const HINT: &str = "Expected \"handler\" or \"handlers\".";
 
 impl LintRule for FreshHandlerExport {
   fn tags(&self) -> Tags {
@@ -65,8 +65,8 @@ impl Handler for Visitor {
       _ => return,
     };
 
-    // Fresh middleware handler must be exported as "handler" not "handlers"
-    if id.sym().eq("handlers") {
+    // Fresh only accepts "handler" or "handlers" as route handler exports
+    if !id.sym().eq("handler") && !id.sym().eq("handlers") {
       ctx.add_diagnostic_with_hint(id.range(), CODE, MESSAGE, HINT);
     }
   }
@@ -120,19 +120,37 @@ mod tests {
       "export async function handler() {}",
     );
 
-    assert_lint_err!(FreshHandlerExport, filename: "file:///routes/index.tsx",  r#"export const handlers = {}"#: [
+    // Both "handler" and "handlers" are valid in Fresh 2.x
+    assert_lint_ok!(
+      FreshHandlerExport,
+      filename: "file:///routes/index.tsx",
+      r#"export const handlers = {}"#,
+    );
+    assert_lint_ok!(
+      FreshHandlerExport,
+      filename: "file:///routes/index.tsx",
+      r#"export function handlers() {}"#,
+    );
+    assert_lint_ok!(
+      FreshHandlerExport,
+      filename: "file:///routes/index.tsx",
+      r#"export async function handlers() {}"#,
+    );
+
+    // Unknown export names should be flagged
+    assert_lint_err!(FreshHandlerExport, filename: "file:///routes/index.tsx",  r#"export const foo = {}"#: [
     {
       col: 13,
       message: MESSAGE,
       hint: HINT,
     }]);
-    assert_lint_err!(FreshHandlerExport, filename: "file:///routes/index.tsx",  r#"export function handlers() {}"#: [
+    assert_lint_err!(FreshHandlerExport, filename: "file:///routes/index.tsx",  r#"export function bar() {}"#: [
     {
       col: 16,
       message: MESSAGE,
       hint: HINT,
     }]);
-    assert_lint_err!(FreshHandlerExport, filename: "file:///routes/index.tsx",  r#"export async function handlers() {}"#: [
+    assert_lint_err!(FreshHandlerExport, filename: "file:///routes/index.tsx",  r#"export async function baz() {}"#: [
     {
       col: 22,
       message: MESSAGE,


### PR DESCRIPTION
## Summary

Updates the `fresh-handler-export` rule from a blacklist approach (flagging only `handlers`) to a whitelist approach (flagging anything that is NOT `handler` or `handlers`).

Closes #1495

## Motivation

Fresh 2.x accepts **both** `handler` and `handlers` as valid route handler export names. From the Fresh source:

```
const handlers = mod.handlers ?? mod.handler ?? null;
```

The old rule was designed for Fresh 1.x where only `handler` (singular) was recognized — exporting `handlers` (plural) was a silent footgun. Fresh 2 changed the contract, so the previous behavior of flagging `handlers` is now a **false positive**.

However, simply deleting the rule or turning it into a no-op would miss the fact that any _other_ export name is still silently ignored by Fresh. The rule retains value by checking that the export name is one of the two recognized names.

## Changes

| Export name | Old behavior | New behavior |
|---|---|---|
| `handler` | ✅ | ✅ |
| `handlers` | ❌ false positive | ✅ |
| `foo` / anything else | ✅ missed | ❌ diagnostic |

- **Logic**: Changed from `if name == "handlers"` → error to `if name != "handler" && name != "handlers"` → error
- **Message**: Updated to `"Fresh route handlers must be exported as \"handler\" or \"handlers\"."`
- **Hint**: Updated to `"Expected \"handler\" or \"handlers\"."`
- **Tests**: Added `assert_lint_ok!` for `handlers` in `routes/`, added `assert_lint_err!` for unknown names (`foo`, `bar`, `baz`)