### PR TITLE
feat(no-await-in-promise-methods): add `no-await-in-promise-methods` rule

### DIFF
--- a/src/rules.rs
+++ b/src/rules.rs
@@ -40,6 +40,7 @@ pub mod jsx_void_dom_elements_no_children;
 pub mod no_array_constructor;
 pub mod no_async_promise_executor;
 pub mod no_await_in_loop;
+pub mod no_await_in_promise_methods;
 pub mod no_await_in_sync_fn;
 pub mod no_boolean_literal_for_arguments;
 pub mod no_case_declarations;
@@ -284,6 +285,7 @@ fn get_all_rules_raw() -> Vec<Box<dyn LintRule>> {
     Box::new(no_array_constructor::NoArrayConstructor),
     Box::new(no_async_promise_executor::NoAsyncPromiseExecutor),
     Box::new(no_await_in_loop::NoAwaitInLoop),
+    Box::new(no_await_in_promise_methods::NoAwaitInPromiseMethods),
     Box::new(no_await_in_sync_fn::NoAwaitInSyncFn),
     Box::new(no_boolean_literal_for_arguments::NoBooleanLiteralForArguments),
     Box::new(no_case_declarations::NoCaseDeclarations),

--- a/src/rules/no_await_in_promise_methods.rs
+++ b/src/rules/no_await_in_promise_methods.rs
@@ -1,0 +1,233 @@
+// Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
+
+use super::{Context, LintRule};
+use crate::handler::{Handler, Traverse};
+use crate::tags::{self, Tags};
+use crate::Program;
+use deno_ast::view::{Callee, Expr, MemberProp};
+use deno_ast::SourceRanged;
+use derive_more::Display;
+
+#[derive(Debug)]
+pub struct NoAwaitInPromiseMethods;
+
+const CODE: &str = "no-await-in-promise-methods";
+
+#[derive(Display)]
+enum NoAwaitInPromiseMethodsMessage {
+  #[display(fmt = "Promise in `Promise.{}()` should not be awaited.", _0)]
+  Unexpected(String),
+}
+
+#[derive(Display)]
+enum NoAwaitInPromiseMethodsHint {
+  #[display(fmt = "Remove the `await`")]
+  Remove,
+}
+
+impl LintRule for NoAwaitInPromiseMethods {
+  fn tags(&self) -> Tags {
+    &[tags::RECOMMENDED]
+  }
+
+  fn code(&self) -> &'static str {
+    CODE
+  }
+
+  fn lint_program_with_ast_view<'view>(
+    &self,
+    context: &mut Context,
+    program: Program<'_>,
+  ) {
+    NoAwaitInPromiseMethodsHandler.traverse(program, context);
+  }
+}
+
+const PROMISE_METHODS: [&str; 4] = ["all", "allSettled", "any", "race"];
+
+struct NoAwaitInPromiseMethodsHandler;
+
+impl Handler for NoAwaitInPromiseMethodsHandler {
+  fn call_expr(
+    &mut self,
+    call_expr: &deno_ast::view::CallExpr,
+    context: &mut Context,
+  ) {
+    let Callee::Expr(Expr::Member(member_expr)) = &call_expr.callee else {
+      return;
+    };
+
+    // Object must be the `Promise` identifier.
+    let Expr::Ident(obj) = &member_expr.obj else {
+      return;
+    };
+    if obj.sym() != "Promise" {
+      return;
+    }
+
+    // Property must be a non-computed identifier among the matched methods.
+    let MemberProp::Ident(prop) = &member_expr.prop else {
+      return;
+    };
+    let method_name = prop.sym();
+    if !PROMISE_METHODS.contains(&method_name.as_ref()) {
+      return;
+    }
+
+    // The sole argument must be an array literal (not a spread).
+    if call_expr.args.len() != 1 {
+      return;
+    }
+    let arg = call_expr.args[0];
+    if arg.inner.spread.is_some() {
+      return;
+    }
+    let Expr::Array(array_lit) = &arg.expr else {
+      return;
+    };
+
+    for elem in array_lit.elems.iter().flatten() {
+      if elem.inner.spread.is_some() {
+        continue;
+      }
+      if let Expr::Await(await_expr) = &elem.expr {
+        context.add_diagnostic_with_hint(
+          await_expr.range(),
+          CODE,
+          NoAwaitInPromiseMethodsMessage::Unexpected(method_name.to_string()),
+          NoAwaitInPromiseMethodsHint::Remove,
+        );
+      }
+    }
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  // Some tests are derived from
+  // https://github.com/oxc-project/oxc/blob/main/crates/oxc_linter/src/rules/unicorn/no_await_in_promise_methods.rs
+  // MIT Licensed.
+
+  #[test]
+  fn no_await_in_promise_methods_valid() {
+    assert_lint_ok! {
+      NoAwaitInPromiseMethods,
+      "Promise.all([promise1, promise2, promise3, promise4])",
+      "Promise.allSettled([promise1, promise2, promise3, promise4])",
+      "Promise.any([promise1, promise2, promise3, promise4])",
+      "Promise.race([promise1, promise2, promise3, promise4])",
+      "Promise.all(...[await promise])",
+      "Promise.all([await promise], extraArguments)",
+      "Promise.all()",
+      "Promise.all(notArrayExpression)",
+      "Promise.all([,])",
+      "Promise[all]([await promise])",
+      "Promise.all?.([await promise])",
+      "Promise?.all([await promise])",
+      "Promise.notListedMethod([await promise])",
+      "NotPromise.all([await promise])",
+      "Promise.all([(await promise, 0)])",
+      "new Promise.all([await promise])",
+      "globalThis.Promise.all([await promise])",
+      r#"Promise["all"]([await promise])"#,
+    };
+  }
+
+  #[test]
+  fn no_await_in_promise_methods_invalid() {
+    assert_lint_err! {
+      NoAwaitInPromiseMethods,
+      "Promise.all([await promise])": [
+        {
+          col: 13,
+          message: variant!(NoAwaitInPromiseMethodsMessage, Unexpected, "all"),
+          hint: NoAwaitInPromiseMethodsHint::Remove,
+        }
+      ],
+      "Promise.allSettled([await promise])": [
+        {
+          col: 20,
+          message: variant!(NoAwaitInPromiseMethodsMessage, Unexpected, "allSettled"),
+          hint: NoAwaitInPromiseMethodsHint::Remove,
+        }
+      ],
+      "Promise.any([await promise])": [
+        {
+          col: 13,
+          message: variant!(NoAwaitInPromiseMethodsMessage, Unexpected, "any"),
+          hint: NoAwaitInPromiseMethodsHint::Remove,
+        }
+      ],
+      "Promise.race([await promise])": [
+        {
+          col: 14,
+          message: variant!(NoAwaitInPromiseMethodsMessage, Unexpected, "race"),
+          hint: NoAwaitInPromiseMethodsHint::Remove,
+        }
+      ],
+      "Promise.all([, await promise])": [
+        {
+          col: 15,
+          message: variant!(NoAwaitInPromiseMethodsMessage, Unexpected, "all"),
+          hint: NoAwaitInPromiseMethodsHint::Remove,
+        }
+      ],
+      "Promise.all([await promise,])": [
+        {
+          col: 13,
+          message: variant!(NoAwaitInPromiseMethodsMessage, Unexpected, "all"),
+          hint: NoAwaitInPromiseMethodsHint::Remove,
+        }
+      ],
+      "Promise.all([await promise],)": [
+        {
+          col: 13,
+          message: variant!(NoAwaitInPromiseMethodsMessage, Unexpected, "all"),
+          hint: NoAwaitInPromiseMethodsHint::Remove,
+        }
+      ],
+      "Promise.all([await (0, promise)],)": [
+        {
+          col: 13,
+          message: variant!(NoAwaitInPromiseMethodsMessage, Unexpected, "all"),
+          hint: NoAwaitInPromiseMethodsHint::Remove,
+        }
+      ],
+      "Promise.all([await (( promise ))])": [
+        {
+          col: 13,
+          message: variant!(NoAwaitInPromiseMethodsMessage, Unexpected, "all"),
+          hint: NoAwaitInPromiseMethodsHint::Remove,
+        }
+      ],
+      "Promise.all([await await promise])": [
+        {
+          col: 13,
+          message: variant!(NoAwaitInPromiseMethodsMessage, Unexpected, "all"),
+          hint: NoAwaitInPromiseMethodsHint::Remove,
+        }
+      ],
+      "Promise.all([...foo, await promise1, await promise2])": [
+        {
+          col: 21,
+          message: variant!(NoAwaitInPromiseMethodsMessage, Unexpected, "all"),
+          hint: NoAwaitInPromiseMethodsHint::Remove,
+        },
+        {
+          col: 37,
+          message: variant!(NoAwaitInPromiseMethodsMessage, Unexpected, "all"),
+          hint: NoAwaitInPromiseMethodsHint::Remove,
+        }
+      ],
+      "Promise.all([await /* comment*/ promise])": [
+        {
+          col: 13,
+          message: variant!(NoAwaitInPromiseMethodsMessage, Unexpected, "all"),
+          hint: NoAwaitInPromiseMethodsHint::Remove,
+        }
+      ]
+    };
+  }
+}


### PR DESCRIPTION
This ports the `no-await-in-promise-methods` rule from oxlint's unicorn
plugin to a native Rust rule.

The rule flags an `await` expression used directly as an element of the
array literal passed to `Promise.all([...])`, `Promise.allSettled([...])`,
`Promise.any([...])`, and `Promise.race([...])`. Awaiting a promise before
handing it to one of these methods defeats their purpose: the methods are
designed to accept pending promises and coordinate them concurrently, so
awaiting an element forces it to settle sequentially before the method even
runs. For example, `Promise.all([await foo()])` is almost always a mistake.

Matching mirrors oxc's behavior exactly: the callee object must be the
`Promise` identifier, the property must be a non-computed identifier naming
one of the four methods, the call must have exactly one argument, and that
argument must be an array literal (not a spread). Each array element that is
directly an `await` expression is reported; spread elements are ignored.

Reference:
https://github.com/oxc-project/oxc/blob/main/crates/oxc_linter/src/rules/unicorn/no_await_in_promise_methods.rs

Tagged RECOMMENDED (on by default) — flagging for maintainer sign-off.
