### PR TITLE
feat(no-useless-fallback-in-spread): add `no-useless-fallback-in-spread` rule

### DIFF
--- a/src/rules.rs
+++ b/src/rules.rs
@@ -110,6 +110,7 @@ pub mod no_unsafe_negation;
 pub mod no_unused_labels;
 pub mod no_unused_vars;
 pub mod no_unversioned_import;
+pub mod no_useless_fallback_in_spread;
 pub mod no_useless_rename;
 pub mod no_var;
 pub mod no_window;
@@ -358,6 +359,7 @@ fn get_all_rules_raw() -> Vec<Box<dyn LintRule>> {
     Box::new(no_unused_labels::NoUnusedLabels),
     Box::new(no_unused_vars::NoUnusedVars),
     Box::new(no_unversioned_import::NoUnversionedImport),
+    Box::new(no_useless_fallback_in_spread::NoUselessFallbackInSpread),
     Box::new(no_useless_rename::NoUselessRename),
     Box::new(no_var::NoVar),
     Box::new(no_window::NoWindow),

--- a/src/rules/no_useless_fallback_in_spread.rs
+++ b/src/rules/no_useless_fallback_in_spread.rs
@@ -1,0 +1,319 @@
+// Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
+
+use super::{Context, LintRule};
+use crate::handler::{Handler, Traverse};
+use crate::tags::{self, Tags};
+use crate::Program;
+use deno_ast::swc::ast::BinaryOp;
+use deno_ast::view::{Expr, ObjectLit, PropOrSpread};
+use deno_ast::SourceRanged;
+use derive_more::Display;
+
+#[derive(Debug)]
+pub struct NoUselessFallbackInSpread;
+
+const CODE: &str = "no-useless-fallback-in-spread";
+
+#[derive(Display)]
+enum NoUselessFallbackInSpreadMessage {
+  #[display(fmt = "Empty fallbacks in spreads are unnecessary")]
+  Unexpected,
+}
+
+#[derive(Display)]
+enum NoUselessFallbackInSpreadHint {
+  #[display(
+    fmt = "Spreading falsy values in object literals won't add any unexpected properties, so it's unnecessary to add an empty object as fallback."
+  )]
+  RemoveFallback,
+}
+
+impl LintRule for NoUselessFallbackInSpread {
+  fn tags(&self) -> Tags {
+    &[tags::RECOMMENDED]
+  }
+
+  fn code(&self) -> &'static str {
+    CODE
+  }
+
+  fn lint_program_with_ast_view<'view>(
+    &self,
+    context: &mut Context,
+    program: Program<'_>,
+  ) {
+    NoUselessFallbackInSpreadHandler.traverse(program, context);
+  }
+}
+
+/// Unwraps any number of nested parenthesized expressions.
+fn unwrap_parens<'a>(expr: &Expr<'a>) -> Expr<'a> {
+  match expr {
+    Expr::Paren(paren) => unwrap_parens(&paren.expr),
+    _ => *expr,
+  }
+}
+
+struct NoUselessFallbackInSpreadHandler;
+
+impl Handler for NoUselessFallbackInSpreadHandler {
+  fn object_lit(&mut self, object_lit: &ObjectLit, context: &mut Context) {
+    for prop in object_lit.props {
+      let PropOrSpread::Spread(spread) = prop else {
+        continue;
+      };
+
+      // The spread argument must be a logical `||` or `??` expression
+      // (possibly wrapped in parentheses).
+      let Expr::Bin(bin_expr) = unwrap_parens(&spread.expr) else {
+        continue;
+      };
+
+      if !matches!(
+        bin_expr.op(),
+        BinaryOp::LogicalOr | BinaryOp::NullishCoalescing
+      ) {
+        continue;
+      }
+
+      // The right operand must be an empty object literal (possibly
+      // wrapped in parentheses).
+      let Expr::Object(object) = unwrap_parens(&bin_expr.right) else {
+        continue;
+      };
+
+      if !object.props.is_empty() {
+        continue;
+      }
+
+      context.add_diagnostic_with_hint(
+        spread.range(),
+        CODE,
+        NoUselessFallbackInSpreadMessage::Unexpected,
+        NoUselessFallbackInSpreadHint::RemoveFallback,
+      );
+    }
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  // Some tests are derived from
+  // https://github.com/oxc-project/oxc/blob/main/crates/oxc_linter/src/rules/unicorn/no_useless_fallback_in_spread.rs
+  // MIT Licensed.
+
+  #[test]
+  fn no_useless_fallback_in_spread_valid() {
+    assert_lint_ok! {
+      NoUselessFallbackInSpread,
+      "const array = [...(foo || [])]",
+      "const array = [...(foo || {})]",
+      "const array = [...(foo && {})]",
+      "const object = {...(foo && {})}",
+      "const object = {...({} || foo)}",
+      "const object = {...({} && foo)}",
+      "const object = {...({} ?? foo)}",
+      "const object = {...(foo ? foo : {})}",
+      "const object = {...foo}",
+      "const object = {...(foo ?? ({} || {}))}",
+      "const {...foo} = object",
+      "function foo({...bar}){}",
+      "const object = {...(foo || {}).toString()}",
+      "const object = {...fn(foo || {})}",
+      "const object = call({}, ...(foo || {}))",
+      r#"const object = {...(foo || {not: "empty"})}"#,
+      "const object = {...(foo || {...{}})}",
+    };
+  }
+
+  #[test]
+  fn no_useless_fallback_in_spread_invalid() {
+    assert_lint_err! {
+      NoUselessFallbackInSpread,
+      "const object = {...(foo || {})}": [
+        {
+          col: 16,
+          message: NoUselessFallbackInSpreadMessage::Unexpected,
+          hint: NoUselessFallbackInSpreadHint::RemoveFallback,
+        }
+      ],
+      "const object = {...(foo ?? {})}": [
+        {
+          col: 16,
+          message: NoUselessFallbackInSpreadMessage::Unexpected,
+          hint: NoUselessFallbackInSpreadHint::RemoveFallback,
+        }
+      ],
+      "const object = {...(foo ?? (( {} )))}": [
+        {
+          col: 16,
+          message: NoUselessFallbackInSpreadMessage::Unexpected,
+          hint: NoUselessFallbackInSpreadHint::RemoveFallback,
+        }
+      ],
+      "const object = {...((( foo )) ?? (( {} )))}": [
+        {
+          col: 16,
+          message: NoUselessFallbackInSpreadMessage::Unexpected,
+          hint: NoUselessFallbackInSpreadHint::RemoveFallback,
+        }
+      ],
+      "const object = {...(( (( foo )) ?? (( {} )) ))}": [
+        {
+          col: 16,
+          message: NoUselessFallbackInSpreadMessage::Unexpected,
+          hint: NoUselessFallbackInSpreadHint::RemoveFallback,
+        }
+      ],
+      "async ()=> ({...((await foo) || {})})": [
+        {
+          col: 13,
+          message: NoUselessFallbackInSpreadMessage::Unexpected,
+          hint: NoUselessFallbackInSpreadHint::RemoveFallback,
+        }
+      ],
+      "const object = {...(0 || {})}": [
+        {
+          col: 16,
+          message: NoUselessFallbackInSpreadMessage::Unexpected,
+          hint: NoUselessFallbackInSpreadHint::RemoveFallback,
+        }
+      ],
+      "const object = {...((-0) || {})}": [
+        {
+          col: 16,
+          message: NoUselessFallbackInSpreadMessage::Unexpected,
+          hint: NoUselessFallbackInSpreadHint::RemoveFallback,
+        }
+      ],
+      "const object = {...(.0 || {})}": [
+        {
+          col: 16,
+          message: NoUselessFallbackInSpreadMessage::Unexpected,
+          hint: NoUselessFallbackInSpreadHint::RemoveFallback,
+        }
+      ],
+      "const object = {...(0n || {})}": [
+        {
+          col: 16,
+          message: NoUselessFallbackInSpreadMessage::Unexpected,
+          hint: NoUselessFallbackInSpreadHint::RemoveFallback,
+        }
+      ],
+      "const object = {...(false || {})}": [
+        {
+          col: 16,
+          message: NoUselessFallbackInSpreadMessage::Unexpected,
+          hint: NoUselessFallbackInSpreadHint::RemoveFallback,
+        }
+      ],
+      "const object = {...(null || {})}": [
+        {
+          col: 16,
+          message: NoUselessFallbackInSpreadMessage::Unexpected,
+          hint: NoUselessFallbackInSpreadHint::RemoveFallback,
+        }
+      ],
+      "const object = {...(undefined || {})}": [
+        {
+          col: 16,
+          message: NoUselessFallbackInSpreadMessage::Unexpected,
+          hint: NoUselessFallbackInSpreadHint::RemoveFallback,
+        }
+      ],
+      "const object = {...((a && b) || {})}": [
+        {
+          col: 16,
+          message: NoUselessFallbackInSpreadMessage::Unexpected,
+          hint: NoUselessFallbackInSpreadHint::RemoveFallback,
+        }
+      ],
+      "const object = {...(NaN || {})}": [
+        {
+          col: 16,
+          message: NoUselessFallbackInSpreadMessage::Unexpected,
+          hint: NoUselessFallbackInSpreadHint::RemoveFallback,
+        }
+      ],
+      r#"const object = {...("" || {})}"#: [
+        {
+          col: 16,
+          message: NoUselessFallbackInSpreadMessage::Unexpected,
+          hint: NoUselessFallbackInSpreadHint::RemoveFallback,
+        }
+      ],
+      "const object = {...([] || {})}": [
+        {
+          col: 16,
+          message: NoUselessFallbackInSpreadMessage::Unexpected,
+          hint: NoUselessFallbackInSpreadHint::RemoveFallback,
+        }
+      ],
+      "const object = {...({} || {})}": [
+        {
+          col: 16,
+          message: NoUselessFallbackInSpreadMessage::Unexpected,
+          hint: NoUselessFallbackInSpreadHint::RemoveFallback,
+        }
+      ],
+      "const object = {...(foo || {}),}": [
+        {
+          col: 16,
+          message: NoUselessFallbackInSpreadMessage::Unexpected,
+          hint: NoUselessFallbackInSpreadHint::RemoveFallback,
+        }
+      ],
+      "const object = {...((foo ?? {}) || {})}": [
+        {
+          col: 16,
+          message: NoUselessFallbackInSpreadMessage::Unexpected,
+          hint: NoUselessFallbackInSpreadHint::RemoveFallback,
+        }
+      ],
+      "const object = {...((foo && {}) || {})}": [
+        {
+          col: 16,
+          message: NoUselessFallbackInSpreadMessage::Unexpected,
+          hint: NoUselessFallbackInSpreadHint::RemoveFallback,
+        }
+      ],
+      "const object = {...(foo && {} || {})}": [
+        {
+          col: 16,
+          message: NoUselessFallbackInSpreadMessage::Unexpected,
+          hint: NoUselessFallbackInSpreadHint::RemoveFallback,
+        }
+      ],
+      "const object = {...({...(foo || {})})}": [
+        {
+          col: 21,
+          message: NoUselessFallbackInSpreadMessage::Unexpected,
+          hint: NoUselessFallbackInSpreadHint::RemoveFallback,
+        }
+      ],
+      "const object = {...({...((0, foo) || {})})}": [
+        {
+          col: 21,
+          message: NoUselessFallbackInSpreadMessage::Unexpected,
+          hint: NoUselessFallbackInSpreadHint::RemoveFallback,
+        }
+      ],
+      "function foo(a = {...(bar || {})}){}": [
+        {
+          col: 18,
+          message: NoUselessFallbackInSpreadMessage::Unexpected,
+          hint: NoUselessFallbackInSpreadHint::RemoveFallback,
+        }
+      ],
+      "const object = {...(document.all || {})}": [
+        {
+          col: 16,
+          message: NoUselessFallbackInSpreadMessage::Unexpected,
+          hint: NoUselessFallbackInSpreadHint::RemoveFallback,
+        }
+      ]
+    };
+  }
+}


### PR DESCRIPTION
This ports the unicorn `no-useless-fallback-in-spread` rule from oxlint as a
native deno_lint rule.

The rule flags a useless empty-object fallback inside an object spread, such as
`{ ...(foo || {}) }` or `{ ...(foo ?? {}) }`. Spreading a nullish (or otherwise
falsy) value into an object literal is a no-op, so providing an empty object
`{}` as a fallback via `||` or `??` adds nothing and can be removed. The rule
only triggers when the spread is inside an object literal (not an array literal
or call arguments), the logical operator is `||` or `??`, and the right operand
is an empty object literal, unwrapping any surrounding parentheses to match
oxc's behavior.

Reference implementation:
https://github.com/oxc-project/oxc/blob/main/crates/oxc_linter/src/rules/unicorn/no_useless_fallback_in_spread.rs

Tagged RECOMMENDED (on by default) — flagging for maintainer sign-off.
